### PR TITLE
Allow MessageFormat content in function parameters

### DIFF
--- a/docs/lib_compiler.js.html
+++ b/docs/lib_compiler.js.html
@@ -208,8 +208,12 @@ Compiler.prototype.token = function(token, plural) {
       }
       if (!this.mf.fmt[token.key]) throw new Error('Formatting function ' + JSON.stringify(token.key) + ' not found!');
       args.push(JSON.stringify(this.lc));
-      if (typeof token.param === 'string') {
-        args.push(JSON.stringify(token.param.trim()))
+      if (token.param) {
+        var param = token.param.tokens.map(function(t) {
+          if (t &amp;&amp; typeof t === 'string') t = t.trim();
+          return this.token(t);
+        }, this);
+        args.push(param);
       }
       fn = Compiler.propname(token.key, 'fmt');
       this.formatters[token.key] = true;
@@ -244,7 +248,7 @@ Compiler.prototype.compile = function(src, lc, plurals) {
   if (typeof src != 'object') {
     this.lc = lc;
     var pc = plurals[lc] || { cardinal: [], ordinal: [] };
-    pc.strictNumberSign = !!this.mf.strictNumberSign;
+    pc.strict = !!this.mf.strictNumberSign;
     var r = parse(src, pc).map(function(token) { return this.token(token); }, this);
     return 'function(d) { return ' + (r.join(' + ') || '""') + '; }';
   } else {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "lerna run build && npm run build:example",
     "clean": "lerna run clean",
     "prepare": "lerna bootstrap",
+    "pretest": "lerna run build --scope messageformat-parser",
     "test:browser": "lerna run build:browser --scope messageformat && serve",
     "test": "lerna run test && mocha"
   },

--- a/packages/messageformat/lib/compiler.js
+++ b/packages/messageformat/lib/compiler.js
@@ -92,7 +92,8 @@ Compiler.prototype.token = function(token, plural) {
 
     case 'select':
       fn = 'select';
-      args.push(this.cases(token, this.mf.strictNumberSign ? null : plural));
+      if (plural && this.mf.strictNumberSign) plural = null;
+      args.push(this.cases(token, plural));
       this.runtime.select = true;
       break;
 
@@ -118,9 +119,9 @@ Compiler.prototype.token = function(token, plural) {
       if (!this.mf.fmt[token.key]) throw new Error('Formatting function ' + JSON.stringify(token.key) + ' not found!');
       args.push(JSON.stringify(this.lc));
       if (token.param) {
-        var tok = token.param.tokens[0]
-        var param = typeof tok === 'string' ? tok.trim() : ''
-        args.push(JSON.stringify(param));
+        if (plural && this.mf.strictNumberSign) plural = null;
+        var s = token.param.tokens.map(function(tok) { return this.token(tok, plural); }, this);
+        args.push('(' + (s.join(' + ') || '""') + ').trim()')
       }
       fn = Compiler.propname(token.key, 'fmt');
       this.formatters[token.key] = true;

--- a/packages/messageformat/lib/compiler.js
+++ b/packages/messageformat/lib/compiler.js
@@ -117,8 +117,10 @@ Compiler.prototype.token = function(token, plural) {
       }
       if (!this.mf.fmt[token.key]) throw new Error('Formatting function ' + JSON.stringify(token.key) + ' not found!');
       args.push(JSON.stringify(this.lc));
-      if (typeof token.param === 'string') {
-        args.push(JSON.stringify(token.param.trim()))
+      if (token.param) {
+        var tok = token.param.tokens[0]
+        var param = typeof tok === 'string' ? tok.trim() : ''
+        args.push(JSON.stringify(param));
       }
       fn = Compiler.propname(token.key, 'fmt');
       this.formatters[token.key] = true;
@@ -153,7 +155,7 @@ Compiler.prototype.compile = function(src, lc, plurals) {
   if (typeof src != 'object') {
     this.lc = lc;
     var pc = plurals[lc] || { cardinal: [], ordinal: [] };
-    pc.strictNumberSign = !!this.mf.strictNumberSign;
+    pc.strict = !!this.mf.strictNumberSign;
     var r = parse(src, pc).map(function(token) { return this.token(token); }, this);
     return 'function(d) { return ' + (r.join(' + ') || '""') + '; }';
   } else {

--- a/packages/messageformat/package-lock.json
+++ b/packages/messageformat/package-lock.json
@@ -761,9 +761,9 @@
       }
     },
     "messageformat-parser": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/messageformat-parser/-/messageformat-parser-3.0.0.tgz",
-      "integrity": "sha512-5KfDWGAHz5kzfKH5V4M7+o3CIFiykCfFDaLK+Ck2fkaxYfLWwKZMioxrSsMRnkfMr0ZaaC0gcxyOUb2d0GCy4A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.0.0.tgz",
+      "integrity": "sha512-jhIvKWiNOdfpGGy5QcqPG00vpwBJIqIxvKouVowoJbRlEyUvl1RQf3lRMKCv5rT/YSpNyD3Nf+rgZMMMCPqGtg=="
     },
     "miller-rabin": {
       "version": "4.0.1",

--- a/packages/messageformat/package.json
+++ b/packages/messageformat/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "make-plural": "^4.3.0",
-    "messageformat-parser": "^3.0.0",
+    "messageformat-parser": "^4.0.0",
     "reserved-words": "^0.1.2"
   },
   "devDependencies": {

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -147,10 +147,26 @@ describe('Formatters', () => {
       expect(msg[0]({ VAR: 'big' })).to.eql('This is BIG.')
     })
 
-    it('should use formatting functions with parameters', () => {
-      mf.addFormatters({ arg: function(v, lc, arg) { return arg } })
-      const msg = mf.compile('This is {VAR, arg, X, Y }.')
-      expect(msg({ VAR: 'big' })).to.eql('This is X, Y.')
+    describe('arguments', () => {
+      beforeEach(() => {
+        mf = new MessageFormat('en')
+        mf.addFormatters({ arg: function(v, lc, arg) { return arg } })
+      })
+
+      it('basic string', () => {
+        const msg = mf.compile('This is {_, arg, X, Y }.')
+        expect(msg({})).to.eql('This is X, Y.')
+      })
+
+      it('select', () => {
+        const msg = mf.compile('This is {_, arg, {VAR, select, x{X} other{Y}}}.')
+        expect(msg({ VAR: 'x' })).to.eql('This is X.')
+      })
+
+      it('# in plural', () => {
+        const msg = mf.compile('This is {VAR, plural, one{} other{{_, arg, #}}}.')
+        expect(msg({ VAR: 99 })).to.eql('This is 99.')
+      })
     })
   })
 })


### PR DESCRIPTION
This would fix #201, but requires messageformat/parser#8 before it'll work -- see there for more details.

For testing, use `npm link` from the parser's `function-args` branch and then `npm link messageformat-parser` here to get the appropriate version.