### PR TITLE
A Formater to translate with objects

### DIFF
--- a/lib/formatters/index.js
+++ b/lib/formatters/index.js
@@ -32,5 +32,6 @@ module.exports = {
   date: require('./date'),
   duration: require('./duration'),
   number: require('./number'),
-  time: require('./time')
+  time: require('./time'),
+  keys: require('./keys')
 }

--- a/lib/formatters/keys.js
+++ b/lib/formatters/keys.js
@@ -1,0 +1,29 @@
+/** Parse an object
+ *
+ * The input value needs to be in a form that the
+ * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object Object object}
+ *
+ * @memberof Formatters
+ * @param {object} object - Object to search trough
+ * @param {string} keys - List of the keys to reach separate with '.'
+ *
+ * @example
+ * var mf = new MessageFormat(['en', 'fi']);
+ *
+ * mf.compile('The key name of the object people is {people, keys, name}')({ people: { name: 'Bastian'}})
+ * // 'The key name of the object people is Bastian'
+ *
+ * mf.compile('{game, keys, player.name} is level {game, keys, player.level}')({ game: { player: {level: 42, name: Kirby}}})
+ * // 'Kirby is level 42'
+ *
+ */
+
+function keys(object,lc,keys) {
+    const args = keys.split('.');
+    for (arg of args) {
+        object = object[arg];
+    }
+    return object
+}
+
+module.exports = function () { return keys; }


### PR DESCRIPTION
I have created this formatter for my work, but I think some it will be useful for some peoples. With this you can use objects in your translation.
- to access **object.key1** you just need to use `{object, keys, key1}`
It would be great if it becomes an official formatter. Feel free to rename it as you please

Example
======

```
var mf = new MessageFormat(['en', 'fi']);

mf.compile('The key name of the object people is {people, keys, name}')({ people: { name: 'Bastian'}})
// 'The key name of the object people is Bastian'

mf.compile('{game, keys, player.name} is level {game, keys, player.level}')({ game: { player: {level: 42, name: Kirby}}})
// 'Kirby is level 42'
```