### PR TITLE
Use type union parameter for MessageFormat constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,10 +9,9 @@ declare namespace MessageFormat {
 }
 
 declare class MessageFormat {
-    constructor(message: { [pluralFuncs: string]: Function });
-    constructor(message: string[]);
-    constructor(message: string);
-    constructor();
+    constructor(
+      message?: { [pluralFuncs: string]: Function } | string[] | string
+    );
     addFormatters: (format: { [name: string]: MessageFormat.Formatter }) => this;
     disablePluralKeyChecks: () => this;
     setBiDiSupport: (enable: boolean) => this;


### PR DESCRIPTION
Adding the type definitions is much appreciated - I've previously included them myself. However, this actually broke my build because the constructor is overloaded instead of using a union type for the parameter. Even though the proposed change doesn't make a semantic difference, here's the problem:
```ts
function(foo: string | string[]) {
  new MessageFormat(foo);
}
```
This currently makes the compiler complain (`Argument of type 'string | string[]' is not assignable to parameter of type 'string'. Type 'string[]' is not assignable to type 'string'.`) but works fine with the proposed change.

The underlying reason is that the Typescript compiler doesn't fully deal with calling an overloaded function with a union type argument, see https://github.com/Microsoft/TypeScript/issues/1805.