### PR TITLE
Harmonise code style with Prettier & add linting with ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+node_modules/
+package.json
+package-lock.json
+/docs/
+/example/i18n.js
+/packages/loader-example/dist/bundle.js
+/packages/messageformat/messageformat.*
+/packages/parser/parser.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+package.json
+package-lock.json
+/docs/
+/example/i18n.js
+/packages/loader-example/dist/bundle.js
+/packages/messageformat/messageformat.*
+/packages/parser/parser.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
-  - "node"
-  - "6"
+  - 'node'
+  - '6'
+
 before_script:
   - npm run prepare # not automatic on npm <4
+
+script:
+  - npm test
+  - npm run lint

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The ICU has an [official guide](http://userguide.icu-project.org/formatparse/mes
 
 There is a good slide-deck on [Plural and Gender in Translated Messages](https://docs.google.com/presentation/d/1ZyN8-0VXmod5hbHveq-M1AeQ61Ga3BmVuahZjbmbBxo/pub?start=false&loop=false&delayms=3000#slide=id.g1bc43a82_2_14) by Markus Scherer and Mark Davis. But, again, remember that many of these problems apply even if you're only outputting english.
 
-
 ## What problems does it solve?
 
 Using messageformat, you can separate your code from your text formatting, while enabling much more humane expressions. In other words, you won't need to see this anymore in your output:
@@ -20,7 +19,6 @@ Using messageformat, you can separate your code from your text formatting, while
 > Number of results: 3.
 
 On a more fundamental level, messageformat and its associated tools can help you build an effective workflow for UI texts and translations, keeping message sources in human-friendly formats, compiling them into JavaScript during your build phase, and making them easy to use from your application code.
-
 
 ## What does it look like?
 
@@ -35,22 +33,21 @@ const msgSrc = `{GENDER, select,
   =0 {no results}
   one {1 result}
   other {# results}
-}.`
+}.`;
 ```
 
 You'll get these results:
 
 ```js
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
-const msg = mf.compile(msgSrc)
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
+const msg = mf.compile(msgSrc);
 
-msg({ GENDER: 'male', RES: 1 })    // 'He found 1 result.'
-msg({ GENDER: 'female', RES: 1 })  // 'She found 1 result.'
-msg({ GENDER: 'male', RES: 0 })    // 'He found no results.'
-msg({ RES: 2 })                    // 'They found 2 results.'
+msg({ GENDER: 'male', RES: 1 }); // 'He found 1 result.'
+msg({ GENDER: 'female', RES: 1 }); // 'She found 1 result.'
+msg({ GENDER: 'male', RES: 0 }); // 'He found no results.'
+msg({ RES: 2 }); // 'They found 2 results.'
 ```
-
 
 ## Getting Started
 
@@ -62,5 +59,5 @@ npm install messageformat
 
 This includes the MessageFormat compiler and a runtime accessor class that provides a slightly nicer API for working with larger numbers of messages. Our [Format Guide] will help with the ICU MessageFormat Syntax, and the [Build-time Compilation Guide] provides some options for integrating messageformat to be a part of your workflow around UI texts and translations.
 
-[Format Guide]: https://messageformat.github.io/messageformat/page-guide
-[Build-time Compilation Guide]: https://messageformat.github.io/messageformat/page-build
+[format guide]: https://messageformat.github.io/messageformat/page-guide
+[build-time compilation guide]: https://messageformat.github.io/messageformat/page-build

--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,25 @@
   "description": "PluralFormat and SelectFormat Message and i18n Tool - A JavaScript Implemenation of the ICU standards.",
   "main": "messageformat.js",
   "license": "MIT",
-  "ignore": [ ".*", "cli/", "docs/", "lib/", "logo/", "pages/", "test/", "package.json"],
+  "ignore": [
+    ".*",
+    "cli/",
+    "docs/",
+    "lib/",
+    "logo/",
+    "pages/",
+    "test/",
+    "package.json"
+  ],
   "keywords": [
-    "i18n", "icu", "internationalization", "gettext",
-    "messageformat", "pluralformat", "selectformat", "choiceformat"
+    "i18n",
+    "icu",
+    "internationalization",
+    "gettext",
+    "messageformat",
+    "pluralformat",
+    "selectformat",
+    "choiceformat"
   ],
   "authors": [
     "Alex Sexton <alexsexton@gmail.com>",

--- a/example/index.html
+++ b/example/index.html
@@ -1,25 +1,30 @@
 <!DOCTYPE html>
 <html>
-<div id="content"></div>
-<input type="button" value="en" id="en" />
-<input type="button" value="fr" id="fr" />
+  <div id="content"></div>
+  <input type="button" value="en" id="en" />
+  <input type="button" value="fr" id="fr" />
 
-<script src="i18n.js"></script>
-<script>
-  function showContents(lc) {
-    var colors = window.i18n[lc].colors;
-    var plural = window.i18n[lc].sub.folder.plural;
-    var el = document.getElementById('content');
-    el.innerHTML = '';
-    [ colors.red(), colors.blue(), colors.green(),
-      plural.test({ NUM: 1 }), plural.test({ NUM: 2 })
-    ].forEach(function(s) {
-      el.innerHTML += '<div>' + s + '</div>';
-    });
-    localStorage.setItem('lang', lc);
-  }
+  <script src="i18n.js"></script>
+  <script>
+    function showContents(lc) {
+      var colors = window.i18n[lc].colors;
+      var plural = window.i18n[lc].sub.folder.plural;
+      var el = document.getElementById('content');
+      el.innerHTML = '';
+      [
+        colors.red(),
+        colors.blue(),
+        colors.green(),
+        plural.test({ NUM: 1 }),
+        plural.test({ NUM: 2 })
+      ].forEach(function(s) {
+        el.innerHTML += '<div>' + s + '</div>';
+      });
+      localStorage.setItem('lang', lc);
+    }
 
-  showContents(localStorage.getItem('lang') || 'en');
-  document.getElementById('en').onclick = showContents.bind(null, 'en');
-  document.getElementById('fr').onclick = showContents.bind(null, 'fr');
-</script>
+    showContents(localStorage.getItem('lang') || 'en');
+    document.getElementById('en').onclick = showContents.bind(null, 'en');
+    document.getElementById('fr').onclick = showContents.bind(null, 'fr');
+  </script>
+</html>

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,4 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "independent"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2221,6 +2221,15 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-utils": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
@@ -2464,6 +2473,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -5081,6 +5096,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
       "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@lerna/add": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.6.0.tgz",
@@ -708,6 +728,18 @@
         "negotiator": "0.6.1"
       }
     },
+    "acorn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
+      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
     "agent-base": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
@@ -926,6 +958,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
@@ -1307,6 +1345,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "class-utils": {
@@ -1873,6 +1917,12 @@
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -1967,6 +2017,15 @@
         "path-type": "^3.0.0"
       }
     },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -2058,10 +2117,167 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.11.1.tgz",
+      "integrity": "sha512-gOKhM8JwlFOc2acbOrkYR05NW8M6DCMSvfcJiBB5NDxRE1gv8kbvxKaC9u69e6ZGEMWXcswA/7eKR229cEIpvg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.0.2",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "eslint-scope": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+          "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.3.0.tgz",
+      "integrity": "sha512-Bc3bh5bAcKNvs3HOpSi6EfGA2IIp7EzWcg2tS4vP7stnXu/J1opihHDM7jI9JCIckyIDTgZLSWn7J3HY0j2JfA==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+      "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.2",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "execa": {
@@ -2281,6 +2497,12 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
     "fast-url-parser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
@@ -2311,6 +2533,16 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "fill-range": {
@@ -2349,6 +2581,18 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
       }
     },
     "flush-write-stream": {
@@ -2463,6 +2707,12 @@
         "mkdirp": ">=0.5 0",
         "rimraf": "2"
       }
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",
@@ -2805,6 +3055,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "globals": {
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
     },
     "globby": {
@@ -3409,6 +3665,12 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
@@ -3441,6 +3703,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
@@ -3514,6 +3782,16 @@
         "@lerna/version": "^3.6.0",
         "import-local": "^1.0.0",
         "libnpm": "^2.0.1"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "libnpm": {
@@ -4121,6 +4399,12 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -4399,6 +4683,28 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
       }
     },
     "os-homedir": {
@@ -4752,10 +5058,22 @@
         }
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "prettier": {
@@ -4768,6 +5086,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "promise-inflight": {
@@ -5062,6 +5386,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
@@ -5141,6 +5471,39 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "caller-path": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+          "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+          "dev": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
     },
     "resolve-cwd": {
       "version": "2.0.0",
@@ -5375,6 +5738,25 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+      "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -5779,6 +6161,51 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
+      "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.6.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "2.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "tar": {
       "version": "2.2.1",
       "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
@@ -5857,6 +6284,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
@@ -5985,6 +6418,15 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -6315,6 +6757,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4758,6 +4758,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:example": "./packages/cli/messageformat.js -l en,fr -n i18n -o example/i18n.js example/",
     "build": "lerna run build && npm run build:example",
     "clean": "lerna run clean",
+    "lint": "eslint '**/*.js'",
     "prepare": "lerna bootstrap",
     "pretest": "lerna run build --scope messageformat-parser",
     "prettier": "prettier --write '**/*.{html,js,json,md,ts}'",
@@ -23,7 +24,50 @@
   "prettier": {
     "singleQuote": true
   },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "commonjs": true
+    },
+    "extends": [
+      "eslint:recommended",
+      "prettier"
+    ],
+    "rules": {
+      "array-callback-return": "error",
+      "camelcase": "error",
+      "consistent-return": "error",
+      "eqeqeq": [
+        "error",
+        "smart"
+      ],
+      "no-constant-condition": [
+        "error",
+        {
+          "checkLoops": false
+        }
+      ],
+      "no-implicit-globals": "error"
+    },
+    "overrides": [
+      {
+        "files": [
+          "test/*.js"
+        ],
+        "env": {
+          "browser": true,
+          "es6": true,
+          "mocha": true
+        },
+        "rules": {
+          "no-unused-vars": 0
+        }
+      }
+    ]
+  },
   "devDependencies": {
+    "eslint": "^5.11.1",
+    "eslint-config-prettier": "^3.3.0",
     "expect.js": "^0.3.1",
     "lerna": "^3.6.0",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
     "clean": "lerna run clean",
     "prepare": "lerna bootstrap",
     "pretest": "lerna run build --scope messageformat-parser",
+    "prettier": "prettier --write '**/*.{html,js,json,md,ts}'",
     "test:browser": "lerna run build:browser --scope messageformat && serve",
     "test": "lerna run test && mocha"
+  },
+  "prettier": {
+    "singleQuote": true
   },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "lerna": "^3.6.0",
     "mocha": "^5.2.0",
+    "prettier": "^1.15.3",
     "rimraf": "^2.6.2",
     "serve": "^10.1.1",
     "tmp": "0.0.33"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "env": {
       "commonjs": true
     },
+    "plugins": [
+      "prettier"
+    ],
     "extends": [
       "eslint:recommended",
       "prettier"
@@ -47,7 +50,8 @@
           "checkLoops": false
         }
       ],
-      "no-implicit-globals": "error"
+      "no-implicit-globals": "error",
+      "prettier/prettier": "error"
     },
     "overrides": [
       {
@@ -68,6 +72,7 @@
   "devDependencies": {
     "eslint": "^5.11.1",
     "eslint-config-prettier": "^3.3.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "expect.js": "^0.3.1",
     "lerna": "^3.6.0",
     "mocha": "^5.2.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,6 @@
 
 Parses and compiles the input JSON and [.properties](https://en.wikipedia.org/wiki/.properties) file(s) of MessageFormat strings into a JS module of corresponding hierarchical functions.
 
-
 ## Installation
 
 ```
@@ -11,66 +10,78 @@ npm install messageformat@next messageformat-cli
 
 [`messageformat`](https://www.npmjs.com/package/messageformat) is a peer dependency of `messageformat-cli`, and needs to be installed separately.
 
-
 ## Usage
 
 ```
 npx messageformat [options] [input]
 ```
+
 or
+
 ```
 ./node_modules/.bin/messageformat [options] [input]
 ```
 
 `input` should consist of one or more files or directories, unless defined in a configuration file. Directories are recursively scanned for `.json` and `.properties` files. With multiple input files, shared parts of the start of their paths are dropped out of the generated module's structure.
 
-
 ## Options
 
 In addition to defining options on the command line, options may also be set in the **`"messageformat"`** object in your **`package.json`** file, or in a **`messageformat.rc.json`** configuration file, using the long-form option names as keys. Input files and directories may also be given as an **`"include"`** array in a configuration file. Command-line options override configuration files.
 
 ### `-l lc, --locale=lc`
+
 The locale(s) _`lc`_ to include; if multiple, first is default and others are selected by matching message key. If not set or empty, path keys matching any locale code will set the active locale, starting with a default `en` locale.
 
 ### `-n ns, --namespace=ns`
-By default, output is an ES6 module with a default export; set _`ns`_ to support other environments. If _`ns`_ does not contain a `.`, the output follows an UMD pattern. For CommonJS module output, use *--namespace=module.exports*.
+
+By default, output is an ES6 module with a default export; set _`ns`_ to support other environments. If _`ns`_ does not contain a `.`, the output follows an UMD pattern. For CommonJS module output, use _--namespace=module.exports_.
 
 ### `-o of, --outfile=of`
+
 Write output to the file _`of`_. If unspecified or `-`, prints to stdout.
 
 ### `--delimiters`
+
 Set of characters by which the file path is split into output object keys. [default: `._/` or `._\` depending on platform]
 
 ### `--disable-plural-key-checks`
+
 By default, messageformat throws an error when a statement uses a non-numerical key that will never be matched as a pluralization category for the current locale. Use this argument to disable the validation and allow unused plural keys. [default: `false`]
 
 ### `--eslint-disable`
+
 Add an `/* eslint-disable */` comment as the first line of the output, to silence [ESLint](https://eslint.org/) warnings. [default: `false`]
 
 ### `--extensions`
+
 Array or comma-separated list of file extensions to parse as source files. [default: `['.json', '.properties']`]
 
 ### `--simplify`
-Simplify the output object structure, by dropping intermediate keys when those keys are shared across all objects at that level, in addition to the default filtering-out of shared keys at the root of the object. [default: `false`]
 
+Simplify the output object structure, by dropping intermediate keys when those keys are shared across all objects at that level, in addition to the default filtering-out of shared keys at the root of the object. [default: `false`]
 
 ## Examples
 
 With `messages/strings.json`, compile it into a node.js module using the default English locale:
+
 ```
 npx messageformat messages/strings.json > messages/en.js
 ```
 
-----
+---
+
 With `messages/en.json` and `messages/fr.json`, combine both into an ES6-compatible module, with the top-level keys `en` and `fr` containing functions that each use the correct language's pluralization rules:
+
 ```
 npx messageformat --locale=en,fr messages/ > messages.js
 ```
 
 Note: The `locale` option could be left out here if is known that the data does not include any 2-3 letter keys matching other locales.
 
-----
+---
+
 Same, but with this configuration in `package.json`:
+
 ```
 {
   ...,

--- a/packages/cli/messageformat.js
+++ b/packages/cli/messageformat.js
@@ -55,41 +55,46 @@ function getOptions(knownOpts, shortHands) {
   let delim = Array.isArray(options.delimiters)
     ? options.delimiters.join('')
     : typeof options.delimiters === 'string'
-      ? options.delimiters
-      : '._' + path.sep;
+    ? options.delimiters
+    : '._' + path.sep;
   delim = delim.replace(/[/\\]+/g, '\\' + path.sep).replace(/[-\]]/g, '\\$&');
   options.delimiters = new RegExp(`[${delim}]`);
-  options.extensions = options.extensions && options.extensions.length > 0 ? (
-    options.extensions.map(ext => ext.trim().replace(/^([^.]*\.)?/, '.'))
-  ) : ['.json', '.properties'];
+  options.extensions =
+    options.extensions && options.extensions.length > 0
+      ? options.extensions.map(ext => ext.trim().replace(/^([^.]*\.)?/, '.'))
+      : ['.json', '.properties'];
   if (options.argv.remain.length > 0) options.include = options.argv.remain;
   options.include = (options.include || []).map(fn => path.resolve(fn));
-  const lc = Array.isArray(options.locale) ? options.locale.join(',') : options.locale;
+  const lc = Array.isArray(options.locale)
+    ? options.locale.join(',')
+    : options.locale;
   options.locale = lc ? lc.split(/[ ,]+/) : null;
-  return options
+  return options;
 }
 
 const options = getOptions(knownOpts, shortHands);
 if (options.help || options.include.length === 0) {
   printUsage();
 } else {
-  const input = readInput(options.include, options.extensions, options.delimiters);
+  const input = readInput(
+    options.include,
+    options.extensions,
+    options.delimiters
+  );
   if (options.simplify) simplify(input);
   const mf = new MessageFormat(options.locale);
   if (options['disable-plural-key-checks']) mf.disablePluralKeyChecks();
   let output = mf.compile(input).toString(options.namespace);
   if (options['eslint-disable']) output = '/* eslint-disable */\n' + output;
   if (options.outfile && options.outfile !== '-') {
-    fs.writeFileSync(path.resolve(options.outfile), output)
+    fs.writeFileSync(path.resolve(options.outfile), output);
   } else {
     console.log(output);
   }
 }
 
-
 function printUsage() {
-  let usage =
-`usage: *messageformat* [options] [_input_, ...]
+  let usage = `usage: *messageformat* [options] [_input_, ...]
 
 Parses the _input_ JSON and .properties files of MessageFormat strings into
 a JS module of corresponding hierarchical functions. Input directories are
@@ -112,32 +117,34 @@ recursively scanned for all .json and .properties files.
 See the messageformat-cli README for more options. Configuration may also be
 set in *package.json* or *messageformat.rc.json*.`;
   if (process.stdout.isTTY) {
-    usage = usage.replace(/_(.+?)_/g, '\x1B[4m$1\x1B[0m')
-                 .replace(/\*(.+?)\*/g, '\x1B[1m$1\x1B[0m');
+    usage = usage
+      .replace(/_(.+?)_/g, '\x1B[4m$1\x1B[0m')
+      .replace(/\*(.+?)\*/g, '\x1B[1m$1\x1B[0m');
   } else {
     usage = usage.replace(/[_*]/g, '');
   }
   console.log(usage);
 }
 
-
 function readInput(include, extensions, sep) {
   const ls = [];
-  include.forEach((fn) => {
+  include.forEach(fn => {
     if (!fs.existsSync(fn)) throw new Error(`Input file not found: ${fn}`);
     if (fs.statSync(fn).isDirectory()) {
       extensions.forEach(ext => {
         ls.push.apply(ls, glob.sync(path.join(fn, '**/*' + ext)));
-      })
+      });
     } else if (extensions.includes(path.extname(fn))) {
       ls.push(fn);
     } else {
-      throw new Error(`Unrecognised file extension (expected ${extensions}): ${fn}`);
+      throw new Error(
+        `Unrecognised file extension (expected ${extensions}): ${fn}`
+      );
     }
   });
 
   let input = {};
-  ls.forEach((fn) => {
+  ls.forEach(fn => {
     const ext = path.extname(fn);
     const parts = fn.slice(0, -ext.length).split(sep);
     const lastIdx = parts.length - 1;
@@ -152,8 +159,8 @@ function readInput(include, extensions, sep) {
           case '.properties':
             const raw = fs.readFileSync(fn);
             const src = raw.toString(uv(raw) ? 'utf8' : 'latin1');
-            root[part] = dotProperties.parse(src, sep.test('.'))
-            break
+            root[part] = dotProperties.parse(src, sep.test('.'));
+            break;
           default:
             root[part] = require(fn);
         }
@@ -173,25 +180,34 @@ function readInput(include, extensions, sep) {
 
 function simplify(input) {
   function getAllObjects(obj, level) {
-    if (typeof obj !== 'object') throw new Error('non-object value')
+    if (typeof obj !== 'object') throw new Error('non-object value');
     if (level === 0) return [obj];
     else if (level === 1) return Object.keys(obj).map(k => obj[k]);
-    else return Object.keys(obj)
-      .map(k => getAllObjects(obj[k], level - 1))
-      .reduce((a, b) => a.concat(b), []);
+    else
+      return Object.keys(obj)
+        .map(k => getAllObjects(obj[k], level - 1))
+        .reduce((a, b) => a.concat(b), []);
   }
 
   var lvl = 0;
   try {
     while (true) {
       var objects = getAllObjects(input, lvl);
-      var keysets = objects.map(obj => Object.keys(obj).map(k => {
-        if (typeof obj[k] !== 'object') throw new Error('non-object value');
-        return Object.keys(obj[k]);
-      }));
+      var keysets = objects.map(obj =>
+        Object.keys(obj).map(k => {
+          if (typeof obj[k] !== 'object') throw new Error('non-object value');
+          return Object.keys(obj[k]);
+        })
+      );
       var key0 = keysets[0][0][0];
-      if (keysets.every(keyset => keyset.every(ks => ks.length === 1 && ks[0] === key0))) {
-        objects.forEach(obj => Object.keys(obj).forEach(k => obj[k] = obj[k][key0]));
+      if (
+        keysets.every(keyset =>
+          keyset.every(ks => ks.length === 1 && ks[0] === key0)
+        )
+      ) {
+        objects.forEach(obj =>
+          Object.keys(obj).forEach(k => (obj[k] = obj[k][key0]))
+        );
       } else {
         ++lvl;
       }

--- a/packages/cli/messageformat.js
+++ b/packages/cli/messageformat.js
@@ -42,12 +42,16 @@ function getOptions(knownOpts, shortHands) {
     const pkgPath = path.resolve('package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
     Object.assign(options, pkg.messageformat);
-  } catch (e) {}
+  } catch (e) {
+    /* ignore error */
+  }
   try {
     const cfgPath = path.resolve('messageformat.rc.json');
     const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
     Object.assign(options, cfg.messageformat || cfg);
-  } catch (e) {}
+  } catch (e) {
+    /* ignore error */
+  }
   const cliOptions = nopt(knownOpts, shortHands, process.argv, 2);
   Object.assign(options, cliOptions);
 
@@ -149,18 +153,19 @@ function readInput(include, extensions, sep) {
     const parts = fn.slice(0, -ext.length).split(sep);
     const lastIdx = parts.length - 1;
     parts.reduce((root, part, idx) => {
-      if (idx == lastIdx) {
+      if (idx === lastIdx) {
         switch (ext) {
           // extension list from https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
           case '.ini':
           case '.cfg':
           case '.prefs':
           case '.pro':
-          case '.properties':
+          case '.properties': {
             const raw = fs.readFileSync(fn);
             const src = raw.toString(uv(raw) ? 'utf8' : 'latin1');
             root[part] = dotProperties.parse(src, sep.test('.'));
             break;
+          }
           default:
             root[part] = require(fn);
         }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,15 @@
   "engines": {
     "node": ">=6.0"
   },
+  "eslintConfig": {
+    "env": {
+      "es6": true,
+      "node": true
+    },
+    "rules": {
+      "no-console": 0
+    }
+  },
   "dependencies": {
     "dot-properties": "^0.2.1",
     "glob": "~7.0.6",

--- a/packages/convert/README.md
+++ b/packages/convert/README.md
@@ -2,6 +2,7 @@
 
 Converts hiearachical objects into [messageformat]-compatible JSON. More
 specifically, it:
+
 - Detects two-letter locale keys and parses their contents according to that
   locale's pluralisation rules
 - Converts `#{var}` and `%{var}` variable replacements into their messageformat
@@ -22,43 +23,41 @@ npm install messageformat-convert
 If using in an environment that does not natively support ES6 features such as
 object destructuring and arrow functions, you'll want to use a transpiler for this.
 
-
 ### Usage
 
 ```js
-const convert = require('messageformat-convert')
+const convert = require('messageformat-convert');
 const { locales, translations } = convert({
   en: {
-    format: "%{attribute} %{message}",
+    format: '%{attribute} %{message}',
     errors: {
       confirmation: "doesn't match %{attribute}",
-      accepted: "must be accepted",
+      accepted: 'must be accepted',
       wrong_length: {
-        one: "is the wrong length (should be 1 character)",
-        other: "is the wrong length (should be %{count} characters)"
+        one: 'is the wrong length (should be 1 character)',
+        other: 'is the wrong length (should be %{count} characters)'
       },
-      equal_to: "must be equal to %{count}"
+      equal_to: 'must be equal to %{count}'
     }
   }
-})
+});
 
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat(locales)
-const messages = mf.compile(translations)
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat(locales);
+const messages = mf.compile(translations);
 
-messages.en.errors.accepted()
+messages.en.errors.accepted();
 // 'must be accepted'
 
 messages.en.format({
   attribute: 'Problem',
   message: messages.en.errors.confirmation({ attribute: 'your style' })
-})
+});
 // 'Problem doesn\'t match your style'
 
-messages.en.errors.wrong_length({ count: 42 })
+messages.en.errors.wrong_length({ count: 42 });
 // 'is the wrong length (should be 42 characters)'
 ```
-
 
 ### API: `convert(data, options)`
 
@@ -84,5 +83,5 @@ The object returned by the function contains the following fields:
 - `translations` (object) – An object containing the MessageFormat strings,
   matching the shape of the input data
 
-[CLDR pluralisation language]: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
+[cldr pluralisation language]: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
 [messageformat]: https://messageformat.github.io/

--- a/packages/convert/index.js
+++ b/packages/convert/index.js
@@ -1,7 +1,7 @@
-const common = require('common-prefix')
-const pluralCategories = require('make-plural/umd/pluralCategories')
+const common = require('common-prefix');
+const pluralCategories = require('make-plural/umd/pluralCategories');
 
-const cldrPluralCategories = ['zero', 'one', 'two', 'few', 'many', 'other']
+const cldrPluralCategories = ['zero', 'one', 'two', 'few', 'many', 'other'];
 
 const defaultOptions = {
   defaultLocale: 'en',
@@ -15,84 +15,98 @@ const defaultOptions = {
   ],
   schema: 'failsafe',
   verbose: false
-}
+};
 
-const getMessageFormat = (msg, { replacements }) => msg ? (
-  replacements.reduce((msg, { pattern, replacement, state }) => {
-    if (state) replacement = replacement.bind(Object.assign({}, state))
-    return msg.replace(pattern, replacement)
-  }, String(msg))
-) : ''
+const getMessageFormat = (msg, { replacements }) =>
+  msg
+    ? replacements.reduce((msg, { pattern, replacement, state }) => {
+        if (state) replacement = replacement.bind(Object.assign({}, state));
+        return msg.replace(pattern, replacement);
+      }, String(msg))
+    : '';
 
 const isPluralObject = (data, locale, { verbose }) => {
-  const { cardinal: pluralKeys } = pluralCategories[locale] || {}
-  const keys = Object.keys(data)
-  if (!pluralKeys || pluralKeys.length === 0 || keys.length === 0) return false
+  const { cardinal: pluralKeys } = pluralCategories[locale] || {};
+  const keys = Object.keys(data);
+  if (!pluralKeys || pluralKeys.length === 0 || keys.length === 0) return false;
   if (
     keys.length === pluralKeys.length &&
-    keys.every(key => (
-      pluralKeys.includes(key) &&
-      (!data[key] || typeof data[key] !== 'object')
-    ))
-  ) return true
+    keys.every(
+      key =>
+        pluralKeys.includes(key) &&
+        (!data[key] || typeof data[key] !== 'object')
+    )
+  )
+    return true;
   if (verbose && keys.every(key => cldrPluralCategories.includes(key))) {
-    console.warn(`messageformat-convert: Nearly valid plural for locale ${locale}: ${JSON.stringify(data)}`)
+    console.warn(
+      `messageformat-convert: Nearly valid plural for locale ${locale}: ${JSON.stringify(
+        data
+      )}`
+    );
   }
-  return false
-}
+  return false;
+};
 
 const getPluralMessage = (data, options) => {
-  const keys = Object.keys(data)
-  const messages = keys.map(key => getMessageFormat(data[key], options))
-  const prefix = common(messages)
-  const suffixLength = common(messages.map(msg => msg.split('').reverse().join(''))).length
-  const suffix = suffixLength > 0 ? messages[0].slice(-suffixLength) : ''
-  const cut = suffixLength > 0 ? (
-    (msg) => msg.slice(prefix.length, -suffixLength)
-  ) : prefix ? (
-    (msg) => msg.slice(prefix.length)
-  ) : (
-    (msg) => msg
-  )
-  const pc = keys.map((key, i) => `${key}{${cut(messages[i])}}`)
-  const pv = options.pluralVariable
-  return `${prefix}{${pv}, plural, ${pc.join(' ')}}${suffix}`
-}
+  const keys = Object.keys(data);
+  const messages = keys.map(key => getMessageFormat(data[key], options));
+  const prefix = common(messages);
+  const suffixLength = common(
+    messages.map(msg =>
+      msg
+        .split('')
+        .reverse()
+        .join('')
+    )
+  ).length;
+  const suffix = suffixLength > 0 ? messages[0].slice(-suffixLength) : '';
+  const cut =
+    suffixLength > 0
+      ? msg => msg.slice(prefix.length, -suffixLength)
+      : prefix
+      ? msg => msg.slice(prefix.length)
+      : msg => msg;
+  const pc = keys.map((key, i) => `${key}{${cut(messages[i])}}`);
+  const pv = options.pluralVariable;
+  return `${prefix}{${pv}, plural, ${pc.join(' ')}}${suffix}`;
+};
 
 const convertData = (data, locale, options) => {
   if (!data) {
-    return ''
+    return '';
   } else if (Array.isArray(data)) {
-    return data.map(d => convertData(d, locale, options))
+    return data.map(d => convertData(d, locale, options));
   } else if (typeof data === 'object') {
     if (options.pluralVariable && isPluralObject(data, locale, options)) {
-      return getPluralMessage(data, options)
+      return getPluralMessage(data, options);
     } else {
       return Object.keys(data).reduce((res, key) => {
-        const { includeLocales: il, verbose } = options
-        const isLcKey = (!il || il.includes(key)) && pluralCategories[key]
+        const { includeLocales: il, verbose } = options;
+        const isLcKey = (!il || il.includes(key)) && pluralCategories[key];
         if (isLcKey) {
-          options._lc[key] = true
-          if (verbose) console.log(`messageformat-convert: Found locale ${key}`)
+          options._lc[key] = true;
+          if (verbose)
+            console.log(`messageformat-convert: Found locale ${key}`);
         }
-        res[key] = convertData(data[key], isLcKey ? key : locale, options)
-        return res
-      }, {})
+        res[key] = convertData(data[key], isLcKey ? key : locale, options);
+        return res;
+      }, {});
     }
   } else {
-    return getMessageFormat(data, options)
+    return getMessageFormat(data, options);
   }
-}
+};
 
 const convert = (data, options) => {
-  if (data.length === 1) data = data[0]
-  options = Object.assign({}, defaultOptions, options)
-  options._lc = { [options.defaultLocale]: true }
-  const translations = convertData(data, options.defaultLocale, options)
+  if (data.length === 1) data = data[0];
+  options = Object.assign({}, defaultOptions, options);
+  options._lc = { [options.defaultLocale]: true };
+  const translations = convertData(data, options.defaultLocale, options);
   return {
     locales: Object.keys(options._lc).filter(lc => lc),
     translations
-  }
-}
+  };
+};
 
-module.exports = convert
+module.exports = convert;

--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -15,6 +15,16 @@
   "engines": {
     "node": ">=6.0"
   },
+  "eslintConfig": {
+    "env": {
+      "es6": true,
+      "node": true
+    },
+    "rules": {
+      "no-console": 0,
+      "no-control-regex": 0
+    }
+  },
   "dependencies": {
     "common-prefix": "1.1.0",
     "make-plural": "^4.3.0"

--- a/packages/loader-example/dist/index.html
+++ b/packages/loader-example/dist/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <title>Getting Started</title>
   </head>
   <body>

--- a/packages/loader-example/package.json
+++ b/packages/loader-example/package.json
@@ -10,6 +10,28 @@
   "scripts": {
     "build": "webpack"
   },
+  "eslintConfig": {
+    "env": {
+      "browser": true,
+      "es6": true
+    },
+    "parserOptions": {
+      "sourceType": "module"
+    },
+    "rules": {
+      "no-console": 0
+    },
+    "overrides": [
+      {
+        "files": [
+          "webpack.config.js"
+        ],
+        "env": {
+          "node": true
+        }
+      }
+    ]
+  },
   "dependencies": {
     "messageformat": "^2.0.4",
     "messageformat-loader": "^0.7.0",

--- a/packages/loader-example/src/index.js
+++ b/packages/loader-example/src/index.js
@@ -1,13 +1,13 @@
-import messages from './messages.json'
+import messages from './messages.json';
 
 function component() {
-  const element = document.createElement('div')
+  const element = document.createElement('div');
   element.innerHTML = [
     'In English: ' + messages.en.select({ GENDER: 'female' }),
     'Suomeksi: ' + messages.fi.select({ GENDER: 'female' })
-  ].join('<br/>')
-  return element
+  ].join('<br/>');
+  return element;
 }
 
-console.log('messages', messages)
-document.body.appendChild(component())
+console.log('messages', messages);
+document.body.appendChild(component());

--- a/packages/loader-example/webpack.config.js
+++ b/packages/loader-example/webpack.config.js
@@ -1,6 +1,6 @@
-const path = require('path')
+const path = require('path');
 
-const locale = ['en', 'fi']
+const locale = ['en', 'fi'];
 
 module.exports = {
   entry: './src/index.js',
@@ -24,4 +24,4 @@ module.exports = {
       }
     ]
   }
-}
+};

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -1,12 +1,10 @@
 # ICU MessageFormat loader for webpack
 
-
 ## Installation
 
 ```
 npm install messageformat messageformat-loader
 ```
-
 
 ## Usage
 
@@ -48,29 +46,29 @@ The default option values are shown, and are not required. [See below](#options)
 ### example.js
 
 ES6, with configuration:
+
 ```js
-import messages from './messages.json'
-messages['ordinal-example']({ N: 1 })
+import messages from './messages.json';
+messages['ordinal-example']({ N: 1 });
 // => 'The 1st message.'
 ```
 
 ES5, without configuration:
+
 ```js
 var messages = require('messageformat-loader?locale=en!./messages.json');
 messages['ordinal-example']({ N: 1 });
 // => 'The 1st message.'
 ```
 
-
 ## Options
 
-* [`locale`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#MessageFormat) The [CLDR language code](http://www.unicode.org/cldr/charts/29/supplemental/language_territory_information.html) or codes to pass to [messageformat.js](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html). If using multiple locales at the same time, exact matches to a locale code in the data structure keys will select that locale within it (as in [`example/src/messages.json`](example/src/messages.json)). Defaults to `en`.
-* [`disablePluralKeyChecks`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#disablePluralKeyChecks) By default, messageformat.js throws an error when a statement uses a non-numerical key that will never be matched as a pluralization category for the current locale. Use this argument to disable the validation and allow unused plural keys. Defaults to `false`.
-* [`intlSupport`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setIntlSupport) Enable or disable support for the default formatters, which require the Intl object. Defaults to `false`.
-* [`biDiSupport`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setBiDiSupport) Enable or disable the addition of Unicode control characters to all input to preserve the integrity of the output when mixing LTR and RTL text. Defaults to `false`.
-* [`formatters`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#addFormatters) Add custom formatter functions to this MessageFormat instance.
-* [`strictNumberSign`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setStrictNumberSign) Follow the stricter ICU MessageFormat spec and throw a runtime error if # is used with non-numeric input. Defaults to `false`.
-
+- [`locale`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#MessageFormat) The [CLDR language code](http://www.unicode.org/cldr/charts/29/supplemental/language_territory_information.html) or codes to pass to [messageformat.js](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html). If using multiple locales at the same time, exact matches to a locale code in the data structure keys will select that locale within it (as in [`example/src/messages.json`](example/src/messages.json)). Defaults to `en`.
+- [`disablePluralKeyChecks`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#disablePluralKeyChecks) By default, messageformat.js throws an error when a statement uses a non-numerical key that will never be matched as a pluralization category for the current locale. Use this argument to disable the validation and allow unused plural keys. Defaults to `false`.
+- [`intlSupport`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setIntlSupport) Enable or disable support for the default formatters, which require the Intl object. Defaults to `false`.
+- [`biDiSupport`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setBiDiSupport) Enable or disable the addition of Unicode control characters to all input to preserve the integrity of the output when mixing LTR and RTL text. Defaults to `false`.
+- [`formatters`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#addFormatters) Add custom formatter functions to this MessageFormat instance.
+- [`strictNumberSign`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setStrictNumberSign) Follow the stricter ICU MessageFormat spec and throw a runtime error if # is used with non-numeric input. Defaults to `false`.
 
 ## Links
 
@@ -78,7 +76,6 @@ messages['ordinal-example']({ N: 1 });
 - Loaders:
   - [Webpack v1](https://webpack.github.io/docs/using-loaders.html)
   - [Webpack v2/3](https://webpack.js.org/concepts/loaders/)
-
 
 ## License
 

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -4,7 +4,8 @@ var MessageFormat = require('messageformat');
 module.exports = function(content) {
   var options = loaderUtils.getOptions(this) || {};
   var locale = options.locale;
-  if (typeof locale === 'string' && locale.indexOf(',') !== -1) locale = locale.split(',');
+  if (typeof locale === 'string' && locale.indexOf(',') !== -1)
+    locale = locale.split(',');
   var messages = JSON.parse(content);
   var messageFormat = new MessageFormat(locale);
   if (options.disablePluralKeyChecks) {
@@ -25,7 +26,7 @@ module.exports = function(content) {
   var messageFunctions = messageFormat.compile(messages);
 
   this.cacheable && this.cacheable();
-  this.value = [ messageFunctions ];
+  this.value = [messageFunctions];
 
   return messageFunctions.toString('module.exports');
 };

--- a/packages/messageformat/README.md
+++ b/packages/messageformat/README.md
@@ -10,7 +10,6 @@ The ICU has an [official guide](http://userguide.icu-project.org/formatparse/mes
 
 There is a good slide-deck on [Plural and Gender in Translated Messages](https://docs.google.com/presentation/d/1ZyN8-0VXmod5hbHveq-M1AeQ61Ga3BmVuahZjbmbBxo/pub?start=false&loop=false&delayms=3000#slide=id.g1bc43a82_2_14) by Markus Scherer and Mark Davis. But, again, remember that many of these problems apply even if you're only outputting english.
 
-
 ## What problems does it solve?
 
 Using messageformat, you can separate your code from your text formatting, while enabling much more humane expressions. In other words, you won't need to see this anymore in your output:
@@ -20,7 +19,6 @@ Using messageformat, you can separate your code from your text formatting, while
 > Number of results: 3.
 
 On a more fundamental level, messageformat and its associated tools can help you build an effective workflow for UI texts and translations, keeping message sources in human-friendly formats, compiling them into JavaScript during your build phase, and making them easy to use from your application code.
-
 
 ## What does it look like?
 
@@ -35,22 +33,21 @@ const msgSrc = `{GENDER, select,
   =0 {no results}
   one {1 result}
   other {# results}
-}.`
+}.`;
 ```
 
 You'll get these results:
 
 ```js
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
-const msg = mf.compile(msgSrc)
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
+const msg = mf.compile(msgSrc);
 
-msg({ GENDER: 'male', RES: 1 })    // 'He found 1 result.'
-msg({ GENDER: 'female', RES: 1 })  // 'She found 1 result.'
-msg({ GENDER: 'male', RES: 0 })    // 'He found no results.'
-msg({ RES: 2 })                    // 'They found 2 results.'
+msg({ GENDER: 'male', RES: 1 }); // 'He found 1 result.'
+msg({ GENDER: 'female', RES: 1 }); // 'She found 1 result.'
+msg({ GENDER: 'male', RES: 0 }); // 'He found no results.'
+msg({ RES: 2 }); // 'They found 2 results.'
 ```
-
 
 ## Getting Started
 
@@ -62,5 +59,5 @@ npm install messageformat
 
 This includes the MessageFormat compiler and a runtime accessor class that provides a slightly nicer API for working with larger numbers of messages. Our [Format Guide] will help with the ICU MessageFormat Syntax, and the [Build-time Compilation Guide] provides some options for integrating messageformat to be a part of your workflow around UI texts and translations.
 
-[Format Guide]: https://messageformat.github.io/messageformat/page-guide
-[Build-time Compilation Guide]: https://messageformat.github.io/messageformat/page-build
+[format guide]: https://messageformat.github.io/messageformat/page-guide
+[build-time compilation guide]: https://messageformat.github.io/messageformat/page-build

--- a/packages/messageformat/index.d.ts
+++ b/packages/messageformat/index.d.ts
@@ -1,22 +1,25 @@
 declare namespace MessageFormat {
-    type Msg = { (params: {}): string; toString(global?: string): string };
-    type Formatter = (val: any, lc: string, arg?: string) => string;
-    type SrcMessage = string | SrcObject;
+  type Msg = { (params: {}): string; toString(global?: string): string };
+  type Formatter = (val: any, lc: string, arg?: string) => string;
+  type SrcMessage = string | SrcObject;
 
-    interface SrcObject {
-        [key: string]: SrcMessage;
-    }
+  interface SrcObject {
+    [key: string]: SrcMessage;
+  }
 }
 
 declare class MessageFormat {
-    constructor(
-      message?: { [pluralFuncs: string]: Function } | string[] | string
-    );
-    addFormatters: (format: { [name: string]: MessageFormat.Formatter }) => this;
-    disablePluralKeyChecks: () => this;
-    setBiDiSupport: (enable: boolean) => this;
-    setStrictNumberSign: (enable: boolean) => this;
-    compile: (messages: MessageFormat.SrcMessage, locale?: string) => MessageFormat.Msg;
+  constructor(
+    message?: { [pluralFuncs: string]: Function } | string[] | string
+  );
+  addFormatters: (format: { [name: string]: MessageFormat.Formatter }) => this;
+  disablePluralKeyChecks: () => this;
+  setBiDiSupport: (enable: boolean) => this;
+  setStrictNumberSign: (enable: boolean) => this;
+  compile: (
+    messages: MessageFormat.SrcMessage,
+    locale?: string
+  ) => MessageFormat.Msg;
 }
 
 export = MessageFormat;

--- a/packages/messageformat/lib/formatters/date.js
+++ b/packages/messageformat/lib/formatters/date.js
@@ -24,14 +24,20 @@
  * cf({ sys: 'HAL 9000', d0: '12 January 1999' })
  * // 'HAL 9000 became operational on 1/12/1999'
  */
-function date(v,lc,p) {
-  var o = {day:'numeric', month:'short', year:'numeric'};
+function date(v, lc, p) {
+  var o = { day: 'numeric', month: 'short', year: 'numeric' };
   switch (p) {
-    case 'full': o.weekday = 'long';
-    case 'long': o.month = 'long'; break;
-    case 'short': o.month = 'numeric';
+    case 'full':
+      o.weekday = 'long';
+    case 'long':
+      o.month = 'long';
+      break;
+    case 'short':
+      o.month = 'numeric';
   }
-  return (new Date(v)).toLocaleDateString(lc, o)
+  return new Date(v).toLocaleDateString(lc, o);
 }
 
-module.exports = function() { return date; }
+module.exports = function() {
+  return date;
+};

--- a/packages/messageformat/lib/formatters/date.js
+++ b/packages/messageformat/lib/formatters/date.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-fallthrough */
+
 /** Represent a date as a short/default/long/full string
  *
  * The input value needs to be in a form that the

--- a/packages/messageformat/lib/formatters/duration.js
+++ b/packages/messageformat/lib/formatters/duration.js
@@ -39,9 +39,18 @@ function duration(value) {
     }
   }
   var first = parts.shift();
-  return sign + first + ':' + parts.map(function(n) {
-    return n < 10 ? '0' + String(n) : String(n)
-  }).join(':');
+  return (
+    sign +
+    first +
+    ':' +
+    parts
+      .map(function(n) {
+        return n < 10 ? '0' + String(n) : String(n);
+      })
+      .join(':')
+  );
 }
 
-module.exports = function () { return duration; }
+module.exports = function() {
+  return duration;
+};

--- a/packages/messageformat/lib/formatters/index.js
+++ b/packages/messageformat/lib/formatters/index.js
@@ -33,4 +33,4 @@ module.exports = {
   duration: require('./duration'),
   number: require('./number'),
   time: require('./time')
-}
+};

--- a/packages/messageformat/lib/formatters/number.js
+++ b/packages/messageformat/lib/formatters/number.js
@@ -27,23 +27,24 @@
  */
 
 function number(value, lc, arg) {
-  var a = arg && arg.split(':') || []
+  var a = (arg && arg.split(':')) || [];
   var opt = {
     integer: { maximumFractionDigits: 0 },
     percent: { style: 'percent' },
     currency: {
       style: 'currency',
-      currency: a[1] && a[1].trim() || CURRENCY,
+      currency: (a[1] && a[1].trim()) || CURRENCY,
       minimumFractionDigits: 2,
       maximumFractionDigits: 2
     }
-  }
-  return new Intl.NumberFormat(lc, opt[a[0]] || {}).format(value)
+  };
+  return new Intl.NumberFormat(lc, opt[a[0]] || {}).format(value);
 }
 
 module.exports = function(mf) {
-  var parts = number.toString()
+  var parts = number
+    .toString()
     .replace('CURRENCY', JSON.stringify(mf.currency || 'USD'))
-    .match(/\(([^)]*)\)[^{]*{([\s\S]*)}/)
-  return new Function(parts[1], parts[2])
-}
+    .match(/\(([^)]*)\)[^{]*{([\s\S]*)}/);
+  return new Function(parts[1], parts[2]);
+};

--- a/packages/messageformat/lib/formatters/number.js
+++ b/packages/messageformat/lib/formatters/number.js
@@ -1,3 +1,5 @@
+/* global CURRENCY, Intl */
+
 /** Represent a number as an integer, percent or currency value
  *
  *  Available in MessageFormat strings as `{VAR, number, integer|percent|currency}`.

--- a/packages/messageformat/lib/formatters/time.js
+++ b/packages/messageformat/lib/formatters/time.js
@@ -21,13 +21,19 @@
  * cf({ T: '1969-07-20 20:17:40 UTC' })
  * // 'The Eagle landed at 10:17:40 PM GMT+2 on Sunday, July 20, 1969'
  */
-function time(v,lc,p) {
-  var o = {second:'numeric', minute:'numeric', hour:'numeric'};
+function time(v, lc, p) {
+  var o = { second: 'numeric', minute: 'numeric', hour: 'numeric' };
   switch (p) {
-    case 'full': case 'long': o.timeZoneName = 'short'; break;
-    case 'short': delete o.second;
+    case 'full':
+    case 'long':
+      o.timeZoneName = 'short';
+      break;
+    case 'short':
+      delete o.second;
   }
-  return (new Date(v)).toLocaleTimeString(lc, o)
+  return new Date(v).toLocaleTimeString(lc, o);
 }
 
-module.exports = function () { return time; }
+module.exports = function() {
+  return time;
+};

--- a/packages/messageformat/lib/messageformat.js
+++ b/packages/messageformat/lib/messageformat.js
@@ -3,7 +3,6 @@ var formatters = require('./formatters');
 var Plurals = require('./plurals');
 var Runtime = require('./runtime');
 
-
 /**
  * Create a new MessageFormat compiler
  *
@@ -42,13 +41,16 @@ function MessageFormat(locale) {
     }, this);
     this.defaultLocale = locale[0];
   } else {
-    for (var lc in locale) if (locale.hasOwnProperty(lc)) {
-      if (typeof locale[lc] !== 'function') {
-        throw new Error('Expected function value for locale ' + JSON.stringify(lc));
+    for (var lc in locale)
+      if (locale.hasOwnProperty(lc)) {
+        if (typeof locale[lc] !== 'function') {
+          throw new Error(
+            'Expected function value for locale ' + JSON.stringify(lc)
+          );
+        }
+        this.pluralFuncs[lc] = locale[lc];
+        if (!this.defaultLocale) this.defaultLocale = lc;
       }
-      this.pluralFuncs[lc] = locale[lc];
-      if (!this.defaultLocale) this.defaultLocale = lc;
-    }
     if (this.defaultLocale) {
       this.hasCustomPluralFuncs = true;
     } else {
@@ -58,7 +60,6 @@ function MessageFormat(locale) {
   this.fmt = {};
   this.runtime = new Runtime(this);
 }
-
 
 /**
  * The default locale
@@ -70,7 +71,6 @@ function MessageFormat(locale) {
  * @default 'en'
  */
 MessageFormat.defaultLocale = 'en';
-
 
 /** Escape special characaters
  *
@@ -85,8 +85,7 @@ MessageFormat.defaultLocale = 'en';
 MessageFormat.escape = function(str, octothorpe) {
   var esc = octothorpe ? '[#{}]' : '[{}]';
   return String(str).replace(new RegExp(esc, 'g'), "'$&'");
-}
-
+};
 
 MessageFormat.formatters = formatters;
 
@@ -126,12 +125,12 @@ MessageFormat.formatters = formatters;
  * messages.answer({ obj: {q: 3, a: 42} })  // 'Answer: 42'
  */
 MessageFormat.prototype.addFormatters = function(fmt) {
-  for (var name in fmt) if (fmt.hasOwnProperty(name)) {
-    this.fmt[name] = fmt[name];
-  }
+  for (var name in fmt)
+    if (fmt.hasOwnProperty(name)) {
+      this.fmt[name] = fmt[name];
+    }
   return this;
 };
-
 
 /** Disable the validation of plural & selectordinal keys
  *
@@ -158,13 +157,13 @@ MessageFormat.prototype.addFormatters = function(fmt) {
  */
 MessageFormat.prototype.disablePluralKeyChecks = function() {
   this.noPluralKeyChecks = true;
-  for (var lc in this.pluralFuncs) if (this.pluralFuncs.hasOwnProperty(lc)) {
-    this.pluralFuncs[lc].cardinal = [];
-    this.pluralFuncs[lc].ordinal = [];
-  }
+  for (var lc in this.pluralFuncs)
+    if (this.pluralFuncs.hasOwnProperty(lc)) {
+      this.pluralFuncs[lc].cardinal = [];
+      this.pluralFuncs[lc].ordinal = [];
+    }
   return this;
 };
-
 
 /** Enable or disable the addition of Unicode control characters to all input
  *  to preserve the integrity of the output when mixing LTR and RTL text.
@@ -187,10 +186,9 @@ MessageFormat.prototype.disablePluralKeyChecks = function() {
  *   // 'first >> SECOND >> THIRD'
  */
 MessageFormat.prototype.setBiDiSupport = function(enable) {
-    this.bidiSupport = !!enable || (typeof enable == 'undefined');
-    return this;
+  this.bidiSupport = !!enable || typeof enable == 'undefined';
+  return this;
 };
-
 
 /** According to the ICU MessageFormat spec, a `#` character directly inside a
  *  `plural` or `selectordinal` statement should be replaced by the number
@@ -224,11 +222,10 @@ MessageFormat.prototype.setBiDiSupport = function(enable) {
  * messages.pastry({ X: 3, P: 'pie' })  // '# pies'
  */
 MessageFormat.prototype.setStrictNumberSign = function(enable) {
-    this.strictNumberSign = !!enable || (typeof enable == 'undefined');
-    this.runtime.setStrictNumber(this.strictNumberSign);
-    return this;
+  this.strictNumberSign = !!enable || typeof enable == 'undefined';
+  this.runtime.setStrictNumber(this.strictNumberSign);
+  return this;
 };
-
 
 /** Compile messages into storable functions
  *
@@ -310,9 +307,18 @@ MessageFormat.prototype.compile = function(messages, locale) {
   function _stringify(obj, level) {
     if (!level) level = 0;
     if (typeof obj != 'object') return obj;
-    var o = [], indent = '';
+    var o = [],
+      indent = '';
     for (var i = 0; i < level; ++i) indent += '  ';
-    for (var k in obj) o.push('\n' + indent + '  ' + Compiler.propname(k) + ': ' + _stringify(obj[k], level + 1));
+    for (var k in obj)
+      o.push(
+        '\n' +
+          indent +
+          '  ' +
+          Compiler.propname(k) +
+          ': ' +
+          _stringify(obj[k], level + 1)
+      );
     return '{' + o.join(',') + '\n' + indent + '}';
   }
 
@@ -320,7 +326,8 @@ MessageFormat.prototype.compile = function(messages, locale) {
   if (Object.keys(this.pluralFuncs).length == 0) {
     if (locale) {
       var fn = Plurals.get(locale, this.noPluralKeyChecks);
-      if (!fn) throw new Error('Locale ' + JSON.stringify(locale) + ' not found!');
+      if (!fn)
+        throw new Error('Locale ' + JSON.stringify(locale) + ' not found!');
       pf[locale] = fn;
     } else {
       locale = this.defaultLocale;
@@ -328,7 +335,14 @@ MessageFormat.prototype.compile = function(messages, locale) {
     }
   } else if (locale) {
     var fn = this.pluralFuncs[locale];
-    if (!fn) throw new Error('Locale ' + JSON.stringify(locale) + ' not found in ' + JSON.stringify(this.pluralFuncs) + '!');
+    if (!fn)
+      throw new Error(
+        'Locale ' +
+          JSON.stringify(locale) +
+          ' not found in ' +
+          JSON.stringify(this.pluralFuncs) +
+          '!'
+      );
     pf[locale] = fn;
   } else {
     locale = this.defaultLocale;
@@ -340,8 +354,10 @@ MessageFormat.prototype.compile = function(messages, locale) {
 
   if (typeof messages != 'object') {
     var fn = new Function(
-        'number, plural, select, fmt', Compiler.funcname(locale),
-        'return ' + obj);
+      'number, plural, select, fmt',
+      Compiler.funcname(locale),
+      'return ' + obj
+    );
     var rt = this.runtime;
     return fn(rt.number, rt.plural, rt.select, this.fmt, pf[locale]);
   }
@@ -349,7 +365,8 @@ MessageFormat.prototype.compile = function(messages, locale) {
   var rtStr = this.runtime.toString(pf, compiler) + '\n';
   var objStr = _stringify(obj);
   var result = new Function(rtStr + 'return ' + objStr)();
-  if (result.hasOwnProperty('toString')) throw new Error('The top-level message key `toString` is reserved');
+  if (result.hasOwnProperty('toString'))
+    throw new Error('The top-level message key `toString` is reserved');
 
   result.toString = function(global) {
     if (!global || global === 'export default') {
@@ -357,16 +374,19 @@ MessageFormat.prototype.compile = function(messages, locale) {
     } else if (global.indexOf('.') > -1) {
       return rtStr + global + ' = ' + objStr;
     } else {
-      return rtStr + [
-        '(function (root, G) {',
-        '  if (typeof define === "function" && define.amd) { define(G); }',
-        '  else if (typeof exports === "object") { module.exports = G; }',
-        '  else { ' + Compiler.propname(global, 'root') + ' = G; }',
-        '})(this, ' + objStr + ');'
-      ].join('\n');
+      return (
+        rtStr +
+        [
+          '(function (root, G) {',
+          '  if (typeof define === "function" && define.amd) { define(G); }',
+          '  else if (typeof exports === "object") { module.exports = G; }',
+          '  else { ' + Compiler.propname(global, 'root') + ' = G; }',
+          '})(this, ' + objStr + ');'
+        ].join('\n')
+      );
     }
-  }
+  };
   return result;
-}
+};
 
 module.exports = MessageFormat;

--- a/packages/messageformat/lib/messageformat.js
+++ b/packages/messageformat/lib/messageformat.js
@@ -323,19 +323,19 @@ MessageFormat.prototype.compile = function(messages, locale) {
   }
 
   var pf = {};
-  if (Object.keys(this.pluralFuncs).length == 0) {
+  if (Object.keys(this.pluralFuncs).length === 0) {
     if (locale) {
-      var fn = Plurals.get(locale, this.noPluralKeyChecks);
-      if (!fn)
+      var pfn0 = Plurals.get(locale, this.noPluralKeyChecks);
+      if (!pfn0)
         throw new Error('Locale ' + JSON.stringify(locale) + ' not found!');
-      pf[locale] = fn;
+      pf[locale] = pfn0;
     } else {
       locale = this.defaultLocale;
       pf = Plurals.getAll(this.noPluralKeyChecks);
     }
   } else if (locale) {
-    var fn = this.pluralFuncs[locale];
-    if (!fn)
+    var pfn1 = this.pluralFuncs[locale];
+    if (!pfn1)
       throw new Error(
         'Locale ' +
           JSON.stringify(locale) +
@@ -343,7 +343,7 @@ MessageFormat.prototype.compile = function(messages, locale) {
           JSON.stringify(this.pluralFuncs) +
           '!'
       );
-    pf[locale] = fn;
+    pf[locale] = pfn1;
   } else {
     locale = this.defaultLocale;
     pf = this.pluralFuncs;

--- a/packages/messageformat/lib/plurals.js
+++ b/packages/messageformat/lib/plurals.js
@@ -10,8 +10,12 @@ var plurals = require('make-plural/umd/plurals');
  */
 
 function wrapPluralFunc(lc, pf, noPluralKeyChecks) {
-  var fn = function() { return pf.apply(this, arguments); };
-  fn.toString = function() { return pf.toString(); };
+  var fn = function() {
+    return pf.apply(this, arguments);
+  };
+  fn.toString = function() {
+    return pf.toString();
+  };
   if (noPluralKeyChecks) {
     fn.cardinal = [];
     fn.ordinal = [];
@@ -26,14 +30,16 @@ function wrapPluralFunc(lc, pf, noPluralKeyChecks) {
 function get(locale, noPluralKeyChecks) {
   for (var l = locale; l; l = l.replace(/[-_]?[^-_]*$/, '')) {
     var pf = plurals[l];
-    if (pf) return wrapPluralFunc(l, pf, noPluralKeyChecks)
+    if (pf) return wrapPluralFunc(l, pf, noPluralKeyChecks);
   }
-  throw new Error('Localisation function not found for locale ' + JSON.stringify(locale));
+  throw new Error(
+    'Localisation function not found for locale ' + JSON.stringify(locale)
+  );
 }
 
 function getAll(noPluralKeyChecks) {
   return Object.keys(plurals).reduce(function(locales, lc) {
-    locales[lc] = wrapPluralFunc(lc, plurals[lc], noPluralKeyChecks)
+    locales[lc] = wrapPluralFunc(lc, plurals[lc], noPluralKeyChecks);
     return locales;
   }, {});
 }
@@ -41,4 +47,4 @@ function getAll(noPluralKeyChecks) {
 module.exports = {
   get: get,
   getAll: getAll
-}
+};

--- a/packages/messageformat/lib/runtime.js
+++ b/packages/messageformat/lib/runtime.js
@@ -1,6 +1,5 @@
 var Compiler = require('./compiler');
 
-
 /** A set of utility functions that are called by the compiled Javascript
  *  functions, these are included locally in the output of {@link
  *  MessageFormat#compile compile()}.
@@ -16,7 +15,6 @@ function Runtime(mf) {
 
 module.exports = Runtime;
 
-
 /** Utility function for `#` in plural rules
  *
  *  Will throw an Error if `value` has a non-numeric value and `offset` is
@@ -30,18 +28,31 @@ module.exports = Runtime;
  */
 function defaultNumber(value, name, offset) {
   if (!offset) return value;
-  if (isNaN(value)) throw new Error('Can\'t apply offset:' + offset + ' to argument `' + name +
-                                    '` with non-numerical value ' + JSON.stringify(value) + '.');
+  if (isNaN(value))
+    throw new Error(
+      "Can't apply offset:" +
+        offset +
+        ' to argument `' +
+        name +
+        '` with non-numerical value ' +
+        JSON.stringify(value) +
+        '.'
+    );
   return value - offset;
 }
 
-
 /** @private */
 function strictNumber(value, name, offset) {
-  if (isNaN(value)) throw new Error('Argument `' + name + '` has non-numerical value ' + JSON.stringify(value) + '.');
+  if (isNaN(value))
+    throw new Error(
+      'Argument `' +
+        name +
+        '` has non-numerical value ' +
+        JSON.stringify(value) +
+        '.'
+    );
   return value - (offset || 0);
 }
-
 
 /** Set how strictly the {@link number} method parses its input.
  *
@@ -57,8 +68,7 @@ function strictNumber(value, name, offset) {
  */
 Runtime.prototype.setStrictNumber = function(enable) {
   this.number = enable ? strictNumber : defaultNumber;
-}
-
+};
 
 /** Utility function for `{N, plural|selectordinal, ...}`
  *
@@ -75,8 +85,7 @@ Runtime.prototype.plural = function(value, offset, lcfunc, data, isOrdinal) {
   var key = lcfunc(value, isOrdinal);
   if (key in data) return data[key];
   return data.other;
-}
-
+};
 
 /** Utility function for `{N, select, ...}`
  *
@@ -87,8 +96,7 @@ Runtime.prototype.plural = function(value, offset, lcfunc, data, isOrdinal) {
 Runtime.prototype.select = function(value, data) {
   if ({}.hasOwnProperty.call(data, value)) return data[value];
   return data.other;
-}
-
+};
 
 /** @private */
 Runtime.prototype.toString = function(pluralFuncs, compiler) {
@@ -96,24 +104,36 @@ Runtime.prototype.toString = function(pluralFuncs, compiler) {
     if (typeof o != 'object') {
       var funcStr = o.toString().replace(/^(function )\w*/, '$1');
       var indent = /([ \t]*)\S.*$/.exec(funcStr);
-      return indent ? funcStr.replace(new RegExp('^' + indent[1], 'mg'), '') : funcStr;
+      return indent
+        ? funcStr.replace(new RegExp('^' + indent[1], 'mg'), '')
+        : funcStr;
     }
     var s = [];
     for (var i in o) {
-      if (level == 0) s.push('var ' + i + ' = ' + _stringify(o[i], level + 1) + ';\n');
+      if (level == 0)
+        s.push('var ' + i + ' = ' + _stringify(o[i], level + 1) + ';\n');
       else s.push(Compiler.propname(i) + ': ' + _stringify(o[i], level + 1));
     }
     if (level == 0) return s.join('');
     if (s.length == 0) return '{}';
-    var indent = '  '; while (--level) indent += '  ';
+    var indent = '  ';
+    while (--level) indent += '  ';
     return '{\n' + s.join(',\n').replace(/^/gm, indent) + '\n}';
   }
 
   var obj = {};
-  Object.keys(compiler.locales).forEach(function(lc) { obj[Compiler.funcname(lc)] = pluralFuncs[lc]; });
-  Object.keys(compiler.runtime).forEach(function(fn) { obj[fn] = this[fn]; }, this);
+  Object.keys(compiler.locales).forEach(function(lc) {
+    obj[Compiler.funcname(lc)] = pluralFuncs[lc];
+  });
+  Object.keys(compiler.runtime).forEach(function(fn) {
+    obj[fn] = this[fn];
+  }, this);
   var fmtKeys = Object.keys(compiler.formatters);
   var fmt = this.mf.fmt;
-  if (fmtKeys.length) obj.fmt = fmtKeys.reduce(function(o, key) { o[key] = fmt[key]; return o; }, {});
+  if (fmtKeys.length)
+    obj.fmt = fmtKeys.reduce(function(o, key) {
+      o[key] = fmt[key];
+      return o;
+    }, {});
   return _stringify(obj, 0);
-}
+};

--- a/packages/messageformat/lib/runtime.js
+++ b/packages/messageformat/lib/runtime.js
@@ -103,19 +103,19 @@ Runtime.prototype.toString = function(pluralFuncs, compiler) {
   function _stringify(o, level) {
     if (typeof o != 'object') {
       var funcStr = o.toString().replace(/^(function )\w*/, '$1');
-      var indent = /([ \t]*)\S.*$/.exec(funcStr);
-      return indent
-        ? funcStr.replace(new RegExp('^' + indent[1], 'mg'), '')
+      var funcIndent = /([ \t]*)\S.*$/.exec(funcStr);
+      return funcIndent
+        ? funcStr.replace(new RegExp('^' + funcIndent[1], 'mg'), '')
         : funcStr;
     }
     var s = [];
     for (var i in o) {
-      if (level == 0)
+      if (level === 0)
         s.push('var ' + i + ' = ' + _stringify(o[i], level + 1) + ';\n');
       else s.push(Compiler.propname(i) + ': ' + _stringify(o[i], level + 1));
     }
-    if (level == 0) return s.join('');
-    if (s.length == 0) return '{}';
+    if (level === 0) return s.join('');
+    if (s.length === 0) return '{}';
     var indent = '  ';
     while (--level) indent += '  ';
     return '{\n' + s.join(',\n').replace(/^/gm, indent) + '\n}';

--- a/packages/messageformat/messages.js
+++ b/packages/messageformat/messages.js
@@ -69,7 +69,9 @@ function Messages(locales, defaultLocale) {
    * @member {string[]} availableLocales
    */
   Object.defineProperty(this, 'availableLocales', {
-    get: function() { return Object.keys(this._data) }
+    get: function() {
+      return Object.keys(this._data);
+    }
   });
 
   /**
@@ -83,8 +85,12 @@ function Messages(locales, defaultLocale) {
    * @member {string|null} locale
    */
   Object.defineProperty(this, 'locale', {
-    get: function() { return this._locale },
-    set: function(lc) { this._locale = this.resolveLocale(lc); }
+    get: function() {
+      return this._locale;
+    },
+    set: function(lc) {
+      this._locale = this.resolveLocale(lc);
+    }
   });
   this.locale = defaultLocale;
 
@@ -99,8 +105,12 @@ function Messages(locales, defaultLocale) {
    * @member {string|null} defaultLocale
    */
   Object.defineProperty(this, 'defaultLocale', {
-    get: function() { return this._defaultLocale },
-    set: function(lc) { this._defaultLocale = this.resolveLocale(lc); }
+    get: function() {
+      return this._defaultLocale;
+    },
+    set: function(lc) {
+      this._defaultLocale = this.resolveLocale(lc);
+    }
   });
   this._defaultLocale = this._locale;
 }
@@ -129,22 +139,22 @@ Messages.prototype.addMessages = function(data, lc, keypath) {
   if (typeof data !== 'function') {
     data = Object.keys(data).reduce(function(map, key) {
       if (key !== 'toString') map[key] = data[key];
-      return map
+      return map;
     }, {});
   }
   if (Array.isArray(keypath) && keypath.length > 0) {
-    var parent = this._data[lc]
+    var parent = this._data[lc];
     for (var i = 0; i < keypath.length - 1; ++i) {
       var key = keypath[i];
-      if (!parent[key]) parent[key] = {}
-      parent = parent[key]
+      if (!parent[key]) parent[key] = {};
+      parent = parent[key];
     }
-    parent[keypath[keypath.length - 1]] = data
+    parent[keypath[keypath.length - 1]] = data;
   } else {
-    this._data[lc] = data
+    this._data[lc] = data;
   }
   return this;
-}
+};
 
 /**
  * Resolve `lc` to the key of an available locale or `null`, allowing for
@@ -158,7 +168,7 @@ Messages.prototype.resolveLocale = function(lc) {
   if (this._data[lc]) return lc;
   if (lc) {
     var l = String(lc);
-    while (l = l.replace(/[-_]?[^-_]*$/, '')) {
+    while ((l = l.replace(/[-_]?[^-_]*$/, ''))) {
       if (this._data[l]) return l;
     }
     var ll = this.availableLocales;
@@ -168,7 +178,7 @@ Messages.prototype.resolveLocale = function(lc) {
     }
   }
   return null;
-}
+};
 
 /**
  * Get the list of fallback locales
@@ -177,10 +187,13 @@ Messages.prototype.resolveLocale = function(lc) {
  */
 Messages.prototype.getFallback = function(lc) {
   if (!lc) lc = this.locale;
-  return this._fallback[lc] || (
-    lc === this.defaultLocale || !this.defaultLocale ? [] : [this.defaultLocale]
+  return (
+    this._fallback[lc] ||
+    (lc === this.defaultLocale || !this.defaultLocale
+      ? []
+      : [this.defaultLocale])
   );
-}
+};
 
 /**
  * Set the fallback locale or locales for `lc`
@@ -195,7 +208,7 @@ Messages.prototype.getFallback = function(lc) {
 Messages.prototype.setFallback = function(lc, fallback) {
   this._fallback[lc] = Array.isArray(fallback) ? fallback : null;
   return this;
-}
+};
 
 /**
  * Check if `key` is a message function for the locale
@@ -213,7 +226,7 @@ Messages.prototype.hasMessage = function(key, lc, fallback) {
   if (!lc) lc = this.locale;
   var fb = fallback ? this.getFallback(lc) : null;
   return _has(this._data, lc, key, fb, 'function');
-}
+};
 
 /**
  * Check if `key` is a message object for the locale
@@ -231,7 +244,7 @@ Messages.prototype.hasObject = function(key, lc, fallback) {
   if (!lc) lc = this.locale;
   var fb = fallback ? this.getFallback(lc) : null;
   return _has(this._data, lc, key, fb, 'object');
-}
+};
 
 /**
  * Get the message or object corresponding to `key`
@@ -258,7 +271,7 @@ Messages.prototype.get = function(key, props, lc) {
     if (msg) return typeof msg == 'function' ? msg(props) : msg;
   }
   return key;
-}
+};
 
 /** @private */
 function _get(obj, key) {

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,4 +1,4 @@
-# messageformat-parser  <a href="http://travis-ci.org/messageformat/parser"><img align="right" alt="Build Status" src="https://secure.travis-ci.org/messageformat/parser.png"></a>
+# messageformat-parser <a href="http://travis-ci.org/messageformat/parser"><img align="right" alt="Build Status" src="https://secure.travis-ci.org/messageformat/parser.png"></a>
 
 A [PEG.js] parser for [ICU MessageFormat] strings – part of [messageformat].
 Outputs an AST defined by [parser.pegjs].
@@ -36,20 +36,18 @@ precedes a curly brace `{}`, or a pound symbol `#` if inside a plural format. A
 literal apostrophe `'` is represented by either a single `'` or a doubled `''`
 apostrophe character.
 
-[ICU MessageFormat]: https://messageformat.github.io/guide/
+[icu messageformat]: https://messageformat.github.io/guide/
 [messageformat]: https://messageformat.github.io/
 [parser.pegjs]: ./parser.pegjs
-[PEG.js]: http://pegjs.org/
-[Unicode CLDR]: http://cldr.unicode.org/index/cldr-spec/plural-rules
+[peg.js]: http://pegjs.org/
+[unicode cldr]: http://cldr.unicode.org/index/cldr-spec/plural-rules
 [apostrophe mode]: http://www.icu-project.org/apiref/icu4c/messagepattern_8h.html#af6e0757e0eb81c980b01ee5d68a9978b
-
 
 ## Installation
 
 ```sh
 npm install messageformat-parser
 ```
-
 
 ## Usage
 
@@ -109,7 +107,6 @@ npm install messageformat-parser
 
 For more example usage, please take a look at our [test suite](./test.js).
 
-
 ## Structure
 
 The output of `parse()` is a `Token` array:
@@ -161,8 +158,8 @@ type Octothorpe = {
 type Identifier = string  // not containing whitespace or control characters
 ```
 
-
 ## License & Contributor License Agreement
-Released under the MIT license. See the [messageformat README][CLA] for details.
 
-[CLA]: https://github.com/messageformat/messageformat.js#contributor-license-agreement
+Released under the MIT license. See the [messageformat README][cla] for details.
+
+[cla]: https://github.com/messageformat/messageformat.js#contributor-license-agreement

--- a/packages/parser/codemod-fix-backslash-escapes.js
+++ b/packages/parser/codemod-fix-backslash-escapes.js
@@ -30,9 +30,10 @@ const fixEscapes = node => {
     /('*)\\([#{}\\]|u[0-9a-f]{4})('*)/g,
     (_, start, char, end) => {
       switch (char[0]) {
-        case 'u':
+        case 'u': {
           const code = parseInt(char.slice(1), 16);
           return start + String.fromCharCode(code) + end;
+        }
         case '\\':
           return `${start}\\${end}`;
         default:

--- a/packages/parser/codemod-fix-backslash-escapes.js
+++ b/packages/parser/codemod-fix-backslash-escapes.js
@@ -21,37 +21,38 @@
  * will double your doubled quotes each time.
  */
 
-let doubleSingleQuotes = false
+let doubleSingleQuotes = false;
 
-const fixEscapes = (node) => {
-  if (node.type !== 'Literal' || typeof node.value !== 'string') return
-  if (doubleSingleQuotes) node.value = node.value.replace(/''+/g, '$&$&')
-  node.value = node.value.replace(/('*)\\([#{}\\]|u[0-9a-f]{4})('*)/g, (_, start, char, end) => {
-    switch (char[0]) {
-      case 'u':
-        const code = parseInt(char.slice(1), 16)
-        return start + String.fromCharCode(code) + end
-      case '\\':
-        return `${start}\\${end}`
-      default:
-        // Assume multiple ' are already escaped
-        if (start === "'") start = "''"
-        if (end === "'") end = "''"
-        return `'${start}${char}${end}'`
+const fixEscapes = node => {
+  if (node.type !== 'Literal' || typeof node.value !== 'string') return;
+  if (doubleSingleQuotes) node.value = node.value.replace(/''+/g, '$&$&');
+  node.value = node.value.replace(
+    /('*)\\([#{}\\]|u[0-9a-f]{4})('*)/g,
+    (_, start, char, end) => {
+      switch (char[0]) {
+        case 'u':
+          const code = parseInt(char.slice(1), 16);
+          return start + String.fromCharCode(code) + end;
+        case '\\':
+          return `${start}\\${end}`;
+        default:
+          // Assume multiple ' are already escaped
+          if (start === "'") start = "''";
+          if (end === "'") end = "''";
+          return `'${start}${char}${end}'`;
+      }
     }
-  })
-}
+  );
+};
 
 module.exports = ({ source }, { jscodeshift: j }, options) => {
-  if (options.doubleSingleQuotes) doubleSingleQuotes = true
-  const ast = j(source)
-  ast
-    .find(j.Property)
-    .forEach(({ value: { value } }) => fixEscapes(value))
+  if (options.doubleSingleQuotes) doubleSingleQuotes = true;
+  const ast = j(source);
+  ast.find(j.Property).forEach(({ value: { value } }) => fixEscapes(value));
   ast
     .find(j.ArrayExpression)
-    .forEach(({ value: { elements }}) => elements.forEach(fixEscapes))
-  return ast.toSource()
-}
+    .forEach(({ value: { elements } }) => elements.forEach(fixEscapes));
+  return ast.toSource();
+};
 
-module.exports.parser = require('json-estree-ast')
+module.exports.parser = require('json-estree-ast');

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -21,6 +21,25 @@
     "parser.js",
     "codemod-fix-backslash-escapes.js"
   ],
+  "eslintConfig": {
+    "env": {
+      "commonjs": true,
+      "es6": true
+    },
+    "overrides": [
+      {
+        "files": [
+          "test.js"
+        ],
+        "env": {
+          "mocha": true
+        },
+        "rules": {
+          "no-unused-vars": 0
+        }
+      }
+    ]
+  },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "mocha": "^5.2.0",

--- a/packages/parser/test.js
+++ b/packages/parser/test.js
@@ -4,45 +4,46 @@ var peg = require('pegjs');
 
 var parse = null;
 
-describe("Parser generation", function() {
-
-  it("should generate a valid parser from pegjs source", function() {
+describe('Parser generation', function() {
+  it('should generate a valid parser from pegjs source', function() {
     var src = fs.readFileSync('./parser.pegjs', 'utf8');
     expect(src).to.not.be.empty();
     var parser = peg.generate(src);
     expect(parser.parse).to.be.a('function');
     parse = parser.parse;
   });
-
 });
-describe("Replacement", function() {
-
-  it("should accept string only input", function() {
+describe('Replacement', function() {
+  it('should accept string only input', function() {
     expect(parse('This is a string')[0]).to.be('This is a string');
     expect(parse('☺☺☺☺')[0]).to.be('☺☺☺☺');
     expect(parse('This is \n a string')[0]).to.be('This is \n a string');
     expect(parse('中国话不用彁字。')[0]).to.be('中国话不用彁字。');
     expect(parse(' \t leading whitspace')[0]).to.be(' \t leading whitspace');
-    expect(parse('trailing whitespace   \n  ')[0]).to.be('trailing whitespace   \n  ');
+    expect(parse('trailing whitespace   \n  ')[0]).to.be(
+      'trailing whitespace   \n  '
+    );
   });
 
-  it("should allow you to escape { and } characters", function() {
+  it('should allow you to escape { and } characters', function() {
     expect(parse("'{'test")[0]).to.eql('{test');
     expect(parse("test'}'")[0]).to.eql('test}');
     expect(parse("'{test}'")[0]).to.eql('{test}');
   });
 
-  it("should gracefully handle quotes (since it ends up in a JS String)", function() {
+  it('should gracefully handle quotes (since it ends up in a JS String)', function() {
     expect(parse('This is a dbl quote: "')[0]).to.eql('This is a dbl quote: "');
-    expect(parse("This is a single quote: '")[0]).to.eql("This is a single quote: '");
+    expect(parse("This is a single quote: '")[0]).to.eql(
+      "This is a single quote: '"
+    );
   });
 
-  it("should accept only a variable", function() {
+  it('should accept only a variable', function() {
     expect(parse('{test}')).to.be.an('object');
     expect(parse('{0}')).to.be.an('object');
   });
 
-  it("should not care about white space in a variable", function() {
+  it('should not care about white space in a variable', function() {
     var targetStr = JSON.stringify(parse('{test}'));
     expect(JSON.stringify(parse('{test }'))).to.eql(targetStr);
     expect(JSON.stringify(parse('{ test}'))).to.eql(targetStr);
@@ -51,7 +52,7 @@ describe("Replacement", function() {
     expect(JSON.stringify(parse('{test}'))).to.eql(targetStr);
   });
 
-  it("should maintain exact strings - not affected by variables", function() {
+  it('should maintain exact strings - not affected by variables', function() {
     expect(parse('x{test}')[0]).to.be('x');
     expect(parse('\n{test}')[0]).to.be('\n');
     expect(parse(' {test}')[0]).to.be(' ');
@@ -61,28 +62,34 @@ describe("Replacement", function() {
     expect(parse('x\n{test}\n')[2]).to.be('\n');
   });
 
-  it("should handle extended character literals", function() {
+  it('should handle extended character literals', function() {
     expect(parse('☺{test}')[0]).to.be('☺');
     expect(parse('中{test}中国话不用彁字。')[2]).to.be('中国话不用彁字。');
   });
 
   it("shouldn't matter if it has html or something in it", function() {
-    expect(parse('<div class="test">content: {TEST}</div>')[0]).to.be('<div class="test">content: ');
-    expect(parse('<div class="test">content: {TEST}</div>')[1].arg).to.be('TEST');
+    expect(parse('<div class="test">content: {TEST}</div>')[0]).to.be(
+      '<div class="test">content: '
+    );
+    expect(parse('<div class="test">content: {TEST}</div>')[1].arg).to.be(
+      'TEST'
+    );
     expect(parse('<div class="test">content: {TEST}</div>')[2]).to.be('</div>');
   });
 
-  it("should allow you to use extension keywords for plural formats everywhere except where they go", function() {
+  it('should allow you to use extension keywords for plural formats everywhere except where they go', function() {
     expect(parse('select select, ')[0]).to.eql('select select, ');
-    expect(parse('select offset, offset:1 ')[0]).to.eql('select offset, offset:1 ');
+    expect(parse('select offset, offset:1 ')[0]).to.eql(
+      'select offset, offset:1 '
+    );
     expect(parse('one other, =1 ')[0]).to.eql('one other, =1 ');
     expect(parse('one {select} ')[1].arg).to.eql('select');
     expect(parse('one {plural} ')[1].arg).to.eql('plural');
   });
 
-  it("should correctly handle apostrophes", function() {
+  it('should correctly handle apostrophes', function() {
     // This mirrors the default DOUBLE_OPTIONAL behavior of ICU.
-    expect(parse("I see '{many}'")[0]).to.eql("I see {many}");
+    expect(parse("I see '{many}'")[0]).to.eql('I see {many}');
     expect(parse("I said '{''Wow!''}'")[0]).to.eql("I said {'Wow!'}");
     expect(parse("I don't know")[0]).to.eql("I don't know");
     expect(parse("I don''t know")[0]).to.eql("I don't know");
@@ -94,13 +101,14 @@ describe("Replacement", function() {
     expect(parse("A '|' A")[0]).to.eql("A '|' A");
   });
 });
-describe("Simple arguments", function() {
-
-  it("should accept a statement based on a variable", function() {
-    expect(function(){ parse('{VAR}'); }).to.not.throwError();
+describe('Simple arguments', function() {
+  it('should accept a statement based on a variable', function() {
+    expect(function() {
+      parse('{VAR}');
+    }).to.not.throwError();
   });
 
-  it("should be very whitespace agnostic", function(){
+  it('should be very whitespace agnostic', function() {
     var res = JSON.stringify(parse('{VAR}'));
     expect(JSON.stringify(parse('{VAR}'))).to.eql(res);
     expect(JSON.stringify(parse('{    VAR   }'))).to.eql(res);
@@ -108,169 +116,224 @@ describe("Simple arguments", function() {
     expect(JSON.stringify(parse('{ \t  VAR  \n }'))).to.eql(res);
   });
 
-  it("should be correctly parsed", function() {
+  it('should be correctly parsed', function() {
     expect(parse('{VAR}')[0].type).to.eql('argument');
     expect(parse('{VAR}')[0].arg).to.eql('VAR');
   });
-
 });
-describe("Selects", function() {
-
-  it("should accept a select statement based on a variable", function() {
-    expect(function(){ parse('{VAR, select, key{a} other{b}}'); }).to.not.throwError();
+describe('Selects', function() {
+  it('should accept a select statement based on a variable', function() {
+    expect(function() {
+      parse('{VAR, select, key{a} other{b}}');
+    }).to.not.throwError();
   });
 
-  it("should be very whitespace agnostic", function(){
+  it('should be very whitespace agnostic', function() {
     var firstRes = JSON.stringify(parse('{VAR, select, key{a} other{b}}'));
-    expect(JSON.stringify(parse('{VAR,select,key{a}other{b}}'))).to.eql(firstRes);
-    expect(JSON.stringify(parse('{    VAR   ,    select   ,    key      {a}   other    {b}    }'))).to.eql(firstRes);
-    expect(JSON.stringify(parse('{ \n   VAR  \n , \n   select  \n\n , \n \n  key \n    \n {a}  \n other \n   {b} \n  \n }'))).to.eql(firstRes);
-    expect(JSON.stringify(parse('{ \t  VAR  \n , \n\t\r  select  \n\t , \t \n  key \n    \t {a}  \n other \t   {b} \t  \t }'))).to.eql(firstRes);
+    expect(JSON.stringify(parse('{VAR,select,key{a}other{b}}'))).to.eql(
+      firstRes
+    );
+    expect(
+      JSON.stringify(
+        parse('{    VAR   ,    select   ,    key      {a}   other    {b}    }')
+      )
+    ).to.eql(firstRes);
+    expect(
+      JSON.stringify(
+        parse(
+          '{ \n   VAR  \n , \n   select  \n\n , \n \n  key \n    \n {a}  \n other \n   {b} \n  \n }'
+        )
+      )
+    ).to.eql(firstRes);
+    expect(
+      JSON.stringify(
+        parse(
+          '{ \t  VAR  \n , \n\t\r  select  \n\t , \t \n  key \n    \t {a}  \n other \t   {b} \t  \t }'
+        )
+      )
+    ).to.eql(firstRes);
   });
 
-  it("should allow you to use MessageFormat extension keywords other places, including in select keys", function() {
+  it('should allow you to use MessageFormat extension keywords other places, including in select keys', function() {
     // use `select` as a select key
-    expect(parse('x {TEST, select, select{a} other{b} }')
-      [1].cases[0].key
+    expect(
+      parse('x {TEST, select, select{a} other{b} }')[1].cases[0].key
     ).to.eql('select');
     // use `offset` as a key (since it goes here in a `plural` case)
-    expect(parse('x {TEST, select, offset{a} other{b} }')
-      [1].cases[0].key
+    expect(
+      parse('x {TEST, select, offset{a} other{b} }')[1].cases[0].key
     ).to.eql('offset');
     // use the exact variable name as a key name
-    expect(parse('x {TEST, select, TEST{a} other{b} }')
-      [1].cases[0].key
-    ).to.eql('TEST');
+    expect(parse('x {TEST, select, TEST{a} other{b} }')[1].cases[0].key).to.eql(
+      'TEST'
+    );
   });
 
   it("should be case-sensitive (select keyword is lowercase, everything else doesn't matter)", function() {
-    expect(function(){ var a = parse('{TEST, Select, a{a} other{b}}'); }).to.throwError();
-    expect(function(){ var a = parse('{TEST, SELECT, a{a} other{b}}'); }).to.throwError();
-    expect(function(){ var a = parse('{TEST, selecT, a{a} other{b}}'); }).to.throwError();
+    expect(function() {
+      var a = parse('{TEST, Select, a{a} other{b}}');
+    }).to.throwError();
+    expect(function() {
+      var a = parse('{TEST, SELECT, a{a} other{b}}');
+    }).to.throwError();
+    expect(function() {
+      var a = parse('{TEST, selecT, a{a} other{b}}');
+    }).to.throwError();
   });
 
-  it("should not accept keys with `=` prefixes", function() {
-    expect(function(){ var a = parse('{TEST, select, =0{a} other{b}}'); }).to.throwError();
+  it('should not accept keys with `=` prefixes', function() {
+    expect(function() {
+      var a = parse('{TEST, select, =0{a} other{b}}');
+    }).to.throwError();
   });
-
 });
-describe("Plurals", function() {
-
-  it("should accept a variable, no offset, and plural keys", function() {
-    expect(function(){ var a = parse('{NUM, plural, one{1} other{2}}'); }).to.not.throwError();
+describe('Plurals', function() {
+  it('should accept a variable, no offset, and plural keys', function() {
+    expect(function() {
+      var a = parse('{NUM, plural, one{1} other{2}}');
+    }).to.not.throwError();
   });
 
-  it("should accept exact values with `=` prefixes", function() {
-    expect(
-      parse('{NUM, plural, =0{e1} other{2}}')[0].cases[0].key
-    ).to.eql(0);
-    expect(
-      parse('{NUM, plural, =1{e1} other{2}}')[0].cases[0].key
-    ).to.eql(1);
-    expect(
-      parse('{NUM, plural, =2{e1} other{2}}')[0].cases[0].key
-    ).to.eql(2);
-    expect(
-      parse('{NUM, plural, =1{e1} other{2}}')[0].cases[1].key
-    ).to.eql("other");
+  it('should accept exact values with `=` prefixes', function() {
+    expect(parse('{NUM, plural, =0{e1} other{2}}')[0].cases[0].key).to.eql(0);
+    expect(parse('{NUM, plural, =1{e1} other{2}}')[0].cases[0].key).to.eql(1);
+    expect(parse('{NUM, plural, =2{e1} other{2}}')[0].cases[0].key).to.eql(2);
+    expect(parse('{NUM, plural, =1{e1} other{2}}')[0].cases[1].key).to.eql(
+      'other'
+    );
   });
 
-  it("should accept the 6 official keywords", function() {
+  it('should accept the 6 official keywords', function() {
     // 'zero', 'one', 'two', 'few', 'many' and 'other'
     expect(
-      parse('{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[0].key
+      parse(
+        '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[0].key
     ).to.eql('zero');
     expect(
-      parse('{NUM, plural,   zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[0].key
+      parse(
+        '{NUM, plural,   zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[0].key
     ).to.eql('zero');
     expect(
-      parse('{NUM, plural,zero    {0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[0].key
+      parse(
+        '{NUM, plural,zero    {0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[0].key
     ).to.eql('zero');
     expect(
-      parse('{NUM, plural,  \nzero\n   {0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[0].key
+      parse(
+        '{NUM, plural,  \nzero\n   {0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[0].key
     ).to.eql('zero');
     expect(
-      parse('{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[1].key
+      parse(
+        '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[1].key
     ).to.eql('one');
     expect(
-      parse('{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[2].key
+      parse(
+        '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[2].key
     ).to.eql('two');
     expect(
-      parse('{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[3].key
+      parse(
+        '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[3].key
     ).to.eql('few');
     expect(
-      parse('{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[4].key
+      parse(
+        '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[4].key
     ).to.eql('many');
     expect(
-      parse('{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}')[0].cases[5].key
+      parse(
+        '{NUM, plural, zero{0} one{1} two{2} few{5} many{100} other{101}}'
+      )[0].cases[5].key
     ).to.eql('other');
   });
 
-  it("should be gracious with whitespace", function() {
+  it('should be gracious with whitespace', function() {
     var firstRes = JSON.stringify(parse('{NUM, plural, one{1} other{2}}'));
-    expect(JSON.stringify(parse('{ NUM, plural, one{1} other{2} }'))).to.eql(firstRes);
-    expect(JSON.stringify(parse('{NUM,plural,one{1}other{2}}'))).to.eql(firstRes);
-    expect(JSON.stringify(parse('{\nNUM,   \nplural,\n   one\n\n{1}\n other {2}\n\n\n}'))).to.eql(firstRes);
-    expect(JSON.stringify(parse('{\tNUM\t,\t\t\r plural\t\n, \tone\n{1}    other\t\n{2}\n\n\n}'))).to.eql(firstRes);
+    expect(JSON.stringify(parse('{ NUM, plural, one{1} other{2} }'))).to.eql(
+      firstRes
+    );
+    expect(JSON.stringify(parse('{NUM,plural,one{1}other{2}}'))).to.eql(
+      firstRes
+    );
+    expect(
+      JSON.stringify(
+        parse('{\nNUM,   \nplural,\n   one\n\n{1}\n other {2}\n\n\n}')
+      )
+    ).to.eql(firstRes);
+    expect(
+      JSON.stringify(
+        parse('{\tNUM\t,\t\t\r plural\t\n, \tone\n{1}    other\t\n{2}\n\n\n}')
+      )
+    ).to.eql(firstRes);
   });
 
-  it("should take an offset", function() {
+  it('should take an offset', function() {
     expect(parse('{NUM, plural, offset:4 other{a}}')).to.be.ok();
     expect(parse('{NUM, plural, offset : 4 other{a}}')).to.be.ok();
     expect(parse('{NUM, plural, offset\n\t\r : \t\n\r4 other{a}}')).to.be.ok();
     // technically this is parsable since js identifiers don't start with numbers
     expect(parse('{NUM,plural,offset:4other{a}}')).to.be.ok();
 
-    expect(
-      parse('{NUM, plural, offset:4 other{a}}')[0].offset
-    ).to.eql(4);
-    expect(
-      parse('{NUM,plural,offset:4other{a}}')[0].offset
-    ).to.eql(4);
+    expect(parse('{NUM, plural, offset:4 other{a}}')[0].offset).to.eql(4);
+    expect(parse('{NUM,plural,offset:4other{a}}')[0].offset).to.eql(4);
   });
 
-  it("should support quoting", function() {
-    expect(parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0].tokens).to.eql([{
-      type: 'function', arg: 'x', key: 'date',
-      param: {
-        tokens: [ 'y-M-dd ', { type: 'octothorpe' }, ' #' ]
+  it('should support quoting', function() {
+    expect(
+      parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0]
+        .tokens
+    ).to.eql([
+      {
+        type: 'function',
+        arg: 'x',
+        key: 'date',
+        param: {
+          tokens: ['y-M-dd ', { type: 'octothorpe' }, ' #']
+        }
       }
-    }]);
-    expect(parse("{NUM, plural, one{# '' #} two{two}}")[0].cases[0].tokens).to.eql([
-      { type: 'octothorpe' }, " ' ", { type: 'octothorpe' }
     ]);
-    expect(parse("{NUM, plural, one{# '#'} two{two}}")[0].cases[0].tokens).to.eql([
-      { type: 'octothorpe' }, ' #'
-    ]);
-    expect(parse("{NUM, plural, one{one#} two{two}}")[0].cases[0].tokens).to.eql([
-      'one', { type: 'octothorpe' }
-    ]);
-  })
+    expect(
+      parse("{NUM, plural, one{# '' #} two{two}}")[0].cases[0].tokens
+    ).to.eql([{ type: 'octothorpe' }, " ' ", { type: 'octothorpe' }]);
+    expect(
+      parse("{NUM, plural, one{# '#'} two{two}}")[0].cases[0].tokens
+    ).to.eql([{ type: 'octothorpe' }, ' #']);
+    expect(
+      parse('{NUM, plural, one{one#} two{two}}')[0].cases[0].tokens
+    ).to.eql(['one', { type: 'octothorpe' }]);
+  });
 
   describe('options.strict', function() {
     var src = "{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}";
 
     it('should parse # correctly without strict option', function() {
       expect(parse(src)[0].cases[0].tokens[2].cases[0].tokens).to.eql([
-        { type: 'octothorpe' }, ' # one', { type: 'octothorpe' }
+        { type: 'octothorpe' },
+        ' # one',
+        { type: 'octothorpe' }
       ]);
-    })
+    });
 
     it('should parse # correctly with strict option', function() {
-      expect(parse(src, { strict: true })[0].cases[0].tokens[2].cases[0].tokens).to.eql([
-        "# '#' one#"
-      ]);
-    })
-  })
-
+      expect(
+        parse(src, { strict: true })[0].cases[0].tokens[2].cases[0].tokens
+      ).to.eql(["# '#' one#"]);
+    });
+  });
 });
-describe("Ordinals", function() {
-
-  it("should accept a variable and ordinal keys", function() {
-    expect(function(){ var a = parse('{NUM, selectordinal, one{1} other{2}}'); }).to.not.throwError();
+describe('Ordinals', function() {
+  it('should accept a variable and ordinal keys', function() {
+    expect(function() {
+      var a = parse('{NUM, selectordinal, one{1} other{2}}');
+    }).to.not.throwError();
   });
 
-  it("should accept exact values with `=` prefixes", function() {
+  it('should accept exact values with `=` prefixes', function() {
     expect(
       parse('{NUM, selectordinal, =0{e1} other{2}}')[0].cases[0].key
     ).to.eql(0);
@@ -282,49 +345,77 @@ describe("Ordinals", function() {
     ).to.eql(2);
     expect(
       parse('{NUM, selectordinal, =1{e1} other{2}}')[0].cases[1].key
-    ).to.eql("other");
+    ).to.eql('other');
+  });
+});
+describe('Functions', function() {
+  it('should require lower-case type', function() {
+    expect(function() {
+      parse('{var,date}');
+    }).to.not.throwError();
+    expect(function() {
+      parse('{var,Date}');
+    }).to.throwError();
+    expect(function() {
+      parse('{var,daTe}');
+    }).to.throwError();
+    expect(function() {
+      parse('{var,9ate}');
+    }).to.throwError();
   });
 
-});
-describe("Functions", function() {
-  it("should require lower-case type", function() {
-    expect(function(){ parse('{var,date}'); }).to.not.throwError();
-    expect(function(){ parse('{var,Date}'); }).to.throwError();
-    expect(function(){ parse('{var,daTe}'); }).to.throwError();
-    expect(function(){ parse('{var,9ate}'); }).to.throwError();
-  })
-
   it('should be gracious with whitespace around arg and key', function() {
-    var expected = { type: 'function', arg: 'var', key: 'date', param: null }
+    var expected = { type: 'function', arg: 'var', key: 'date', param: null };
     expect(parse('{var,date}')[0]).to.eql(expected);
     expect(parse('{var, date}')[0]).to.eql(expected);
     expect(parse('{ var, date }')[0]).to.eql(expected);
     expect(parse('{\nvar,   \ndate\n}')[0]).to.eql(expected);
-  })
+  });
 
-  it("should accept parameters", function() {
+  it('should accept parameters', function() {
     expect(parse('{var,date,long}')[0]).to.eql({
-      type: 'function', arg: 'var', key: 'date', param: { tokens: ['long'] }
+      type: 'function',
+      arg: 'var',
+      key: 'date',
+      param: { tokens: ['long'] }
     });
-    expect(parse('{var,date,long,short}')[0].param.tokens).to.eql(['long,short']);
-  })
+    expect(parse('{var,date,long,short}')[0].param.tokens).to.eql([
+      'long,short'
+    ]);
+  });
 
-  it("should accept parameters with whitespace", function() {
+  it('should accept parameters with whitespace', function() {
     expect(parse('{var,date,y-M-d HH:mm:ss zzzz}')[0]).to.eql({
-      type: 'function', arg: 'var', key: 'date', param: { tokens: ['y-M-d HH:mm:ss zzzz'] }
+      type: 'function',
+      arg: 'var',
+      key: 'date',
+      param: { tokens: ['y-M-d HH:mm:ss zzzz'] }
     });
-    expect(parse('{var,date,   y-M-d HH:mm:ss zzzz    }')[0].param.tokens).to.eql(['   y-M-d HH:mm:ss zzzz    ']);
-  })
+    expect(
+      parse('{var,date,   y-M-d HH:mm:ss zzzz    }')[0].param.tokens
+    ).to.eql(['   y-M-d HH:mm:ss zzzz    ']);
+  });
 
-  it("should accept parameters with special characters", function() {
+  it('should accept parameters with special characters', function() {
     expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz}")[0]).to.eql({
-      type: 'function', arg: 'var', key: 'date', param: { tokens: [ 'y-M-d {,} \' HH:mm:ss zzzz' ] }
+      type: 'function',
+      arg: 'var',
+      key: 'date',
+      param: { tokens: ["y-M-d {,} ' HH:mm:ss zzzz"] }
     });
-    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz'}'}")[0].param.tokens).to.eql(["y-M-d {,} ' HH:mm:ss zzzz}"]);
-    expect(parse("{var,date,y-M-d # HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d # HH:mm:ss zzzz"]);
-    expect(parse("{var,date,y-M-d '#' HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d '#' HH:mm:ss zzzz"]);
-    expect(parse("{var,date,y-M-d, HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d, HH:mm:ss zzzz"]);
-  })
+    expect(
+      parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz'}'}")[0].param.tokens
+    ).to.eql(["y-M-d {,} ' HH:mm:ss zzzz}"]);
+    expect(parse('{var,date,y-M-d # HH:mm:ss zzzz}')[0].param.tokens).to.eql([
+      'y-M-d # HH:mm:ss zzzz'
+    ]);
+    expect(parse("{var,date,y-M-d '#' HH:mm:ss zzzz}")[0].param.tokens).to.eql([
+      "y-M-d '#' HH:mm:ss zzzz"
+    ]);
+    expect(parse('{var,date,y-M-d, HH:mm:ss zzzz}')[0].param.tokens).to.eql([
+      'y-M-d, HH:mm:ss zzzz'
+    ]);
+  });
 
   it('should accept parameters containing a basic variable', function() {
     expect(parse('{foo, date, {bar}}')[0]).to.eql({
@@ -332,215 +423,505 @@ describe("Functions", function() {
       arg: 'foo',
       key: 'date',
       param: { tokens: [' ', { arg: 'bar', type: 'argument' }] }
-    })
-  })
+    });
+  });
 
   it('should accept parameters containing a select', function() {
     expect(parse('{foo, date, {bar, select, other{baz}}}')[0]).to.eql({
       type: 'function',
       arg: 'foo',
       key: 'date',
-      param: { tokens: [' ', {
-        arg: 'bar',
-        type: 'select',
-        cases: [{ key: 'other', tokens: ['baz'] }]
-      }] }
-    })
-  })
+      param: {
+        tokens: [
+          ' ',
+          {
+            arg: 'bar',
+            type: 'select',
+            cases: [{ key: 'other', tokens: ['baz'] }]
+          }
+        ]
+      }
+    });
+  });
 
   it('should accept parameters containing a plural', function() {
     expect(parse('{foo, date, {bar, plural, other{#}}}')[0]).to.eql({
       type: 'function',
       arg: 'foo',
       key: 'date',
-      param: { tokens: [' ', {
-        arg: 'bar',
-        type: 'plural',
-        offset: 0,
-        cases: [{ key: 'other', tokens: [{ type: 'octothorpe' }] }]
-      }] }
-    })
-  })
+      param: {
+        tokens: [
+          ' ',
+          {
+            arg: 'bar',
+            type: 'plural',
+            offset: 0,
+            cases: [{ key: 'other', tokens: [{ type: 'octothorpe' }] }]
+          }
+        ]
+      }
+    });
+  });
 
   describe('options.strict', function() {
     it('should require known function key with strict option', function() {
-      expect(function() { parse('{foo, bar}') }).to.not.throwError()
-      expect(function() { parse('{foo, bar}', { strict: true }) }).to.throwError()
-      expect(function() { parse('{foo, date}', { strict: true }) }).to.not.throwError()
-    })
+      expect(function() {
+        parse('{foo, bar}');
+      }).to.not.throwError();
+      expect(function() {
+        parse('{foo, bar}', { strict: true });
+      }).to.throwError();
+      expect(function() {
+        parse('{foo, date}', { strict: true });
+      }).to.not.throwError();
+    });
 
     it('parameter parsing should obey strict option', function() {
-      expect(parse("{foo, date, {bar'}', quote'', other{#}}}", { strict: true })[0]).to.eql({
+      expect(
+        parse("{foo, date, {bar'}', quote'', other{#}}}", { strict: true })[0]
+      ).to.eql({
         type: 'function',
         arg: 'foo',
         key: 'date',
         param: { tokens: [" {bar}, quote', other{#}}"] }
-      })
-    })
+      });
+    });
 
     it('should require matched braces in parameter if strict option is set', function() {
       expect(function() {
-        parse("{foo, date, {bar{}}", { strict: true })
+        parse('{foo, date, {bar{}}', { strict: true });
       }).to.throwError();
-    })
-  })
+    });
+  });
 });
 
-describe("Nested/Recursive blocks", function() {
-
-  it("should allow a select statement inside of a select statement", function() {
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, select, other{a}}}}'); }).to.not.throwError();
+describe('Nested/Recursive blocks', function() {
+  it('should allow a select statement inside of a select statement', function() {
+    expect(function() {
+      var a = parse('{NUM1, select, other{{NUM2, select, other{a}}}}');
+    }).to.not.throwError();
     expect(
-      parse('{NUM1, select, other{{NUM2, select, other{a}}}}')
-        [0].cases[0].tokens[0].cases[0].tokens[0]
+      parse('{NUM1, select, other{{NUM2, select, other{a}}}}')[0].cases[0]
+        .tokens[0].cases[0].tokens[0]
     ).to.eql('a');
 
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}'); }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}'
+      );
+    }).to.not.throwError();
     expect(
-      parse('{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}')
-        [0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0]
+      parse(
+        '{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}'
+      )[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0]
     ).to.eql('b');
 
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{{NUM4, select, other{c}}}}}}}}'); }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{{NUM4, select, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
     expect(
-      parse('{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{{NUM4, select, other{c}}}}}}}}')
-        [0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0]
+      parse(
+        '{NUM1, select, other{{NUM2, select, other{{NUM3, select, other{{NUM4, select, other{c}}}}}}}}'
+      )[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0].cases[0]
+        .tokens[0]
     ).to.eql('c');
   });
 
-  it("should allow nested plural statements - with and without offsets", function() {
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{a}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{a}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{a}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{a}}}}'); }).to.not.throwError();
+  it('should allow nested plural statements - with and without offsets', function() {
+    expect(function() {
+      var a = parse('{NUM1, plural, other{{NUM2, plural, other{a}}}}');
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{a}}}}');
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{a}}}}');
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{a}}}}'
+      );
+    }).to.not.throwError();
 
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
 
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
     // ok we get it, it's recursive.
 
     expect(
-      parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}')
-        [0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0]
+      parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      )[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0].cases[0]
+        .tokens[0]
     ).to.eql('c');
   });
 
-  it("should allow nested plural and select statements - with and without offsets", function() {
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, select, other{a}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{a}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, offset:1 other{a}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{a}}}}'); }).to.not.throwError();
+  it('should allow nested plural and select statements - with and without offsets', function() {
+    expect(function() {
+      var a = parse('{NUM1, plural, other{{NUM2, select, other{a}}}}');
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{a}}}}');
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse('{NUM1, select, other{{NUM2, plural, offset:1 other{a}}}}');
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{a}}}}'
+      );
+    }).to.not.throwError();
 
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, select, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, select, other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'); }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, select, other{{NUM3, select, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, select, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, select, other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{b}}}}}}'
+      );
+    }).to.not.throwError();
 
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, select, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, select, other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
-    expect(function(){ var a = parse('{NUM1, select, other{{NUM2, select, other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'); }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, offset:1 other{{NUM4, plural, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, select, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, offset:1 other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, select, other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, plural, other{{NUM2, plural, offset:1 other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
+    expect(function() {
+      var a = parse(
+        '{NUM1, select, other{{NUM2, select, other{{NUM3, plural, offset:1 other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      );
+    }).to.not.throwError();
     // ok we get it, it's recursive.
 
     expect(
-      parse('{NUM1, selectordinal, other{{NUM2, plural, offset:1 other{{NUM3, selectordinal, other{{NUM4, plural, offset:1 other{c}}}}}}}}')
-        [0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0]
+      parse(
+        '{NUM1, selectordinal, other{{NUM2, plural, offset:1 other{{NUM3, selectordinal, other{{NUM4, plural, offset:1 other{c}}}}}}}}'
+      )[0].cases[0].tokens[0].cases[0].tokens[0].cases[0].tokens[0].cases[0]
+        .tokens[0]
     ).to.eql('c');
   });
-
 });
-describe("Errors", function() {
-
-  it("should catch mismatched/invalid bracket situations", function() {
-    expect(function(){ parse('}'); }).to.throwError();
-    expect(function(){ parse('{'); }).to.throwError();
-    expect(function(){ parse('{{X}'); }).to.throwError();
-    expect(function(){ parse('{}'); }).to.throwError();
-    expect(function(){ parse('{}{'); }).to.throwError();
-    expect(function(){ parse('{X}{'); }).to.throwError();
-    expect(function(){ parse('}{}'); }).to.throwError();
-    expect(function(){ parse('}{X}'); }).to.throwError();
-    expect(function(){ parse('{}}'); }).to.throwError();
-    expect(function(){ parse('{X}}'); }).to.throwError();
-    expect(function(){ parse('{{X}}'); }).to.throwError();
-    expect(function(){ parse(); }).to.throwError();
+describe('Errors', function() {
+  it('should catch mismatched/invalid bracket situations', function() {
+    expect(function() {
+      parse('}');
+    }).to.throwError();
+    expect(function() {
+      parse('{');
+    }).to.throwError();
+    expect(function() {
+      parse('{{X}');
+    }).to.throwError();
+    expect(function() {
+      parse('{}');
+    }).to.throwError();
+    expect(function() {
+      parse('{}{');
+    }).to.throwError();
+    expect(function() {
+      parse('{X}{');
+    }).to.throwError();
+    expect(function() {
+      parse('}{}');
+    }).to.throwError();
+    expect(function() {
+      parse('}{X}');
+    }).to.throwError();
+    expect(function() {
+      parse('{}}');
+    }).to.throwError();
+    expect(function() {
+      parse('{X}}');
+    }).to.throwError();
+    expect(function() {
+      parse('{{X}}');
+    }).to.throwError();
+    expect(function() {
+      parse();
+    }).to.throwError();
     // Technically an empty string is valid.
-    expect(function(){ parse(''); }).to.not.throwError();
+    expect(function() {
+      parse('');
+    }).to.not.throwError();
   });
 
-  it("should not allow an offset for SELECTs", function() {
-    expect(function(){ parse('{NUM, select, offset:1 test { 1 } test2 { 2 }}'); }).to.throwError();
+  it('should not allow an offset for SELECTs', function() {
+    expect(function() {
+      parse('{NUM, select, offset:1 test { 1 } test2 { 2 }}');
+    }).to.throwError();
   });
 
-  it("should not allow invalid keys for PLURALs", function() {
-    expect(function(){ parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}'); }).to.throwError();
-    expect(function(){ parse('{NUM, plural, one { 1 } some { error } other { 2 }}', { cardinal: ['one', 'other'] }); }).to.throwError();
+  it('should not allow invalid keys for PLURALs', function() {
+    expect(function() {
+      parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}');
+    }).to.throwError();
+    expect(function() {
+      parse('{NUM, plural, one { 1 } some { error } other { 2 }}', {
+        cardinal: ['one', 'other']
+      });
+    }).to.throwError();
   });
 
-  it("should not allow invalid keys for SELECTORDINALs", function() {
-    expect(function(){ parse('{NUM, selectordinal, one { 1 } invalid { error } other { 2 }}'); }).to.throwError();
-    expect(function(){ parse('{NUM, selectordinal, one { 1 } some { error } other { 2 }}', { ordinal: ['one', 'other'] }); }).to.throwError();
+  it('should not allow invalid keys for SELECTORDINALs', function() {
+    expect(function() {
+      parse('{NUM, selectordinal, one { 1 } invalid { error } other { 2 }}');
+    }).to.throwError();
+    expect(function() {
+      parse('{NUM, selectordinal, one { 1 } some { error } other { 2 }}', {
+        ordinal: ['one', 'other']
+      });
+    }).to.throwError();
   });
 
-  it("should allow an offset for SELECTORDINALs", function() {
-    expect(function(){ parse('{NUM, selectordinal, offset:1 one { 1 } other { 2 }}'); }).to.not.throwError();
+  it('should allow an offset for SELECTORDINALs', function() {
+    expect(function() {
+      parse('{NUM, selectordinal, offset:1 one { 1 } other { 2 }}');
+    }).to.not.throwError();
   });
 
   it("shouldn't allow characters in variables that aren't valid JavaScript identifiers", function() {
-    expect(function(){ parse('{☺}'); }).to.throwError();
-    expect(function(){ parse('{a☺}'); }).to.throwError();
+    expect(function() {
+      parse('{☺}');
+    }).to.throwError();
+    expect(function() {
+      parse('{a☺}');
+    }).to.throwError();
   });
 
-  it("should allow characters in variables that are valid ICU identifiers", function() {
-    expect(function(){ parse('{ű\u3000á}'); }).to.not.throwError();
+  it('should allow characters in variables that are valid ICU identifiers', function() {
+    expect(function() {
+      parse('{ű\u3000á}');
+    }).to.not.throwError();
   });
 
-  it("should allow positional variables", function() {
-    expect(function(){ parse('{0}'); }).to.not.throwError();
+  it('should allow positional variables', function() {
+    expect(function() {
+      parse('{0}');
+    }).to.not.throwError();
   });
 
-  it("should throw errors on negative offsets", function() {
-    expect(function(){ parse('{NUM, plural, offset:-4 other{a}}'); }).to.throwError();
+  it('should throw errors on negative offsets', function() {
+    expect(function() {
+      parse('{NUM, plural, offset:-4 other{a}}');
+    }).to.throwError();
   });
 
-  it("should require closing bracket", function(){
-    const message = '{count, plural, one {car} other {cars}'
-    expect(function(){ parse(message); }).to.throwError();
-  })
+  it('should require closing bracket', function() {
+    const message = '{count, plural, one {car} other {cars}';
+    expect(function() {
+      parse(message);
+    }).to.throwError();
+  });
 });

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -4,8 +4,8 @@ These docs are hosted by [GitHub Pages] at [messageformat.github.io/messageforma
 
 To re-build the docs, run `make docs` in the project root. As the links are slightly prettified (dropping the .html extensions), if you want to view them locally, you may want to run something like `npx http-server` in this directory.
 
-[GitHub Pages]: https://pages.github.com/
+[github pages]: https://pages.github.com/
 [messageformat.github.io/messageformat]: https://messageformat.github.io/messageformat/
-[JSDoc]: http://usejsdoc.org/
+[jsdoc]: http://usejsdoc.org/
 [custom fork]: https://github.com/messageformat/docstrap
-[DocStrap]: https://docstrap.github.io/docstrap/
+[docstrap]: https://docstrap.github.io/docstrap/

--- a/packages/website/jsdoc-conf.json
+++ b/packages/website/jsdoc-conf.json
@@ -6,9 +6,7 @@
       "node_modules/messageformat/messages.js"
     ]
   },
-  "plugins": [
-    "plugins/markdown"
-  ],
+  "plugins": ["plugins/markdown"],
   "opts": {
     "destination": "docs/",
     "package": "node_modules/messageformat/package.json",

--- a/packages/website/pages/about.md
+++ b/packages/website/pages/about.md
@@ -1,16 +1,15 @@
 ## Features
 
-* Handles arbitrary nesting of pluralization and select rules
-* Supports all ~466 languages included in the Unicode CLDR
-* Works on the server and the client
-* Remarkably useful even for single-language use
-* Speed & efficiency: Can pre-compile messages to JavaScript code
-  * Great for speed: message formatting is just string concatenation
-* Compatible with other MessageFormat implementations
-* Extendable with custom formatting functions
-* Very whitespace tolerant
-* Supports Unicode, including RTL and mixed LTR/RTL strings
-
+- Handles arbitrary nesting of pluralization and select rules
+- Supports all ~466 languages included in the Unicode CLDR
+- Works on the server and the client
+- Remarkably useful even for single-language use
+- Speed & efficiency: Can pre-compile messages to JavaScript code
+  - Great for speed: message formatting is just string concatenation
+- Compatible with other MessageFormat implementations
+- Extendable with custom formatting functions
+- Very whitespace tolerant
+- Supports Unicode, including RTL and mixed LTR/RTL strings
 
 ## License
 
@@ -37,7 +36,6 @@ You may use this software under the MIT License:
 > OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 > WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
 ## Contributor License Agreement
 
 We require all contributions to be covered under the JS Foundation's [Contributor License Agreement](https://js.foundation/CLA/). This can be done electronically and essentially ensures that you are making it clear that your contributions are your contributions, you have the legal right to contribute and you are transferring the copyright of your works to the JavaScript Foundation.
@@ -46,18 +44,16 @@ If you are an unfamiliar contributor to the committer assessing your pull reques
 
 If your GitHub user id you are submitting your pull request from differs from the e-mail address which you have signed your CLA under, you should specifically note what you have your CLA filed under (and for CCLA that you are listed under your company's authorised contributors).
 
-
 ## Authors
 
-* Alex Sexton - [@SlexAxton](http://twitter.com/SlexAxton) - [alexsexton.com](http://alexsexton.com/)
-* Eemeli Aro - [@eemeli_aro](http://twitter.com/eemeli_aro) - [github.com/eemeli](https://github.com/eemeli)
-
+- Alex Sexton - [@SlexAxton](http://twitter.com/SlexAxton) - [alexsexton.com](http://alexsexton.com/)
+- Eemeli Aro - [@eemeli_aro](http://twitter.com/eemeli_aro) - [github.com/eemeli](https://github.com/eemeli)
 
 ## Credits
 
 Thanks to:
 
-* [Vincit](https://vincit.fi/en/) - Eemeli's current employer - for letting him do cool stuff like this.
-* [Bazaarvoice](https://github.com/Bazaarvoice) - Alex's previous employer - for letting him do cool stuff like this.
-* Google has an implementation that is similar in Google Closure, the code has been vetted against many of their tests.
-* Norbert Lindenberg for showing Alex how good it can be.
+- [Vincit](https://vincit.fi/en/) - Eemeli's current employer - for letting him do cool stuff like this.
+- [Bazaarvoice](https://github.com/Bazaarvoice) - Alex's previous employer - for letting him do cool stuff like this.
+- Google has an implementation that is similar in Google Closure, the code has been vetted against many of their tests.
+- Norbert Lindenberg for showing Alex how good it can be.

--- a/packages/website/pages/build.md
+++ b/packages/website/pages/build.md
@@ -1,19 +1,20 @@
 Fundamentally, messageformat is a compiler that turns ICU MessageFormat input into JavaScript. While it's certainly possible to use it directly in your client code, that will mean including the full compiler in your client-side code (admittedly, just 15kB when minified & gzipped), and being okay with `new Function` being called for each message string.
 
 The recommended alternative is to use messageformat as a compile-time tool. To that end, we provide three different sorts of solutions:
+
 - **Webpack loaders** for JSON, .properties, gettext PO, and YAML files
 - **[messageformat-cli]** for command-line use, supporting JSON and .properties files
 - Our **JavaScript API**, in particular {@link MessageFormat#compile}
 
 Compiling messages during your build will allow for a significant decrease in filesize and execution time, as all that's required to run on the client are the final compiled functions.
 
-[Webpack]: https://webpack.js.org/
+[webpack]: https://webpack.js.org/
 [messageformat-cli]: https://www.npmjs.com/package/messageformat-cli
-
 
 ## Webpack loaders
 
 Each of the loaders is similar, supporting a specific file type. Their configuration options vary slightly, depending on the common practices for the format; please see their own documentations for details:
+
 - JSON: [messageformat-loader]
 - .properties: [messageformat-properties-loader] – Used by [Java resource bundles]
 - PO files: [messageformat-po-loader] – Used by [gettext]
@@ -21,11 +22,11 @@ Each of the loaders is similar, supporting a specific file type. Their configura
 
 [messageformat-loader]: https://www.npmjs.com/package/messageformat-loader
 [messageformat-properties-loader]: https://www.npmjs.com/package/messageformat-properties-loader
-[Java resource bundles]: https://docs.oracle.com/javase/9/docs/api/java/util/ResourceBundle.html#getBundle-java.lang.String-java.util.Locale-java.lang.ClassLoader-
+[java resource bundles]: https://docs.oracle.com/javase/9/docs/api/java/util/ResourceBundle.html#getBundle-java.lang.String-java.util.Locale-java.lang.ClassLoader-
 [messageformat-po-loader]: https://www.npmjs.com/package/messageformat-po-loader
 [gettext]: https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
 [messageformat-yaml-loader]: https://www.npmjs.com/package/messageformat-yaml-loader
-[Rails i18n]: http://guides.rubyonrails.org/i18n.html
+[rails i18n]: http://guides.rubyonrails.org/i18n.html
 
 Using [messageformat-loader] as an example, these enable a JavaScript API that looks like this:
 
@@ -49,7 +50,6 @@ messages.ordinal({ N: 1 })          // 'The 1st message.'</code></pre>
 </div>
 
 During the build, the loader will compile your messages into their respective functions, and package only those into the webpack output.
-
 
 ## CLI Compiler
 
@@ -85,7 +85,6 @@ See the messageformat-cli README for more options. Configuration may also be
 set in package.json or messageformat.rc.json.
 ```
 
-
 ## Using compiled messageformat output
 
 The output of the loaders and the CLI will be a hierarchical object, made up of the non-identical file and object paths of the input. For example, the messageformat package's `example/i18n.js` sample output includes a function `en.sub.folder.plural.test()`, which was compiled from the `test` key in the source file `example/en/sub/folder/plural.json`. Obviously this is a slightly contribed example, but even in real-world use it's likely that you'll end up with a sufficient number of messages that it makes sense to split them in separate files and/or into some sort of hierarchy.
@@ -120,21 +119,22 @@ It works like this (using [messageformat-loader], configured for `en` and `fi` l
 import msgData from './messages.json'
 const messages = new Messages(msgData, 'en')  // sets default locale
 
-messages.hasMessage('a')                // true
-messages.hasObject('c')                 // true
-messages.get('b', { COUNT: 3 })         // 'This has 3 users.'
-messages.get(['c', 'd'], { P: 0.314 })  // 'We have 31% code coverage.'
+messages.hasMessage('a') // true
+messages.hasObject('c') // true
+messages.get('b', { COUNT: 3 }) // 'This has 3 users.'
+messages.get(['c', 'd'], { P: 0.314 }) // 'We have 31% code coverage.'
 
-messages.get('e')                       // 'e'
+messages.get('e') // 'e'
 messages.setFallback('en', ['foo', 'fi'])
-messages.get('e')                       // 'Minä puhun vain suomea.'
+messages.get('e') // 'Minä puhun vain suomea.'
 
 messages.locale = 'fi'
-messages.hasMessage('a')                // false
-messages.hasMessage('a', 'en')          // true
-messages.hasMessage('a', null, true)    // true
-messages.hasObject('c')                 // false
-messages.get('b', { COUNT: 3 })         // 'Tällä on 3 käyttäjää.'
-messages.get('c').d({ P: 0.628 })       // 'We have 63% code coverage.'</code></pre>
+messages.hasMessage('a') // false
+messages.hasMessage('a', 'en') // true
+messages.hasMessage('a', null, true) // true
+messages.hasObject('c') // false
+messages.get('b', { COUNT: 3 }) // 'Tällä on 3 käyttäjää.'
+messages.get('c').d({ P: 0.628 }) // 'We have 63% code coverage.'</code></pre>
+
   </div>
 </div>

--- a/packages/website/pages/guide.md
+++ b/packages/website/pages/guide.md
@@ -11,16 +11,15 @@ message formatting system when doing translations, and not everything requires
 variables.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
-const message = mf.compile('This is a message.')
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
+const message = mf.compile('This is a message.');
 
-message()  // "This is a message."
+message(); // "This is a message."
 ```
 
 **Note**: if a message _does_ require data to be passed in, an error is thrown if
 you do not.
-
 
 ## Variables
 
@@ -37,19 +36,17 @@ Simply putting a variable name in between `{` and `}` will place that variable
 there in the output.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
-const varMessage = mf.compile('His name is {NAME}.')
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
+const varMessage = mf.compile('His name is {NAME}.');
 
-varMessage({ NAME: 'Jed' })  // 'His name is Jed.'
+varMessage({ NAME: 'Jed' }); // 'His name is Jed.'
 ```
-
 
 ## SelectFormat
 
 SelectFormat is a lot like a switch statement for your messages. Often it's used
-to select gender in a string. The format of the statement is `{varname, select,
-this{...} that{...} other{...}}`, where `varname` matches a key in the data you
+to select gender in a string. The format of the statement is `{varname, select, this{...} that{...} other{...}}`, where `varname` matches a key in the data you
 give to the resulting function, and `'this'` and `'that'` are some of the
 string-equivalent values that it may have. The `other` key is required, and is
 selected if no other case matches.
@@ -58,21 +55,20 @@ selected if no other case matches.
 left out of the input data, the case `undefined{...}` would match that.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MesssageFormat('en')
+const MessageFormat = require('messageformat');
+const mf = new MesssageFormat('en');
 const selectMessage = mf.compile(
   `{ GENDER, select,
        male {He}
        female {She}
        other {They}
    } liked this.`
-)
+);
 
-selectMessage({ GENDER: 'male' })    // 'He liked this.'
-selectMessage({ GENDER: 'female' })  // 'She liked this.'
-selectMessage({})                    // 'They liked this.'
+selectMessage({ GENDER: 'male' }); // 'He liked this.'
+selectMessage({ GENDER: 'female' }); // 'She liked this.'
+selectMessage({}); // 'They liked this.'
 ```
-
 
 ## PluralFormat
 
@@ -98,11 +94,11 @@ The keyword for cardinal plurals is `plural`, and for ordinal plurals is
 
 Within a plural statement, `#` will be replaced by the variable value.
 
-[CLDR table of plural rules]: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
+[cldr table of plural rules]: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
 const messages = mf.compile({
   results: `There { COUNT, plural,
                     =0 {are no results}
@@ -115,15 +111,14 @@ const messages = mf.compile({
                        few {#rd}
                        other {#th}
                      } in the queue.`
-})
+});
 
-messages.results({ COUNT: 0 })    // 'There are no results.'
-messages.results({ COUNT: 1 })    // 'There is one result.'
-messages.results({ COUNT: 100 })  // 'There are 100 results.'
-messages.position({ POS: 1 })     // 'You are 1st in the queue.'
-messages.position({ POS: 33 })    // 'You are 33rd in the queue.'
+messages.results({ COUNT: 0 }); // 'There are no results.'
+messages.results({ COUNT: 1 }); // 'There is one result.'
+messages.results({ COUNT: 100 }); // 'There are 100 results.'
+messages.position({ POS: 1 }); // 'You are 1st in the queue.'
+messages.position({ POS: 33 }); // 'You are 33rd in the queue.'
 ```
-
 
 ### Plural Offset
 
@@ -133,8 +128,8 @@ determining its plural category. Literal/exact matches are tested before
 applying the offset.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
 const offsetMessage = mf.compile(
   `You { ADDS, plural, offset:1
          =0 {did not add this}
@@ -142,14 +137,13 @@ const offsetMessage = mf.compile(
          one {and one other person added this}
          other {and # others added this}
        }.`
-)
+);
 
-offsetMessage({ ADDS: 0 })  // 'You did not add this.'
-offsetMessage({ ADDS: 1 })  // 'You added this.'
-offsetMessage({ ADDS: 2 })  // 'You and one other person added this.'
-offsetMessage({ ADDS: 3 })  // 'You and 2 others added this.'
+offsetMessage({ ADDS: 0 }); // 'You did not add this.'
+offsetMessage({ ADDS: 1 }); // 'You added this.'
+offsetMessage({ ADDS: 2 }); // 'You and one other person added this.'
+offsetMessage({ ADDS: 3 }); // 'You and 2 others added this.'
 ```
-
 
 ## Formatters
 
@@ -161,18 +155,17 @@ object defined by ECMA-402.
 in all browsers (in particular, IE <=10 and Safari <=9.1), so you may need to
 use a [polyfill].
 
-[simpleArg syntax]: http://icu-project.org/apiref/icu4j/com/ibm/icu/text/MessageFormat.html
-[Intl]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+[simplearg syntax]: http://icu-project.org/apiref/icu4j/com/ibm/icu/text/MessageFormat.html
+[intl]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
 [polyfill]: https://www.npmjs.com/package/intl
-
 
 ### date
 
 Supported parameters are `short`, `default`, `long` , or `full`.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat(['en', 'fi'])
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat(['en', 'fi']);
 const messages = mf.compile({
   en: {
     today: 'Today is {T, date}',
@@ -182,42 +175,40 @@ const messages = mf.compile({
   fi: {
     today: 'Tänään on {T, date}'
   }
-})
+});
 
-messages.en.today({ T: Date.now() })  // 'Today is Mar 30, 2018'
-messages.fi.today({ T: Date.now() })  // 'Tänään on 30. maalisk. 2018'
-messages.en.unix({ T: 0 })
-  // 'Unix time started on Thursday, January 1, 1970'
-messages.en.uptime({ sys: 'HAL 9000', d0: '12 January 1999' })
-  // 'HAL 9000 became operational on 1/12/1999'
+messages.en.today({ T: Date.now() }); // 'Today is Mar 30, 2018'
+messages.fi.today({ T: Date.now() }); // 'Tänään on 30. maalisk. 2018'
+messages.en.unix({ T: 0 });
+// 'Unix time started on Thursday, January 1, 1970'
+messages.en.uptime({ sys: 'HAL 9000', d0: '12 January 1999' });
+// 'HAL 9000 became operational on 1/12/1999'
 ```
-
 
 ### duration
 
 Represent a duration in seconds as a string.
 
 ```javascript
-const MessageFormat = require('messageformat')
+const MessageFormat = require('messageformat');
 const mf = new MessageFormat();
 const messages = mf.compile({
   since: 'It has been {D, duration}',
   countdown: 'Countdown: {D, duration}'
-})
+});
 
-messages.since({ D: 123 })             // 'It has been 2:03'
-messages.countdown({ D: -151200.42 })  // 'Countdown: -42:00:00.420'
+messages.since({ D: 123 }); // 'It has been 2:03'
+messages.countdown({ D: -151200.42 }); // 'Countdown: -42:00:00.420'
 ```
-
 
 ### number
 
 Supported parameters are `integer`, `percent` , or `currency`. To specify a non-default currency, use `currency:CODE`.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
-mf.currency = 'EUR'  // needs to be set before first compile() call
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
+mf.currency = 'EUR'; // needs to be set before first compile() call
 const messages = mf.compile({
   almost: '{N} is almost {N, number, integer}',
   complete: '{P, number, percent} complete',
@@ -225,12 +216,12 @@ const messages = mf.compile({
     eur: 'The total is {V, number, currency}.',
     gbp: 'The total is {V, number, currency:GBP}.'
   }
-})
+});
 
-messages.almost({ N: 3.14 })       // '3.14 is almost 3'
-messages.complete({ P: 0.99 })     // '99% complete'
-messages.currency.eur({ V: 5.5 })  // 'The total is €5.50.'
-messages.currency.gbp({ V: 5.5 })  // 'The total is £5.50.'
+messages.almost({ N: 3.14 }); // '3.14 is almost 3'
+messages.complete({ P: 0.99 }); // '99% complete'
+messages.currency.eur({ V: 5.5 }); // 'The total is €5.50.'
+messages.currency.gbp({ V: 5.5 }); // 'The total is £5.50.'
 ```
 
 ### time
@@ -254,7 +245,6 @@ messages.eagle({ T: '1969-07-20 20:17:40 UTC' })
   // 'The Eagle landed at 10:17:40 PM GMT+2 on Sunday, July 20, 1969'
 ```
 
-
 ### Custom Formatters
 
 In MessageFormat source, a formatter function is called with the syntax
@@ -264,9 +254,10 @@ In MessageFormat source, a formatter function is called with the syntax
 argument.
 
 In JavaScript, a formatter is a function called with three parameters:
-  - The **`value`** of the variable; this can be of any user-defined type
-  - The current **`locale`** code
-  - The trimmed **`arg`** string value, or `null` if not set
+
+- The **`value`** of the variable; this can be of any user-defined type
+- The current **`locale`** code
+- The trimmed **`arg`** string value, or `null` if not set
 
 As formatter functions may be used in a precompiled context, they should not
 refer to any variables that are not defined by the function parameters or
@@ -275,24 +266,29 @@ static `MessageFormat.formatters` object, or use
 {@link MessageFormat#addFormatters} to add them to a MessageFormat instance.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en-GB')
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en-GB');
 mf.addFormatters({
-  upcase: function(v) { return v.toUpperCase(); },
-  locale: function(v, lc) { return lc; },
-  prop: function(v, lc, p) { return v[p] }
-})
+  upcase: function(v) {
+    return v.toUpperCase();
+  },
+  locale: function(v, lc) {
+    return lc;
+  },
+  prop: function(v, lc, p) {
+    return v[p];
+  }
+});
 const messages = mf.compile({
   describe: 'This is {VAR, upcase}.',
   locale: 'The current locale is {_, locale}.',
   answer: 'Answer: {obj, prop, a}'
-})
+});
 
-messages.describe({ VAR: 'big' })        // 'This is BIG.'
-messages.locale({})                      // 'The current locale is en-GB.'
-messages.answer({ obj: {q: 3, a: 42} })  // 'Answer: 42'
+messages.describe({ VAR: 'big' }); // 'This is BIG.'
+messages.locale({}); // 'The current locale is en-GB.'
+messages.answer({ obj: { q: 3, a: 42 } }); // 'Answer: 42'
 ```
-
 
 ## Nesting
 
@@ -311,19 +307,18 @@ All types of messageformat statements may be nested within each other, to unlimi
 }
 ```
 
-
 ## Escaping
 
 The characters `{` and `}` must be escaped with `'quotes'` to be included in the output as literal characters. Within plural statements, `#` must also be similarly escaped. The utility function {@link MessageFormat.escape} may help with this.
 
 ```javascript
-const MessageFormat = require('messageformat')
-const mf = new MessageFormat('en')
+const MessageFormat = require('messageformat');
+const mf = new MessageFormat('en');
 const messages = mf.compile({
   esc: "'{' {S, plural, other{# is a '#'}} '}'",
   var: MessageFormat.escape('Use {var} for variables')
-})
+});
 
-messages.esc({ S: 5 })    // '{ 5 is a # }'
-messages.var({ var: 5 })  // 'Use {var} for variables'
+messages.esc({ S: 5 }); // '{ 5 is a # }'
+messages.var({ var: 5 }); // 'Use {var} for variables'
 ```

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -25,7 +25,9 @@ describe('Formatters', () => {
     it('argument', () => {
       const msg = mf.compile('Unix time started on {T, date, full}');
       const data = { T: 0 };
-      expect(msg(data)).to.eql('Unix time started on Thursday, January 1, 1970');
+      expect(msg(data)).to.eql(
+        'Unix time started on Thursday, January 1, 1970'
+      );
     });
 
     it('complex', () => {
@@ -112,62 +114,83 @@ describe('Formatters', () => {
     });
 
     it('full time & date', () => {
-      const msg = mf.compile('The Eagle landed at {T, time, full} on {T, date, full}');
+      const msg = mf.compile(
+        'The Eagle landed at {T, time, full} on {T, date, full}'
+      );
       const data = { T: '1969-07-20 20:17:40 UTC' };
-      expect(msg(data)).to.match(/^The Eagle landed at \d\d?:\d\d:40 .M \S+ on \w+day, July \d\d, 1969$/);
+      expect(msg(data)).to.match(
+        /^The Eagle landed at \d\d?:\d\d:40 .M \S+ on \w+day, July \d\d, 1969$/
+      );
     });
   });
 
   describe('Custom formatters', () => {
-    let mf
+    let mf;
     beforeEach(() => {
-      mf = new MessageFormat('en')
-    })
+      mf = new MessageFormat('en');
+    });
 
     it('should throw an error when using an undefined formatting function', () => {
-      expect(() => { mf.compile('This is {VAR,uppercase}.') }).to.throwError()
-    })
+      expect(() => {
+        mf.compile('This is {VAR,uppercase}.');
+      }).to.throwError();
+    });
 
     it('should use formatting functions - set in MessageFormat.formatters', () => {
-      let msg = mf.compile('The date is {VAR,date}.')
-      expect(msg({ VAR: '2010-12-31' })).to.contain('2010')
-      msg = mf.compile('Countdown: {VAR, duration}.')
-      expect(msg({ VAR: -151200.42 })).to.eql('Countdown: -42:00:00.420.')
-    })
+      let msg = mf.compile('The date is {VAR,date}.');
+      expect(msg({ VAR: '2010-12-31' })).to.contain('2010');
+      msg = mf.compile('Countdown: {VAR, duration}.');
+      expect(msg({ VAR: -151200.42 })).to.eql('Countdown: -42:00:00.420.');
+    });
 
     it('should use formatting functions - set by #addFormatters()', () => {
-      mf.addFormatters({ uppercase: function(v) { return v.toUpperCase() } })
-      const msg = mf.compile('This is {VAR,uppercase}.')
-      expect(msg({ VAR: 'big' })).to.eql('This is BIG.')
-    })
+      mf.addFormatters({
+        uppercase: function(v) {
+          return v.toUpperCase();
+        }
+      });
+      const msg = mf.compile('This is {VAR,uppercase}.');
+      expect(msg({ VAR: 'big' })).to.eql('This is BIG.');
+    });
 
     it('should use formatting functions for object input - set by #addFormatters()', () => {
-      mf.addFormatters({ uppercase: function(v) { return v.toUpperCase() } })
-      const msg = mf.compile(['This is {VAR,uppercase}.', 'Other string'])
-      expect(msg[0]({ VAR: 'big' })).to.eql('This is BIG.')
-    })
+      mf.addFormatters({
+        uppercase: function(v) {
+          return v.toUpperCase();
+        }
+      });
+      const msg = mf.compile(['This is {VAR,uppercase}.', 'Other string']);
+      expect(msg[0]({ VAR: 'big' })).to.eql('This is BIG.');
+    });
 
     describe('arguments', () => {
       beforeEach(() => {
-        mf = new MessageFormat('en')
-        mf.addFormatters({ arg: function(v, lc, arg) { return arg } })
-      })
+        mf = new MessageFormat('en');
+        mf.addFormatters({
+          arg: function(v, lc, arg) {
+            return arg;
+          }
+        });
+      });
 
       it('basic string', () => {
-        const msg = mf.compile('This is {_, arg, X, Y }.')
-        expect(msg({})).to.eql('This is X, Y.')
-      })
+        const msg = mf.compile('This is {_, arg, X, Y }.');
+        expect(msg({})).to.eql('This is X, Y.');
+      });
 
       it('select', () => {
-        const msg = mf.compile('This is {_, arg, {VAR, select, x{X} other{Y}}}.')
-        expect(msg({ VAR: 'x' })).to.eql('This is X.')
-      })
+        const msg = mf.compile(
+          'This is {_, arg, {VAR, select, x{X} other{Y}}}.'
+        );
+        expect(msg({ VAR: 'x' })).to.eql('This is X.');
+      });
 
       it('# in plural', () => {
-        const msg = mf.compile('This is {VAR, plural, one{} other{{_, arg, #}}}.')
-        expect(msg({ VAR: 99 })).to.eql('This is 99.')
-      })
-    })
-  })
-})
-
+        const msg = mf.compile(
+          'This is {VAR, plural, one{} other{{_, arg, #}}}.'
+        );
+        expect(msg({ VAR: 99 })).to.eql('This is 99.');
+      });
+    });
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -1,12 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
   <head>
-    <meta charset=utf-8 />
+    <meta charset="utf-8" />
     <title>messageformat Test Suite</title>
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/expect.js/index.js"></script>
-    <script>mocha.setup('bdd')</script>
+    <script>
+      mocha.setup('bdd');
+    </script>
     <script src="../packages/messageformat/messageformat.js"></script>
     <script src="messageformat.js"></script>
   </head>
@@ -14,7 +16,7 @@
     <h1>messageformat Test Suite</h1>
     <div id="mocha"></div>
     <script>
-      window.onload = function () {
+      window.onload = function() {
         mocha.run().globals(['MessageFormat']);
       };
     </script>

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -515,10 +515,10 @@ describe('Real World Uses', function() {
       '} group.';
 
     var mf = new MessageFormat('en');
-    var mf_func = mf.compile(input);
+    var mfunc = mf.compile(input);
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 0,
         PERSON: 'Allie Sexton',
         GENDER: 'female'
@@ -526,7 +526,7 @@ describe('Real World Uses', function() {
     ).to.eql('Allie Sexton added no one to her group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 1,
         PERSON: 'Allie Sexton',
         GENDER: 'female'
@@ -534,7 +534,7 @@ describe('Real World Uses', function() {
     ).to.eql('Allie Sexton added just herself to her group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 2,
         PERSON: 'Allie Sexton',
         GENDER: 'female'
@@ -542,7 +542,7 @@ describe('Real World Uses', function() {
     ).to.eql('Allie Sexton added herself and one other person to her group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 3,
         PERSON: 'Allie Sexton',
         GENDER: 'female'
@@ -550,7 +550,7 @@ describe('Real World Uses', function() {
     ).to.eql('Allie Sexton added herself and 2 other people to her group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 0,
         PERSON: 'Alex Sexton',
         GENDER: 'male'
@@ -558,7 +558,7 @@ describe('Real World Uses', function() {
     ).to.eql('Alex Sexton added no one to his group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 1,
         PERSON: 'Alex Sexton',
         GENDER: 'male'
@@ -566,7 +566,7 @@ describe('Real World Uses', function() {
     ).to.eql('Alex Sexton added just himself to his group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 2,
         PERSON: 'Alex Sexton',
         GENDER: 'male'
@@ -574,7 +574,7 @@ describe('Real World Uses', function() {
     ).to.eql('Alex Sexton added himself and one other person to his group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 3,
         PERSON: 'Alex Sexton',
         GENDER: 'male'
@@ -582,28 +582,28 @@ describe('Real World Uses', function() {
     ).to.eql('Alex Sexton added himself and 2 other people to his group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 0,
         PERSON: 'Al Sexton'
       })
     ).to.eql('Al Sexton added no one to their group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 1,
         PERSON: 'Al Sexton'
       })
     ).to.eql('Al Sexton added just themself to their group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 2,
         PERSON: 'Al Sexton'
       })
     ).to.eql('Al Sexton added themself and one other person to their group.');
 
     expect(
-      mf_func({
+      mfunc({
         PLURAL_NUM_PEOPLE: 3,
         PERSON: 'Al Sexton'
       })

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -1,219 +1,238 @@
 if (typeof require !== 'undefined') {
-  var expect = require('expect.js')
-  var MessageFormat = require('../packages/messageformat')
+  var expect = require('expect.js');
+  var MessageFormat = require('../packages/messageformat');
 }
 
 describe('new MessageFormat()', () => {
   it('should exist', () => {
-    expect(MessageFormat).to.be.a('function')
-  })
+    expect(MessageFormat).to.be.a('function');
+  });
 
   it('should be a constructor', () => {
-    const mf = new MessageFormat('en')
-    expect(mf).to.be.a(MessageFormat)
-  })
+    const mf = new MessageFormat('en');
+    expect(mf).to.be.a(MessageFormat);
+  });
 
   it('should have a compile() function', () => {
-    const mf = new MessageFormat('en')
-    expect(mf.compile).to.be.a('function')
-  })
+    const mf = new MessageFormat('en');
+    expect(mf.compile).to.be.a('function');
+  });
 
   it('should fallback when a base pluralFunc exists', () => {
-    const mf = new MessageFormat('en-x-test1-test2')
-    expect(mf.pluralFuncs['en-x-test1-test2']).to.be.a('function')
-  })
+    const mf = new MessageFormat('en-x-test1-test2');
+    expect(mf.pluralFuncs['en-x-test1-test2']).to.be.a('function');
+  });
 
   it('should fallback when a base pluralFunc exists (underscores)', () => {
-    const mf = new MessageFormat('en_x_test1_test2')
-    expect(mf.pluralFuncs['en_x_test1_test2']).to.be.a('function')
-  })
+    const mf = new MessageFormat('en_x_test1_test2');
+    expect(mf.pluralFuncs['en_x_test1_test2']).to.be.a('function');
+  });
 
   it('should bail on non-existing locales', () => {
-    expect(() => new MessageFormat('lawlz')).to.throwError()
-  })
+    expect(() => new MessageFormat('lawlz')).to.throwError();
+  });
 
   it('should default to `en` when no locale is passed into the constructor', () => {
-    expect(new MessageFormat().defaultLocale).to.eql('en')
-  })
-})
+    expect(new MessageFormat().defaultLocale).to.eql('en');
+  });
+});
 
 describe('compile()', () => {
-  let mf
+  let mf;
   beforeEach(() => {
-    mf = new MessageFormat('en')
-  })
+    mf = new MessageFormat('en');
+  });
 
   it('should exist', () => {
-    expect(mf.compile).to.be.a('function')
-  })
+    expect(mf.compile).to.be.a('function');
+  });
 
   it('compiles a string to a function', () => {
-    expect(mf.compile('test')).to.be.a('function')
-  })
+    expect(mf.compile('test')).to.be.a('function');
+  });
 
   it('can output a non-formatted string', () => {
-    expect((mf.compile('This is a string.'))()).to.eql('This is a string.')
-  })
+    expect(mf.compile('This is a string.')()).to.eql('This is a string.');
+  });
 
   it('throws an error when no `other` option is found - plurals', () => {
-    expect(() => mf.compile('{X, plural, someoption{a}}')).to.throwError()
-  })
+    expect(() => mf.compile('{X, plural, someoption{a}}')).to.throwError();
+  });
 
   it('throws an error when no `other` option is found - selects', () => {
-    expect(() => mf.compile('{X, select, someoption{a}}')).to.throwError()
-  })
+    expect(() => mf.compile('{X, select, someoption{a}}')).to.throwError();
+  });
 
   it('throws an error when no `other` option is found - selectordinals', () => {
-    expect(() => mf.compile('{X, selectordinal, someoption{a}}')).to.throwError()
-  })
+    expect(() =>
+      mf.compile('{X, selectordinal, someoption{a}}')
+    ).to.throwError();
+  });
 
   it('does not throw an error when no `other` option is found - plurals with custom pluralFunc', () => {
-    const fake = (x, ord) => ord ? 'few' : 'some'
-    fake.cardinal = ['some']
-    fake.ordinal = ['few']
-    mf = new MessageFormat({ fake })
-    expect(() => mf.compile('{X, plural, some{a}}')).to.not.throwError()
-  })
+    const fake = (x, ord) => (ord ? 'few' : 'some');
+    fake.cardinal = ['some'];
+    fake.ordinal = ['few'];
+    mf = new MessageFormat({ fake });
+    expect(() => mf.compile('{X, plural, some{a}}')).to.not.throwError();
+  });
 
   it('should use the locale plural function', () => {
-    mf = new MessageFormat('cy')
-    const mfunc = mf.compile('{num, plural, zero{0} one{1} two{2} few{3} many{6} other{+}}')
-    expect(mfunc.toString()).to.match(/\bcy\b/)
-    expect(mfunc({num: 5})).to.be('+')
-  })
+    mf = new MessageFormat('cy');
+    const mfunc = mf.compile(
+      '{num, plural, zero{0} one{1} two{2} few{3} many{6} other{+}}'
+    );
+    expect(mfunc.toString()).to.match(/\bcy\b/);
+    expect(mfunc({ num: 5 })).to.be('+');
+  });
 
   it('should use the locale selectordinal function', () => {
-    mf = new MessageFormat('cy')
-    const mfunc = mf.compile('{num, selectordinal, zero{0,7,8,9} one{1} two{2} few{3,4} many{5,6} other{+}}')
-    expect(mfunc.toString()).to.match(/\bcy\b/)
-    expect(mfunc({num: 5})).to.be('5,6')
-  })
+    mf = new MessageFormat('cy');
+    const mfunc = mf.compile(
+      '{num, selectordinal, zero{0,7,8,9} one{1} two{2} few{3,4} many{5,6} other{+}}'
+    );
+    expect(mfunc.toString()).to.match(/\bcy\b/);
+    expect(mfunc({ num: 5 })).to.be('5,6');
+  });
 
   it('should have configurable # parsing support', () => {
-    const msg = '{X, plural, one{#} other{{Y, select, other{#}}}}'
-    const msg2 = "{X, plural, one{#} other{{Y, select, other{'#'}}}}"
-    expect(mf.compile(msg)({ X: 3, Y: 5 })).to.eql('3')
-    expect(mf.compile(msg)({ X: 'x' })).to.eql('x')
-    expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.eql('#')
-    expect(mf.compile(msg2)({ X: 'x' })).to.eql('#')
-    mf.setStrictNumberSign(true)
-    expect(mf.compile(msg)({ X: 3, Y: 5 })).to.eql('#')
-    expect(() => { mf.compile(msg)({ X: 'x' }) }).to.throwError(/\bX\b.*non-numerical value/)
-    expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.eql("'#'")
-    mf.setStrictNumberSign(false)
-    expect(mf.compile(msg)({ X: 3, Y: 5 })).to.eql('3')
-    expect(mf.compile(msg)({ X: 'x' })).to.eql('x')
-    expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.eql('#')
-    expect(mf.compile(msg2)({ X: 'x' })).to.eql('#')
-  })
+    const msg = '{X, plural, one{#} other{{Y, select, other{#}}}}';
+    const msg2 = "{X, plural, one{#} other{{Y, select, other{'#'}}}}";
+    expect(mf.compile(msg)({ X: 3, Y: 5 })).to.eql('3');
+    expect(mf.compile(msg)({ X: 'x' })).to.eql('x');
+    expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.eql('#');
+    expect(mf.compile(msg2)({ X: 'x' })).to.eql('#');
+    mf.setStrictNumberSign(true);
+    expect(mf.compile(msg)({ X: 3, Y: 5 })).to.eql('#');
+    expect(() => {
+      mf.compile(msg)({ X: 'x' });
+    }).to.throwError(/\bX\b.*non-numerical value/);
+    expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.eql("'#'");
+    mf.setStrictNumberSign(false);
+    expect(mf.compile(msg)({ X: 3, Y: 5 })).to.eql('3');
+    expect(mf.compile(msg)({ X: 'x' })).to.eql('x');
+    expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.eql('#');
+    expect(mf.compile(msg2)({ X: 'x' })).to.eql('#');
+  });
 
   it('can compile an object of messages into a function', () => {
-    const data = { key: 'I have {FRIENDS, plural, one{one friend} other{# friends}}.' }
-    const mfunc = mf.compile(data)
-    expect(mfunc).to.be.an('object')
-    expect(mfunc.toString()).to.match(/\bkey\b/)
+    const data = {
+      key: 'I have {FRIENDS, plural, one{one friend} other{# friends}}.'
+    };
+    const mfunc = mf.compile(data);
+    expect(mfunc).to.be.an('object');
+    expect(mfunc.toString()).to.match(/\bkey\b/);
 
-    expect(mfunc.key).to.be.a('function')
-    expect(mfunc.key({FRIENDS:1})).to.eql('I have one friend.')
-    expect(mfunc.key({FRIENDS:2})).to.eql('I have 2 friends.')
-  })
+    expect(mfunc.key).to.be.a('function');
+    expect(mfunc.key({ FRIENDS: 1 })).to.eql('I have one friend.');
+    expect(mfunc.key({ FRIENDS: 2 })).to.eql('I have 2 friends.');
+  });
 
   it('can compile an object enclosing reserved JavaScript words used as keys in quotes', () => {
     const data = {
-      'default': 'default is a JavaScript reserved word so should be quoted',
-      'unreserved': 'unreserved is not a JavaScript reserved word so should not be quoted'
-    }
-    const mfunc = mf.compile(data)
-    expect(mfunc.toString()).to.match(/"default"/)
-    expect(mfunc.toString()).to.match(/[^"]unreserved[^"]/)
+      default: 'default is a JavaScript reserved word so should be quoted',
+      unreserved:
+        'unreserved is not a JavaScript reserved word so should not be quoted'
+    };
+    const mfunc = mf.compile(data);
+    expect(mfunc.toString()).to.match(/"default"/);
+    expect(mfunc.toString()).to.match(/[^"]unreserved[^"]/);
 
-    expect(mfunc['default']).to.be.a('function')
-    expect(mfunc['default']()).to.eql('default is a JavaScript reserved word so should be quoted')
+    expect(mfunc['default']).to.be.a('function');
+    expect(mfunc['default']()).to.eql(
+      'default is a JavaScript reserved word so should be quoted'
+    );
 
-    expect(mfunc.unreserved).to.be.a('function')
-    expect(mfunc.unreserved()).to.eql('unreserved is not a JavaScript reserved word so should not be quoted')
-  })
+    expect(mfunc.unreserved).to.be.a('function');
+    expect(mfunc.unreserved()).to.eql(
+      'unreserved is not a JavaScript reserved word so should not be quoted'
+    );
+  });
 
   it('can be instantiated multiple times for multiple languages', () => {
     const mf = {
-        en: new MessageFormat('en'),
-        ru: new MessageFormat('ru')
-    }
+      en: new MessageFormat('en'),
+      ru: new MessageFormat('ru')
+    };
     const cf = {
-        en: mf.en.compile('{count} {count, plural, other{users}}'),
-        ru: mf.ru.compile('{count} {count, plural, other{пользователей}}')
-    }
-    expect(() => cf.en({count: 12})).to.not.throwError()
-    expect(cf.en({count: 12})).to.eql('12 users')
-    expect(() => cf.ru({count: 13})).to.not.throwError()
-    expect(cf.ru({count: 13})).to.eql('13 пользователей')
-  })
+      en: mf.en.compile('{count} {count, plural, other{users}}'),
+      ru: mf.ru.compile('{count} {count, plural, other{пользователей}}')
+    };
+    expect(() => cf.en({ count: 12 })).to.not.throwError();
+    expect(cf.en({ count: 12 })).to.eql('12 users');
+    expect(() => cf.ru({ count: 13 })).to.not.throwError();
+    expect(cf.ru({ count: 13 })).to.eql('13 пользователей');
+  });
 
   it('can support multiple languages', () => {
-    mf = new MessageFormat(['en', 'fr', 'ru'])
-    mf.addFormatters({ lc: (v, lc) => lc })
+    mf = new MessageFormat(['en', 'fr', 'ru']);
+    mf.addFormatters({ lc: (v, lc) => lc });
     const cf = mf.compile({
-        fr: 'Locale: {_, lc}',
-        ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
-    })
-    expect(cf.fr({})).to.eql('Locale: fr')
-    expect(cf.ru({ count: 12 })).to.eql('3')
-  })
+      fr: 'Locale: {_, lc}',
+      ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
+    });
+    expect(cf.fr({})).to.eql('Locale: fr');
+    expect(cf.ru({ count: 12 })).to.eql('3');
+  });
 
   it('defaults to supporting all languages: compile({ fr, ru })', () => {
-    mf = new MessageFormat()
-    mf.addFormatters({ lc: (v, lc) => lc })
+    mf = new MessageFormat();
+    mf.addFormatters({ lc: (v, lc) => lc });
     const cf = mf.compile({
-        fr: 'Locale: {_, lc}',
-        xx: 'Locale: {_, lc}',
-        ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
-    })
-    expect(cf.fr({})).to.eql('Locale: fr')
-    expect(cf.xx({})).to.eql('Locale: en')
-    expect(cf.ru({ count: 12 })).to.eql('3')
-  })
+      fr: 'Locale: {_, lc}',
+      xx: 'Locale: {_, lc}',
+      ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
+    });
+    expect(cf.fr({})).to.eql('Locale: fr');
+    expect(cf.xx({})).to.eql('Locale: en');
+    expect(cf.ru({ count: 12 })).to.eql('3');
+  });
 
   it('defaults to supporting all languages: compile(src, locale)', () => {
-    mf = new MessageFormat()
-    mf.addFormatters({ lc: (v, lc) => lc })
-    const cf0 = mf.compile('Locale: {_, lc}', 'fr')
-    expect(cf0({})).to.eql('Locale: fr')
-    const cf1 = mf.compile({
+    mf = new MessageFormat();
+    mf.addFormatters({ lc: (v, lc) => lc });
+    const cf0 = mf.compile('Locale: {_, lc}', 'fr');
+    expect(cf0({})).to.eql('Locale: fr');
+    const cf1 = mf.compile(
+      {
         fr: 'Locale: {_, lc}',
         en: '{count, plural, one{1} few{2} many{3} other{x:#}}'
-    }, 'ru-RU')
-    expect(cf1.fr({})).to.eql('Locale: ru-RU')
-    expect(cf1.en({ count: 12 })).to.eql('3')
-  })
-})
+      },
+      'ru-RU'
+    );
+    expect(cf1.fr({})).to.eql('Locale: ru-RU');
+    expect(cf1.en({ count: 12 })).to.eql('3');
+  });
+});
 
-describe("Basic Message Formatting", function() {
-
-  it("gets non-ascii character all the way through.", function() {
+describe('Basic Message Formatting', function() {
+  it('gets non-ascii character all the way through.', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile('中{test}中国话不用彁字。'))({test:"☺"})).to.eql("中☺中国话不用彁字。");
+    expect(mf.compile('中{test}中国话不用彁字。')({ test: '☺' })).to.eql(
+      '中☺中国话不用彁字。'
+    );
   });
 
-  it("escapes double quotes", function() {
+  it('escapes double quotes', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile('She said "Hello"'))()).to.eql('She said "Hello"');
+    expect(mf.compile('She said "Hello"')()).to.eql('She said "Hello"');
   });
 
-  it("should handle apostrophes correctly", function() {
+  it('should handle apostrophes correctly', function() {
     var mf = new MessageFormat('en');
-    expect(mf.compile("I see '{many}'")()).to.eql("I see {many}");
+    expect(mf.compile("I see '{many}'")()).to.eql('I see {many}');
     expect(mf.compile("I said '{''Wow!''}'")()).to.eql("I said {'Wow!'}");
     expect(mf.compile("I don't know")()).to.eql("I don't know");
     expect(mf.compile("I don''t know")()).to.eql("I don't know");
   });
 
-  it("accepts escaped special characters", function() {
+  it('accepts escaped special characters', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile("'{'"))()).to.eql('{');
-    expect((mf.compile("'}'"))()).to.eql('}');
+    expect(mf.compile("'{'")()).to.eql('{');
+    expect(mf.compile("'}'")()).to.eql('}');
   });
 
-  it("accepts special characters escaped with MessageFormat.escape", function() {
+  it('accepts special characters escaped with MessageFormat.escape', function() {
     var mf = new MessageFormat('en');
     expect(mf.compile(MessageFormat.escape('{'))()).to.eql('{');
     expect(mf.compile(MessageFormat.escape('}'))()).to.eql('}');
@@ -221,270 +240,377 @@ describe("Basic Message Formatting", function() {
     expect(mf.compile(MessageFormat.escape('#', true))()).to.eql("'#'");
   });
 
-  it("should get escaped brackets all the way out the other end", function() {
+  it('should get escaped brackets all the way out the other end', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile("'{{{'"))()).to.eql("{{{");
-    expect((mf.compile("'}}}'"))()).to.eql("}}}");
-    expect((mf.compile("'{{{'{test}'}}}'"))({test:4})).to.eql("{{{4}}}");
-    expect((mf.compile("'{{{'{test, plural, other{#}}'}}}'"))({test:4})).to.eql("{{{4}}}");
+    expect(mf.compile("'{{{'")()).to.eql('{{{');
+    expect(mf.compile("'}}}'")()).to.eql('}}}');
+    expect(mf.compile("'{{{'{test}'}}}'")({ test: 4 })).to.eql('{{{4}}}');
+    expect(
+      mf.compile("'{{{'{test, plural, other{#}}'}}}'")({ test: 4 })
+    ).to.eql('{{{4}}}');
   });
 
-  it("can substitute named variables", function() {
+  it('can substitute named variables', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile("The var is {VAR}."))({"VAR":5})).to.eql("The var is 5.");
+    expect(mf.compile('The var is {VAR}.')({ VAR: 5 })).to.eql('The var is 5.');
   });
 
-  it("can substitute positional variables", function() {
+  it('can substitute positional variables', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile("The var is {0}."))({"0":5})).to.eql("The var is 5.");
-    expect((mf.compile("The var is {0}."))([5])).to.eql("The var is 5.");
-    expect((mf.compile("The vars are {0} and {1}."))([5,-3])).to.eql("The vars are 5 and -3.");
-    expect((mf.compile("The vars are {0} and {01}."))([5,-3])).to.eql("The vars are 5 and undefined.");
+    expect(mf.compile('The var is {0}.')({ '0': 5 })).to.eql('The var is 5.');
+    expect(mf.compile('The var is {0}.')([5])).to.eql('The var is 5.');
+    expect(mf.compile('The vars are {0} and {1}.')([5, -3])).to.eql(
+      'The vars are 5 and -3.'
+    );
+    expect(mf.compile('The vars are {0} and {01}.')([5, -3])).to.eql(
+      'The vars are 5 and undefined.'
+    );
   });
 
-  it("can substitute shorthand variables", function() {
+  it('can substitute shorthand variables', function() {
     var mf = new MessageFormat('en');
-    expect((mf.compile("{VAR, plural, other{The var is #.}}"))({ VAR: 5 })).to.eql("The var is 5.");
-    expect((mf.compile("{0, plural, other{The var is #.}}"))([5])).to.eql("The var is 5.");
-    expect((mf.compile("{VAR, plural, offset:1 other{The var is #.}}"))({ VAR: 5 })).to.eql("The var is 4.");
-    expect((mf.compile("{X, plural, other{{Y, select, other{The var is #.}}}}"))({ X: 5, Y: 'key' })).to.eql("The var is 5.");
+    expect(
+      mf.compile('{VAR, plural, other{The var is #.}}')({ VAR: 5 })
+    ).to.eql('The var is 5.');
+    expect(mf.compile('{0, plural, other{The var is #.}}')([5])).to.eql(
+      'The var is 5.'
+    );
+    expect(
+      mf.compile('{VAR, plural, offset:1 other{The var is #.}}')({ VAR: 5 })
+    ).to.eql('The var is 4.');
+    expect(
+      mf.compile('{X, plural, other{{Y, select, other{The var is #.}}}}')({
+        X: 5,
+        Y: 'key'
+      })
+    ).to.eql('The var is 5.');
   });
 
-  it("allows escaped shorthand variable: #", function() {
+  it('allows escaped shorthand variable: #', function() {
     var mf = new MessageFormat('en');
     var mfunc = mf.compile("{X, plural, other{# is a '#'}}");
-    expect(mfunc({X:3})).to.eql("3 is a #");
+    expect(mfunc({ X: 3 })).to.eql('3 is a #');
   });
 
-  it("should not substitute octothorpes that are outside of curly braces", function() {
+  it('should not substitute octothorpes that are outside of curly braces', function() {
     var mf = new MessageFormat('en');
     var mfunc = mf.compile('This is an octothorpe: #');
-    expect(mfunc({X:3})).to.eql("This is an octothorpe: #");
+    expect(mfunc({ X: 3 })).to.eql('This is an octothorpe: #');
   });
 
-  it("obeys plural functions", function() {
-    var mf = new MessageFormat({ fake: function(x) { return 'few'; } });
-    expect((mf.compile("res: {val, plural, few{wasfew} other{failed}}"))({val:0})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, plural, few{wasfew} other{failed}}"))({val:1})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, plural, few{wasfew} other{failed}}"))({val:2})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, plural, few{wasfew} other{failed}}"))({val:3})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, plural, few{wasfew} other{failed}}"))({})).to.be("res: wasfew");
+  it('obeys plural functions', function() {
+    var mf = new MessageFormat({
+      fake: function(x) {
+        return 'few';
+      }
+    });
+    expect(
+      mf.compile('res: {val, plural, few{wasfew} other{failed}}')({ val: 0 })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, plural, few{wasfew} other{failed}}')({ val: 1 })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, plural, few{wasfew} other{failed}}')({ val: 2 })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, plural, few{wasfew} other{failed}}')({ val: 3 })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, plural, few{wasfew} other{failed}}')({})
+    ).to.be('res: wasfew');
   });
 
-  it("obeys selectordinal functions", function() {
-    var mf = new MessageFormat({ fake: function(x, ord) { return ord ? 'few' : 'other'; } });
-    expect((mf.compile("res: {val, selectordinal, few{wasfew} other{failed}}"))({val:0})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, selectordinal, few{wasfew} other{failed}}"))({val:1})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, selectordinal, few{wasfew} other{failed}}"))({val:2})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, selectordinal, few{wasfew} other{failed}}"))({val:3})).to.be("res: wasfew");
-    expect((mf.compile("res: {val, selectordinal, few{wasfew} other{failed}}"))({})).to.be("res: wasfew");
+  it('obeys selectordinal functions', function() {
+    var mf = new MessageFormat({
+      fake: function(x, ord) {
+        return ord ? 'few' : 'other';
+      }
+    });
+    expect(
+      mf.compile('res: {val, selectordinal, few{wasfew} other{failed}}')({
+        val: 0
+      })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, selectordinal, few{wasfew} other{failed}}')({
+        val: 1
+      })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, selectordinal, few{wasfew} other{failed}}')({
+        val: 2
+      })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, selectordinal, few{wasfew} other{failed}}')({
+        val: 3
+      })
+    ).to.be('res: wasfew');
+    expect(
+      mf.compile('res: {val, selectordinal, few{wasfew} other{failed}}')({})
+    ).to.be('res: wasfew');
   });
 
-  it("only calculates the offset from non-literals", function() {
+  it('only calculates the offset from non-literals', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("{NUM, plural, offset:1 =0{a} one{b} other{c}}");
-    expect(mfunc({NUM:0})).to.eql('a');
-    expect(mfunc({NUM:1})).to.eql('c');
-    expect(mfunc({NUM:2})).to.eql('b');
+    var mfunc = mf.compile('{NUM, plural, offset:1 =0{a} one{b} other{c}}');
+    expect(mfunc({ NUM: 0 })).to.eql('a');
+    expect(mfunc({ NUM: 1 })).to.eql('c');
+    expect(mfunc({ NUM: 2 })).to.eql('b');
   });
 
-  it("should obey `i=0 and v=0` rules", function() {
+  it('should obey `i=0 and v=0` rules', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("{NUM, plural, one{a} other{b}}");
-    expect(mfunc({NUM:'1'})).to.eql('a');
-    expect(mfunc({NUM:'1.0'})).to.eql('b');
+    var mfunc = mf.compile('{NUM, plural, one{a} other{b}}');
+    expect(mfunc({ NUM: '1' })).to.eql('a');
+    expect(mfunc({ NUM: '1.0' })).to.eql('b');
   });
 
-  it("should give priority to literals", function() {
+  it('should give priority to literals', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("{NUM, plural, =34{a} one{b} other{c}}");
-    expect(mfunc({NUM:34})).to.eql('a');
+    var mfunc = mf.compile('{NUM, plural, =34{a} one{b} other{c}}');
+    expect(mfunc({ NUM: 34 })).to.eql('a');
   });
 
   it("should throw an error when you don't pass it any data, but it expects it", function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("{NEEDSDATAYO}");
-    expect(function(){ var z = mfunc(); }).to.throwError();
+    var mfunc = mf.compile('{NEEDSDATAYO}');
+    expect(function() {
+      var z = mfunc();
+    }).to.throwError();
   });
 
   it("should not throw an error when you don't pass it any data, but it expects none", function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("Just a string");
-    expect(function(){ var z = mfunc(); }).to.not.throwError();
+    var mfunc = mf.compile('Just a string');
+    expect(function() {
+      var z = mfunc();
+    }).to.not.throwError();
   });
 
-  it("should be able to disable plural checks", function() {
+  it('should be able to disable plural checks', function() {
     var mf0 = new MessageFormat('en');
     var mf1 = new MessageFormat('en');
     var msg = '{X, plural, zero{none} one{one} other{some: #}}';
-    expect(function(){ mf0.compile(msg) }).to.throwError();
+    expect(function() {
+      mf0.compile(msg);
+    }).to.throwError();
     mf0.disablePluralKeyChecks();
-    expect(mf0.compile(msg)({ X: 0 })).to.eql("some: 0");
-    expect(function(){ mf1.compile(msg) }).to.throwError();
+    expect(mf0.compile(msg)({ X: 0 })).to.eql('some: 0');
+    expect(function() {
+      mf1.compile(msg);
+    }).to.throwError();
   });
 
-  it("should add control codes to bidirectional text", function() {
+  it('should add control codes to bidirectional text', function() {
     var msg = '{0} >> {1}';
     var data = ['Hello! English', 'Hello \u0647\u0644\u0627\u060d'];
     var mfEn = new MessageFormat('en').setBiDiSupport(true);
     var mfEg = new MessageFormat('ar-EG').setBiDiSupport(true);
-    expect(mfEn.compile(msg)(data)).to.equal('\u200eHello! English\u200e >> \u200eHello \u0647\u0644\u0627\u060d\u200e');
-    expect(mfEg.compile(msg)(data)).to.equal('\u200fHello! English\u200f >> \u200fHello \u0647\u0644\u0627\u060d\u200f');
+    expect(mfEn.compile(msg)(data)).to.equal(
+      '\u200eHello! English\u200e >> \u200eHello \u0647\u0644\u0627\u060d\u200e'
+    );
+    expect(mfEg.compile(msg)(data)).to.equal(
+      '\u200fHello! English\u200f >> \u200fHello \u0647\u0644\u0627\u060d\u200f'
+    );
   });
 
-  it("should allow for a simple select", function() {
+  it('should allow for a simple select', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("I am {FEELING, select, a{happy} b{sad} other{indifferent}}.");
-    expect(mfunc({FEELING:"a"})).to.eql("I am happy.");
-    expect(mfunc({FEELING:"b"})).to.eql("I am sad.");
-    expect(mfunc({FEELING:"q"})).to.eql("I am indifferent.");
-    expect(mfunc({})).to.eql("I am indifferent.");
+    var mfunc = mf.compile(
+      'I am {FEELING, select, a{happy} b{sad} other{indifferent}}.'
+    );
+    expect(mfunc({ FEELING: 'a' })).to.eql('I am happy.');
+    expect(mfunc({ FEELING: 'b' })).to.eql('I am sad.');
+    expect(mfunc({ FEELING: 'q' })).to.eql('I am indifferent.');
+    expect(mfunc({})).to.eql('I am indifferent.');
   });
 
-  it("should allow for a simple plural form", function() {
+  it('should allow for a simple plural form', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("I have {FRIENDS, plural, one{one friend} other{# friends}}.");
-    expect(mfunc({FRIENDS:0})).to.eql("I have 0 friends.");
-    expect(mfunc({FRIENDS:1})).to.eql("I have one friend.");
-    expect(mfunc({FRIENDS:2})).to.eql("I have 2 friends.");
+    var mfunc = mf.compile(
+      'I have {FRIENDS, plural, one{one friend} other{# friends}}.'
+    );
+    expect(mfunc({ FRIENDS: 0 })).to.eql('I have 0 friends.');
+    expect(mfunc({ FRIENDS: 1 })).to.eql('I have one friend.');
+    expect(mfunc({ FRIENDS: 2 })).to.eql('I have 2 friends.');
   });
 
-  it("should allow for a simple selectordinal form", function() {
+  it('should allow for a simple selectordinal form', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("The {FLOOR, selectordinal, one{#st} two{#nd} few{#rd} other{#th}} floor.");
-    expect(mfunc({FLOOR:0})).to.eql("The 0th floor.");
-    expect(mfunc({FLOOR:1})).to.eql("The 1st floor.");
-    expect(mfunc({FLOOR:2})).to.eql("The 2nd floor.");
+    var mfunc = mf.compile(
+      'The {FLOOR, selectordinal, one{#st} two{#nd} few{#rd} other{#th}} floor.'
+    );
+    expect(mfunc({ FLOOR: 0 })).to.eql('The 0th floor.');
+    expect(mfunc({ FLOOR: 1 })).to.eql('The 1st floor.');
+    expect(mfunc({ FLOOR: 2 })).to.eql('The 2nd floor.');
   });
 
   it("should reject number injections of numbers that don't exist", function() {
     var mf = new MessageFormat('en');
     var mfunc = mf.compile(
-      "I have {FRIENDS, plural, one{one friend} other{# friends but {ENEMIES, plural, offset:1 " +
-      "=0{no enemies} =1{one nemesis} one{two enemies} other{one nemesis and # enemies}}}}."
+      'I have {FRIENDS, plural, one{one friend} other{# friends but {ENEMIES, plural, offset:1 ' +
+        '=0{no enemies} =1{one nemesis} one{two enemies} other{one nemesis and # enemies}}}}.'
     );
-    expect(mfunc({FRIENDS:0, ENEMIES: 0})).to.eql("I have 0 friends but no enemies.");
-    expect(function(){ var x = mfunc({}); }).to.throwError(/\bENEMIES\b.*non-numerical value/);
-    expect(function(){ var x = mfunc({FRIENDS:0}); }).to.throwError(/\bENEMIES\b.*non-numerical value/);
-    expect(mfunc({ENEMIES:1})).to.eql('I have undefined friends but one nemesis.');
+    expect(mfunc({ FRIENDS: 0, ENEMIES: 0 })).to.eql(
+      'I have 0 friends but no enemies.'
+    );
+    expect(function() {
+      var x = mfunc({});
+    }).to.throwError(/\bENEMIES\b.*non-numerical value/);
+    expect(function() {
+      var x = mfunc({ FRIENDS: 0 });
+    }).to.throwError(/\bENEMIES\b.*non-numerical value/);
+    expect(mfunc({ ENEMIES: 1 })).to.eql(
+      'I have undefined friends but one nemesis.'
+    );
   });
 
-  it("should not expose prototype members - selects", function() {
+  it('should not expose prototype members - selects', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("I am {FEELING, select, a{happy} hasOwnProperty{evil} other{indifferent}}.");
-    expect(mfunc({FEELING:"toString"})).to.eql("I am indifferent.");
+    var mfunc = mf.compile(
+      'I am {FEELING, select, a{happy} hasOwnProperty{evil} other{indifferent}}.'
+    );
+    expect(mfunc({ FEELING: 'toString' })).to.eql('I am indifferent.');
   });
 
-  it("should not expose prototype members - plurals", function() {
+  it('should not expose prototype members - plurals', function() {
     var mf = new MessageFormat('en');
-    var mfunc = mf.compile("I have {FRIENDS, plural, one{one friend} other{friends}}.");
-    expect(mfunc({FRIENDS:"toString"})).to.eql("I have friends.");
+    var mfunc = mf.compile(
+      'I have {FRIENDS, plural, one{one friend} other{friends}}.'
+    );
+    expect(mfunc({ FRIENDS: 'toString' })).to.eql('I have friends.');
   });
-
 });
-describe("Real World Uses", function() {
-
-  it("can correctly pull in a different pluralization rule set", function() {
+describe('Real World Uses', function() {
+  it('can correctly pull in a different pluralization rule set', function() {
     // note, cy.js was included in the html file for the browser
     // and then in the common.js file
     var mf = new MessageFormat('cy');
-    var mfunc = mf.compile("{NUM, plural, zero{a} one{b} two{c} few{d} many{e} other{f} =42{omg42}}");
-    expect(mfunc({NUM:0})).to.eql('a');
-    expect(mfunc({NUM:1})).to.eql('b');
-    expect(mfunc({NUM:2})).to.eql('c');
-    expect(mfunc({NUM:3})).to.eql('d');
-    expect(mfunc({NUM:6})).to.eql('e');
-    expect(mfunc({NUM:15})).to.eql('f');
-    expect(mfunc({NUM:42})).to.eql('omg42');
+    var mfunc = mf.compile(
+      '{NUM, plural, zero{a} one{b} two{c} few{d} many{e} other{f} =42{omg42}}'
+    );
+    expect(mfunc({ NUM: 0 })).to.eql('a');
+    expect(mfunc({ NUM: 1 })).to.eql('b');
+    expect(mfunc({ NUM: 2 })).to.eql('c');
+    expect(mfunc({ NUM: 3 })).to.eql('d');
+    expect(mfunc({ NUM: 6 })).to.eql('e');
+    expect(mfunc({ NUM: 15 })).to.eql('f');
+    expect(mfunc({ NUM: 42 })).to.eql('omg42');
   });
 
-  it("can parse complex, real-world messages with nested selects and plurals with offsets", function() {
-    var input = "" +
-    "{PERSON} added {PLURAL_NUM_PEOPLE, plural, offset:1" +
-    "     =0 {no one}"+
-    "     =1 {just {GENDER, select, male {him} female {her} other{them}}self}"+
-    "    one {{GENDER, select, male {him} female {her} other{them}}self and one other person}"+
-    "  other {{GENDER, select, male {him} female {her} other{them}}self and # other people}"+
-    "} to {GENDER, select,"+
-    "   male {his}"+
-    " female {her}"+
-    "  other {their}"+
-    "} group.";
+  it('can parse complex, real-world messages with nested selects and plurals with offsets', function() {
+    var input =
+      '' +
+      '{PERSON} added {PLURAL_NUM_PEOPLE, plural, offset:1' +
+      '     =0 {no one}' +
+      '     =1 {just {GENDER, select, male {him} female {her} other{them}}self}' +
+      '    one {{GENDER, select, male {him} female {her} other{them}}self and one other person}' +
+      '  other {{GENDER, select, male {him} female {her} other{them}}self and # other people}' +
+      '} to {GENDER, select,' +
+      '   male {his}' +
+      ' female {her}' +
+      '  other {their}' +
+      '} group.';
 
     var mf = new MessageFormat('en');
     var mf_func = mf.compile(input);
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 0,
-        PERSON : "Allie Sexton",
-        GENDER: "female"
-    })).to.eql('Allie Sexton added no one to her group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 0,
+        PERSON: 'Allie Sexton',
+        GENDER: 'female'
+      })
+    ).to.eql('Allie Sexton added no one to her group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 1,
-        PERSON : "Allie Sexton",
-        GENDER: "female"
-    })).to.eql('Allie Sexton added just herself to her group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 1,
+        PERSON: 'Allie Sexton',
+        GENDER: 'female'
+      })
+    ).to.eql('Allie Sexton added just herself to her group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 2,
-        PERSON : "Allie Sexton",
-        GENDER: "female"
-    })).to.eql('Allie Sexton added herself and one other person to her group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 2,
+        PERSON: 'Allie Sexton',
+        GENDER: 'female'
+      })
+    ).to.eql('Allie Sexton added herself and one other person to her group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 3,
-        PERSON : "Allie Sexton",
-        GENDER: "female"
-    })).to.eql('Allie Sexton added herself and 2 other people to her group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 3,
+        PERSON: 'Allie Sexton',
+        GENDER: 'female'
+      })
+    ).to.eql('Allie Sexton added herself and 2 other people to her group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 0,
-        PERSON : "Alex Sexton",
-        GENDER: "male"
-    })).to.eql('Alex Sexton added no one to his group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 0,
+        PERSON: 'Alex Sexton',
+        GENDER: 'male'
+      })
+    ).to.eql('Alex Sexton added no one to his group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 1,
-        PERSON : "Alex Sexton",
-        GENDER: "male"
-    })).to.eql('Alex Sexton added just himself to his group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 1,
+        PERSON: 'Alex Sexton',
+        GENDER: 'male'
+      })
+    ).to.eql('Alex Sexton added just himself to his group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 2,
-        PERSON : "Alex Sexton",
-        GENDER: "male"
-    })).to.eql('Alex Sexton added himself and one other person to his group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 2,
+        PERSON: 'Alex Sexton',
+        GENDER: 'male'
+      })
+    ).to.eql('Alex Sexton added himself and one other person to his group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 3,
-        PERSON : "Alex Sexton",
-        GENDER: "male"
-    })).to.eql('Alex Sexton added himself and 2 other people to his group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 3,
+        PERSON: 'Alex Sexton',
+        GENDER: 'male'
+      })
+    ).to.eql('Alex Sexton added himself and 2 other people to his group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 0,
-        PERSON : "Al Sexton"
-    })).to.eql('Al Sexton added no one to their group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 0,
+        PERSON: 'Al Sexton'
+      })
+    ).to.eql('Al Sexton added no one to their group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 1,
-        PERSON : "Al Sexton"
-    })).to.eql('Al Sexton added just themself to their group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 1,
+        PERSON: 'Al Sexton'
+      })
+    ).to.eql('Al Sexton added just themself to their group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 2,
-        PERSON : "Al Sexton"
-    })).to.eql('Al Sexton added themself and one other person to their group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 2,
+        PERSON: 'Al Sexton'
+      })
+    ).to.eql('Al Sexton added themself and one other person to their group.');
 
-    expect(mf_func({
-        PLURAL_NUM_PEOPLE : 3,
-        PERSON : "Al Sexton"
-    })).to.eql('Al Sexton added themself and 2 other people to their group.');
+    expect(
+      mf_func({
+        PLURAL_NUM_PEOPLE: 3,
+        PERSON: 'Al Sexton'
+      })
+    ).to.eql('Al Sexton added themself and 2 other people to their group.');
   });
-
 });
-describe("Module/CommonJS support", function() {
+describe('Module/CommonJS support', function() {
   var colorSrc = { red: 'red', blue: 'blue', green: 'green' };
   var cf = new MessageFormat('en').compile(colorSrc);
 
@@ -521,7 +647,7 @@ describe("Module/CommonJS support", function() {
     var moduleFmt = 'window.i18n';
     it('should work with `' + moduleFmt + '`', function() {
       eval(cf.toString(moduleFmt));
-      expect(window).to.have.property('i18n')
+      expect(window).to.have.property('i18n');
       var colors = window.i18n;
       expect(colors.red()).to.eql('red');
       expect(colors.blue()).to.eql('blue');

--- a/test/messages.js
+++ b/test/messages.js
@@ -23,11 +23,11 @@ describe('Messages', () => {
       }
     };
     msgData = mf.compile(msgSet);
-  })
+  });
 
   beforeEach(() => {
     messages = new Messages(msgData, 'en');
-  })
+  });
 
   it('constructor', () => {
     expect(messages).to.be.a(Messages);
@@ -46,7 +46,7 @@ describe('Messages', () => {
     expect(messages.defaultLocale).to.be('en');
     messages.defaultLocale = 'fi-FI';
     expect(messages.defaultLocale).to.be('fi');
-    messages._data['sv-SE'] = {}
+    messages._data['sv-SE'] = {};
     messages.defaultLocale = 'sv';
     expect(messages.defaultLocale).to.be('sv-SE');
     messages.defaultLocale = 'foo';
@@ -57,7 +57,7 @@ describe('Messages', () => {
     expect(messages.locale).to.be('en');
     messages.locale = 'fi-FI';
     expect(messages.locale).to.be('fi');
-    messages._data['sv-SE'] = {}
+    messages._data['sv-SE'] = {};
     messages.locale = 'sv';
     expect(messages.locale).to.be('sv-SE');
     messages.locale = 'foo';
@@ -86,9 +86,9 @@ describe('Messages', () => {
     expect(messages.resolveLocale('en')).to.be('en');
     expect(messages.resolveLocale('en-US')).to.be('en');
     expect(messages.resolveLocale('sv')).to.be(null);
-    messages._data['sv-SE'] = {}
+    messages._data['sv-SE'] = {};
     expect(messages.resolveLocale('sv')).to.be('sv-SE');
-  })
+  });
 
   it('get/set fallback', () => {
     expect(messages.getFallback()).to.eql([]);
@@ -107,7 +107,9 @@ describe('Messages', () => {
 
   it('get message', () => {
     expect(messages.get('b', { COUNT: 3 })).to.eql('This has 3 users.');
-    expect(messages.get(['c', 'd'], { P: 0.314 })).to.eql('We have 31% code coverage.');
+    expect(messages.get(['c', 'd'], { P: 0.314 })).to.eql(
+      'We have 31% code coverage.'
+    );
     expect(messages.get('e')).to.eql('e');
     messages.setFallback('en', ['foo', 'fi']);
     expect(messages.get('e')).to.eql('Minä puhun vain suomea.');
@@ -116,23 +118,25 @@ describe('Messages', () => {
   });
 
   it('get object', () => {
-    expect(messages.get('c')).to.have.property('d')
+    expect(messages.get('c')).to.have.property('d');
     messages.locale = 'fi';
-    expect(messages.get('c')).to.have.property('d')
-    expect(messages.get('c').d({ P: 0.628 })).to.eql('We have 63% code coverage.');
+    expect(messages.get('c')).to.have.property('d');
+    expect(messages.get('c').d({ P: 0.628 })).to.eql(
+      'We have 63% code coverage.'
+    );
     expect(messages.get([])).to.only.have.keys(['b', 'e']);
   });
 
   it('addMessages', () => {
     const mf = new MessageFormat('sv');
-    const sv = { e: 'Jag pratar lite svenska.' }
+    const sv = { e: 'Jag pratar lite svenska.' };
     messages.addMessages(mf.compile(sv), 'sv');
     expect(messages.availableLocales).to.eql(['en', 'fi', 'sv']);
-    messages.locale = 'sv'
+    messages.locale = 'sv';
     expect(messages.get('e')).to.eql('Jag pratar lite svenska.');
     expect(messages.getFallback()).to.eql(['en']);
     expect(messages.get([])).to.only.have.key('e');
-    messages.addMessages(() => 'z', null, ['x', 'y'])
+    messages.addMessages(() => 'z', null, ['x', 'y']);
     expect(messages.get(['x', 'y'])).to.eql('z');
   });
 });


### PR DESCRIPTION
With these various packages, it's starting to make sense to use proper tools to keep them harmonious.

The Prettier config just sets `singleQuote: true`, and the ESLint config is relatively limited as well (mostly just extending `eslint:recommended`) so the total number of corrections that needed to be made was pretty small.

Furthermore, the Travis CI tests have been updated to also lint the code & check the styling.