### PR TITLE
Add TypeScript definition for `toString` with optional `global` argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace MessageFormat {
-    type Msg = (params: {}) => string;
+    type Msg = { (params: {}): string; toString(global?: string): string };
     type Formatter = (val: any, lc: string, arg?: string) => string;
     type SrcMessage = string | SrcObject;
 


### PR DESCRIPTION
MessageFormat's `compile` method returns a function with the native `toString` method [overwritten with a custom implementation](https://github.com/messageformat/messageformat/blob/b563d80/lib/messageformat.js#L354-L368), having an optional `global` parameter to output code depending on the environment.

This PR adds the custom `toString` method to the TypeScript type definitions, avoiding
```
Expected 0 arguments, but got 1.
``` 
errors when calling it with an argument, since the native method signature has no parameters.