### PR TITLE
feat(loader): Add convert option, using messageformat-convert

### DIFF
--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -87,7 +87,7 @@ messages['ordinal-example']({ N: 1 });
 - [messageformat](https://messageformat.github.io/)
 - Loaders:
   - [Webpack v1](https://webpack.github.io/docs/using-loaders.html)
-  - [Webpack v2/3/4](https://webpack.js.org/concepts/loaders/)
+  - [Webpack v2+](https://webpack.js.org/concepts/loaders/)
 
 ## License
 

--- a/packages/loader/README.md
+++ b/packages/loader/README.md
@@ -18,6 +18,7 @@ For a working demo of the loader, run `npm install` in the `example/` directory,
   loader: require.resolve('messageformat-loader'),
   options: {
     biDiSupport: false,
+    convert: false,
     disablePluralKeyChecks: false,
     formatters: null,
     intlSupport: false,
@@ -63,19 +64,30 @@ messages['ordinal-example']({ N: 1 });
 
 ## Options
 
-- [`locale`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#MessageFormat) The [CLDR language code](http://www.unicode.org/cldr/charts/29/supplemental/language_territory_information.html) or codes to pass to [messageformat.js](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html). If using multiple locales at the same time, exact matches to a locale code in the data structure keys will select that locale within it (as in [`example/src/messages.json`](example/src/messages.json)). Defaults to `en`.
-- [`disablePluralKeyChecks`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#disablePluralKeyChecks) By default, messageformat.js throws an error when a statement uses a non-numerical key that will never be matched as a pluralization category for the current locale. Use this argument to disable the validation and allow unused plural keys. Defaults to `false`.
-- [`intlSupport`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setIntlSupport) Enable or disable support for the default formatters, which require the Intl object. Defaults to `false`.
-- [`biDiSupport`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setBiDiSupport) Enable or disable the addition of Unicode control characters to all input to preserve the integrity of the output when mixing LTR and RTL text. Defaults to `false`.
-- [`formatters`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#addFormatters) Add custom formatter functions to this MessageFormat instance.
-- [`strictNumberSign`](https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setStrictNumberSign) Follow the stricter ICU MessageFormat spec and throw a runtime error if # is used with non-numeric input. Defaults to `false`.
+- [`locale`] The [CLDR language code] or codes to pass to [messageformat.js]. If using multiple locales at the same time, exact matches to a locale code in the data structure keys will select that locale within it (as in [`example/src/messages.json`](example/src/messages.json)). Defaults to `en`.
+- [`convert`] Use `messageformat-convert` to convert non-MessageFormat syntax and plural objects into MessageFormat. Use an object value to configure. Defaults to `false`.
+- [`disablePluralKeyChecks`] By default, messageformat.js throws an error when a statement uses a non-numerical key that will never be matched as a pluralization category for the current locale. Use this argument to disable the validation and allow unused plural keys. Defaults to `false`.
+- [`intlSupport`] Enable or disable support for the default formatters, which require the Intl object. Defaults to `false`.
+- [`biDiSupport`] Enable or disable the addition of Unicode control characters to all input to preserve the integrity of the output when mixing LTR and RTL text. Defaults to `false`.
+- [`formatters`] Add custom formatter functions to this MessageFormat instance.
+- [`strictNumberSign`] Follow the stricter ICU MessageFormat spec and throw a runtime error if # is used with non-numeric input. Defaults to `false`.
+
+[`locale`]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#MessageFormat
+[cldr language code]: http://www.unicode.org/cldr/charts/29/supplemental/language_territory_information.html
+[messageformat.js]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html
+[`convert`]: https://github.com/messageformat/messageformat/tree/master/packages/convert
+[`disablepluralkeychecks`]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#disablePluralKeyChecks
+[`intlsupport`]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setIntlSupport
+[`bidisupport`]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setBiDiSupport
+[`formatters`]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#addFormatters
+[`strictnumbersign`]: https://messageformat.github.io/messageformat.js/doc/MessageFormat.html#setStrictNumberSign
 
 ## Links
 
 - [messageformat](https://messageformat.github.io/)
 - Loaders:
   - [Webpack v1](https://webpack.github.io/docs/using-loaders.html)
-  - [Webpack v2/3](https://webpack.js.org/concepts/loaders/)
+  - [Webpack v2/3/4](https://webpack.js.org/concepts/loaders/)
 
 ## License
 

--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -1,12 +1,20 @@
 var loaderUtils = require('loader-utils');
 var MessageFormat = require('messageformat');
+var convert = require('messageformat-convert');
 
 module.exports = function(content) {
+  var messages = JSON.parse(content);
   var options = loaderUtils.getOptions(this) || {};
   var locale = options.locale;
+  if (options.convert) {
+    var cm = convert(messages, options.convert);
+    if (!locale) {
+      locale = cm.locales;
+    }
+    messages = cm.translations;
+  }
   if (typeof locale === 'string' && locale.indexOf(',') !== -1)
     locale = locale.split(',');
-  var messages = JSON.parse(content);
   var messageFormat = new MessageFormat(locale);
   if (options.disablePluralKeyChecks) {
     messageFormat.disablePluralKeyChecks();

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -18,7 +18,8 @@
   "repository": "messageformat/messageformat",
   "main": "index.js",
   "dependencies": {
-    "loader-utils": "^1.2.3"
+    "loader-utils": "^1.2.3",
+    "messageformat-convert": "^0.2.0"
   },
   "devDependencies": {
     "messageformat": "^2.0.4"


### PR DESCRIPTION
This adds a new default-false `convert` option, which allows using non-MessageFormat input as a data source by first converting said input into MessageFormat. With the default options it handles the format used by [Rails i18n](https://guides.rubyonrails.org/i18n.html), but it's configurable for other formats as well.

This is a feature of `messageformat-yaml-loader`, and a part of its merge into `messageformat-loader`.

`messageformat-convert` is atm only available in this repo, but it'll get published on npm  pretty soon.