### PR TITLE
Add TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+declare module "messageformat" {
+    class MessageFormat {
+        constructor(message: { [pluralFuncs: string]: Function });
+        constructor(message: string[]);
+        constructor(message: string);
+        addFormatters: (format: {}) => MessageFormat;
+        disablePluralKeyChecks: () => MessageFormat;
+        setBiDiSupport: (enable: boolean) => MessageFormat;
+        setStrictNumberSign: (enable: boolean) => MessageFormat;
+        compile: (messages: string, locale?: string) => Msg;
+    }
+
+    type Msg = (params: {}) => string;
+    export = MessageFormat;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,21 @@
 declare module "messageformat" {
+    type Msg = (params: {}) => string;
+    type Formatter = (val: any, lc: string, arg?: string) => string;
+    type SrcMessage = string | SrcObject;
+
+    interface SrcObject {
+        [key: string]: SrcMessage;
+    }
     class MessageFormat {
         constructor(message: { [pluralFuncs: string]: Function });
         constructor(message: string[]);
         constructor(message: string);
-        addFormatters: (format: {}) => MessageFormat;
+        constructor();
+        addFormatters: (format: { [name: string]: Formatter }) => MessageFormat;
         disablePluralKeyChecks: () => MessageFormat;
         setBiDiSupport: (enable: boolean) => MessageFormat;
         setStrictNumberSign: (enable: boolean) => MessageFormat;
-        compile: (messages: string, locale?: string) => Msg;
+        compile: (messages: SrcMessage, locale?: string) => Msg;
     }
-
-    type Msg = (params: {}) => string;
     export = MessageFormat;
 }


### PR DESCRIPTION
This PR contains a simple definition file that allows TypeScript developer to use the library without having to shim a custom definition file in their project. The definition file is not complete at the moment but sufficient for basic scenarios.