### PR TITLE
es6 style imports for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module "messageformat" {
+declare namespace messageformat {
     type Msg = (params: {}) => string;
     type Formatter = (val: any, lc: string, arg?: string) => string;
     type SrcMessage = string | SrcObject;
@@ -6,16 +6,18 @@ declare module "messageformat" {
     interface SrcObject {
         [key: string]: SrcMessage;
     }
-    class MessageFormat {
-        constructor(message: { [pluralFuncs: string]: Function });
-        constructor(message: string[]);
-        constructor(message: string);
-        constructor();
-        addFormatters: (format: { [name: string]: Formatter }) => MessageFormat;
-        disablePluralKeyChecks: () => MessageFormat;
-        setBiDiSupport: (enable: boolean) => MessageFormat;
-        setStrictNumberSign: (enable: boolean) => MessageFormat;
-        compile: (messages: SrcMessage, locale?: string) => Msg;
-    }
-    export = MessageFormat;
 }
+
+declare class messageformat {
+    constructor(message: { [pluralFuncs: string]: Function });
+    constructor(message: string[]);
+    constructor(message: string);
+    constructor();
+    addFormatters: (format: { [name: string]: messageformat.Formatter }) => messageformat;
+    disablePluralKeyChecks: () => messageformat;
+    setBiDiSupport: (enable: boolean) => messageformat;
+    setStrictNumberSign: (enable: boolean) => messageformat;
+    compile: (messages: messageformat.SrcMessage, locale?: string) => messageformat.Msg;
+}
+
+export = messageformat;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace messageformat {
+declare namespace MessageFormat {
     type Msg = (params: {}) => string;
     type Formatter = (val: any, lc: string, arg?: string) => string;
     type SrcMessage = string | SrcObject;
@@ -8,16 +8,16 @@ declare namespace messageformat {
     }
 }
 
-declare class messageformat {
+declare class MessageFormat {
     constructor(message: { [pluralFuncs: string]: Function });
     constructor(message: string[]);
     constructor(message: string);
     constructor();
-    addFormatters: (format: { [name: string]: messageformat.Formatter }) => messageformat;
-    disablePluralKeyChecks: () => messageformat;
-    setBiDiSupport: (enable: boolean) => messageformat;
-    setStrictNumberSign: (enable: boolean) => messageformat;
-    compile: (messages: messageformat.SrcMessage, locale?: string) => messageformat.Msg;
+    addFormatters: (format: { [name: string]: MessageFormat.Formatter }) => this;
+    disablePluralKeyChecks: () => this;
+    setBiDiSupport: (enable: boolean) => this;
+    setStrictNumberSign: (enable: boolean) => this;
+    compile: (messages: MessageFormat.SrcMessage, locale?: string) => MessageFormat.Msg;
 }
 
-export = messageformat;
+export = MessageFormat;

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,8 +6,6 @@ declare namespace MessageFormat {
     interface SrcObject {
         [key: string]: SrcMessage;
     }
-
-    class MessageFormat extends messageformat {}
 }
 
 declare class MessageFormat {

--- a/lib/messageformat.js
+++ b/lib/messageformat.js
@@ -363,5 +363,4 @@ MessageFormat.prototype.compile = function(messages, locale) {
   return result;
 }
 
-MessageFormat.MessageFormat = MessageFormat;
 module.exports = MessageFormat;


### PR DESCRIPTION
With this proposal it should be possible to import this package in typescript projects using require or es6 module style

``` typescript
// old way with require
import MessageFormat = require('messageformat');

// new way with import from syntax
import * as MessageFormat from 'messageformat';

// cleanest way, that needed adjustment in messageformat.js
import { MessageFormat } from 'messageformat';
```

The last version needed a change in the javascript file and was not possible only changing the types definition. Therefore I nested MessageFormat in itself

```javascript
// lib/messageformat.js
MessageFormat.MessageFormat = MessageFormat;
module.exports = MessageFormat;
```