### PR TITLE
Fix dependencies and two broken tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,56 +25,58 @@
       }
     },
     "@lerna/add": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.6.0.tgz",
-      "integrity": "sha512-aFVekkHMno3hj1Vg3EiIpAwrZ4g34i8z4KrCx7ATY6BRuxVT4Nt/Nk3l2k6gEOq3tWUDtUctLHxIAo14FI8sng==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.13.1.tgz",
+      "integrity": "sha512-cXk42YbuhzEnADCK8Qte5laC9Qo03eJLVnr0qKY85jQUM/T4URe3IIUemqpg0CpVATrB+Vz+iNdeqw9ng1iALw==",
       "dev": true,
       "requires": {
-        "@lerna/bootstrap": "^3.6.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/filter-options": "^3.6.0",
-        "@lerna/npm-conf": "^3.4.1",
-        "@lerna/validation-error": "^3.6.0",
+        "@lerna/bootstrap": "3.13.1",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
-        "libnpm": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
         "p-map": "^1.2.0",
+        "pacote": "^9.5.0",
         "semver": "^5.5.0"
       }
     },
     "@lerna/batch-packages": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.6.0.tgz",
-      "integrity": "sha512-khG15B+EFLH3Oms6A6WsMAy54DrnKIhEAm6CCATN2BKnBkNgitYjLN2vKBzlR2LfQpTkgub67QKIJkMFQcK1Sg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.13.0.tgz",
+      "integrity": "sha512-TgLBTZ7ZlqilGnzJ3xh1KdAHcySfHytgNRTdG9YomfriTU6kVfp1HrXxKJYVGs7ClPUNt2CTFEOkw0tMBronjw==",
       "dev": true,
       "requires": {
-        "@lerna/package-graph": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
-        "libnpm": "^2.0.1"
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/bootstrap": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.6.0.tgz",
-      "integrity": "sha512-z6rZQw/aLEN+ragWRYqIIVwA9rDv3QtmRc5VyIRrlV/JiuGpq67FcSR6BrCMc/A7UJ9Kx95+bESm/HUwheKoiQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.13.1.tgz",
+      "integrity": "sha512-mKdi5Ds5f82PZwEFyB9/W60I3iELobi1i87sTeVrbJh/um7GvqpSPy7kG/JPxyOdMpB2njX6LiJgw+7b6BEPWw==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.6.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/filter-options": "^3.6.0",
-        "@lerna/has-npm-version": "^3.3.0",
-        "@lerna/npm-conf": "^3.4.1",
-        "@lerna/npm-install": "^3.6.0",
-        "@lerna/package-graph": "^3.6.0",
-        "@lerna/rimraf-dir": "^3.6.0",
-        "@lerna/run-lifecycle": "^3.6.0",
-        "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/symlink-binary": "^3.6.0",
-        "@lerna/symlink-dependencies": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/has-npm-version": "3.13.0",
+        "@lerna/npm-install": "3.13.0",
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/rimraf-dir": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/symlink-binary": "3.13.0",
+        "@lerna/symlink-dependencies": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
         "get-port": "^3.2.0",
-        "libnpm": "^2.0.1",
         "multimatch": "^2.1.0",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0",
@@ -84,32 +86,32 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.6.0.tgz",
-      "integrity": "sha512-L1SXTtQrsv+4F5Knw5sW/nGnMJq+bbOzhZX2srJ10WsuHuzk3cJWAi7dVEsS3RPKUw9DWOuHKy86o3v6byEiqA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.13.1.tgz",
+      "integrity": "sha512-BRXitEJGOkoudbxEewW7WhjkLxFD+tTk4PrYpHLyCBk63pNTWtQLRE6dc1hqwh4emwyGncoyW6RgXfLgMZgryw==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "^3.6.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/listable": "^3.6.0",
-        "@lerna/output": "^3.6.0",
-        "@lerna/version": "^3.6.0"
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/listable": "3.13.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/version": "3.13.1"
       }
     },
     "@lerna/check-working-tree": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.6.0.tgz",
-      "integrity": "sha512-Ioy1t2aVasAwhY1Oi5kfpwbW9RDupxxVVu2t2c1EeBYYCu3jIt1A5ad34gidgsKyiG3HeBEVziI4Uaihnb96ZQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.13.0.tgz",
+      "integrity": "sha512-dsdO15NXX5To+Q53SYeCrBEpiqv4m5VkaPZxbGQZNwoRen1MloXuqxSymJANQn+ZLEqarv5V56gydebeROPH5A==",
       "dev": true,
       "requires": {
-        "@lerna/describe-ref": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0"
+        "@lerna/describe-ref": "3.13.0",
+        "@lerna/validation-error": "3.13.0"
       }
     },
     "@lerna/child-process": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.3.0.tgz",
-      "integrity": "sha512-q2d/OPlNX/cBXB6Iz1932RFzOmOHq6ZzPjqebkINNaTojHWuuRpvJJY4Uz3NGpJ3kEtPDvBemkZqUBTSO5wb1g==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.13.0.tgz",
+      "integrity": "sha512-0iDS8y2jiEucD4fJHEzKoc8aQJgm7s+hG+0RmDNtfT0MM3n17pZnf5JOMtS1FJp+SEXOjMKQndyyaDIPFsnp6A==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.1",
@@ -118,278 +120,338 @@
       }
     },
     "@lerna/clean": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.6.0.tgz",
-      "integrity": "sha512-4LodI/jh8IEYtqnrY/OFSpWn5YfDWoDv+5QjiJpd91EjW9vjmkvyhzQ5fG9KtltwgYVn/NJ5zlI1WfmMEXvFFQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.13.1.tgz",
+      "integrity": "sha512-myGIaXv7RUO2qCFZXvx8SJeI+eN6y9SUD5zZ4/LvNogbOiEIlujC5lUAqK65rAHayQ9ltSa/yK6Xv510xhZXZQ==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.6.0",
-        "@lerna/filter-options": "^3.6.0",
-        "@lerna/prompt": "^3.6.0",
-        "@lerna/rimraf-dir": "^3.6.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/rimraf-dir": "3.13.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0",
         "p-waterfall": "^1.0.0"
       }
     },
     "@lerna/cli": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.6.0.tgz",
-      "integrity": "sha512-FGCx7XOLpqmU5eFOlo0Lt0hRZraxSUTEWM0bce0p+HNpOxBc91o6d2tenW1azPYFP9HzsMQey1NBtU0ofJJeog==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.13.0.tgz",
+      "integrity": "sha512-HgFGlyCZbYaYrjOr3w/EsY18PdvtsTmDfpUQe8HwDjXlPeCCUgliZjXLOVBxSjiOvPeOSwvopwIHKWQmYbwywg==",
       "dev": true,
       "requires": {
-        "@lerna/global-options": "^3.1.3",
+        "@lerna/global-options": "3.13.0",
         "dedent": "^0.7.0",
-        "libnpm": "^2.0.1",
+        "npmlog": "^4.1.2",
         "yargs": "^12.0.1"
       }
     },
     "@lerna/collect-updates": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.6.0.tgz",
-      "integrity": "sha512-knliEz3phY51SGnwDhhYqx6SJN6y9qh/gZrZgQ7ogqz1UgA/MyJb27gszjsyyG6jUQshimBpjsG7OMwjt8+n9A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.13.0.tgz",
+      "integrity": "sha512-uR3u6uTzrS1p46tHQ/mlHog/nRJGBqskTHYYJbgirujxm6FqNh7Do+I1Q/7zSee407G4lzsNxZdm8IL927HemQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/describe-ref": "^3.6.0",
-        "libnpm": "^2.0.1",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/describe-ref": "3.13.0",
         "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
         "slash": "^1.0.0"
       }
     },
     "@lerna/command": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.6.0.tgz",
-      "integrity": "sha512-BGpXaY2WrxPcIiZX0aATO2HQBatvYT7Qy46lqMnV9RrTePYJ1PPbX1nMzLXSxgrnnlTcTwJNEkw/TL9Xzrph7Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.13.1.tgz",
+      "integrity": "sha512-SYWezxX+iheWvzRoHCrbs8v5zHPaxAx3kWvZhqi70vuGsdOVAWmaG4IvHLn11ztS+Vpd5PM+ztBWSbnykpLFKQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/package-graph": "^3.6.0",
-        "@lerna/project": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
-        "@lerna/write-log-file": "^3.6.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/project": "3.13.1",
+        "@lerna/validation-error": "3.13.0",
+        "@lerna/write-log-file": "3.13.0",
         "dedent": "^0.7.0",
         "execa": "^1.0.0",
         "is-ci": "^1.0.10",
-        "libnpm": "^2.0.1",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.5",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/conventional-commits": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.6.0.tgz",
-      "integrity": "sha512-KkY3wd7w/tj76EEIhTMYZlSBk/5WkT2NA9Gr/EuSwKV70PYyVA55l1OGlikBUAnuqIjwyfw9x3y+OcbYI4aNEg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.13.0.tgz",
+      "integrity": "sha512-BeAgcNXuocmLhPxnmKU2Vy8YkPd/Uo+vu2i/p3JGsUldzrPC8iF3IDxH7fuXpEFN2Nfogu7KHachd4tchtOppA==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.6.0",
-        "conventional-changelog-angular": "^5.0.2",
-        "conventional-changelog-core": "^3.1.5",
+        "@lerna/validation-error": "3.13.0",
+        "conventional-changelog-angular": "^5.0.3",
+        "conventional-changelog-core": "^3.1.6",
         "conventional-recommended-bump": "^4.0.4",
         "fs-extra": "^7.0.0",
         "get-stream": "^4.0.0",
-        "libnpm": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
+        "pify": "^3.0.0",
         "semver": "^5.5.0"
       }
     },
     "@lerna/create": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.6.0.tgz",
-      "integrity": "sha512-21OunW25Y3Q/oynqWVk0znQFBvZ5tHyLPhzkJeomGmOj0il1RdOUiChu9G9AYsCaLDwBFR0ZFqvTgJ5iw/eaIg==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.13.1.tgz",
+      "integrity": "sha512-pLENMXgTkQuvKxAopjKeoLOv9fVUCnpTUD7aLrY5d95/1xqSZlnsOcQfUYcpMf3GpOvHc8ILmI5OXkPqjAf54g==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/npm-conf": "^3.4.1",
-        "@lerna/validation-error": "^3.6.0",
-        "camelcase": "^4.1.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "camelcase": "^5.0.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "globby": "^8.0.1",
         "init-package-json": "^1.10.3",
-        "libnpm": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
         "p-reduce": "^1.0.0",
+        "pacote": "^9.5.0",
         "pify": "^3.0.0",
         "semver": "^5.5.0",
         "slash": "^1.0.0",
         "validate-npm-package-license": "^3.0.3",
         "validate-npm-package-name": "^3.0.0",
         "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "dev": true
+        }
       }
     },
     "@lerna/create-symlink": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.6.0.tgz",
-      "integrity": "sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.13.0.tgz",
+      "integrity": "sha512-PTvg3jAAJSAtLFoZDsuTMv1wTOC3XYIdtg54k7uxIHsP8Ztpt+vlilY/Cni0THAqEMHvfiToel76Xdta4TU21Q==",
       "dev": true,
       "requires": {
         "cmd-shim": "^2.0.2",
         "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/describe-ref": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.6.0.tgz",
-      "integrity": "sha512-hVZJ2hYVbrrNiEG+dEg/Op4pYAbROkDZdiIUabAJffr0T/frcN+5es2HfmOC//4+78Cs1M9iTyQRoyC1RXS2BQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.13.0.tgz",
+      "integrity": "sha512-UJefF5mLxLae9I2Sbz5RLYGbqbikRuMqdgTam0MS5OhXnyuuKYBUpwBshCURNb1dPBXTQhSwc7+oUhORx8ojCg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "libnpm": "^2.0.1"
+        "@lerna/child-process": "3.13.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/diff": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.6.0.tgz",
-      "integrity": "sha512-p5+VyYKuAnw6NFVrT4s9eBubFZEYlJmiR1mdVlwNtohqS86gERjrPtI0unUK/pxFKb1U2ZNo4fhSlPd+pLwfHg==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.13.1.tgz",
+      "integrity": "sha512-cKqmpONO57mdvxtp8e+l5+tjtmF04+7E+O0QEcLcNUAjC6UR2OSM77nwRCXDukou/1h72JtWs0jjcdYLwAmApg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
-        "libnpm": "^2.0.1"
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/validation-error": "3.13.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/exec": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.6.0.tgz",
-      "integrity": "sha512-lwLYASpS8FoQpVYLBpoZlS7bpzkO9pD3D9XeDDKZBodDhdZeCEx2Md2CxZU1RKYDSVIXA8oObvlUh1FEhRQv2w==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.13.1.tgz",
+      "integrity": "sha512-I34wEP9lrAqqM7tTXLDxv/6454WFzrnXDWpNDbiKQiZs6SIrOOjmm6I4FiQsx+rU3o9d+HkC6tcUJRN5mlJUgA==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.6.0",
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/filter-options": "^3.6.0",
-        "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.6.0"
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/validation-error": "3.13.0"
       }
     },
     "@lerna/filter-options": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.6.0.tgz",
-      "integrity": "sha512-6iUMZuvvXPL5EAF7Zo9azaZ6FxOq6tGbiSX8fUXgCdN+jlRjorvkzR+E0HS4bEGTWmV446lnLwdQLZuySfLcbQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.13.0.tgz",
+      "integrity": "sha512-SRp7DCo9zrf+7NkQxZMkeyO1GRN6GICoB9UcBAbXhLbWisT37Cx5/6+jh49gYB63d/0/WYHSEPMlheUrpv1Srw==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "^3.6.0",
-        "@lerna/filter-packages": "^3.6.0",
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/filter-packages": "3.13.0",
         "dedent": "^0.7.0"
       }
     },
     "@lerna/filter-packages": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.6.0.tgz",
-      "integrity": "sha512-O/nIENV3LOqp/TiUIw3Ir6L/wUGFDeYBdJsJTQDlTAyHZsgYA1OIn9FvlW8nqBu1bNLzoBVHXh3c5azx1kE+Hg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.13.0.tgz",
+      "integrity": "sha512-RWiZWyGy3Mp7GRVBn//CacSnE3Kw82PxE4+H6bQ3pDUw/9atXn7NRX+gkBVQIYeKamh7HyumJtyOKq3Pp9BADQ==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.6.0",
-        "libnpm": "^2.0.1",
-        "multimatch": "^2.1.0"
+        "@lerna/validation-error": "3.13.0",
+        "multimatch": "^2.1.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/get-npm-exec-opts": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz",
-      "integrity": "sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.13.0.tgz",
+      "integrity": "sha512-Y0xWL0rg3boVyJk6An/vurKzubyJKtrxYv2sj4bB8Mc5zZ3tqtv0ccbOkmkXKqbzvNNF7VeUt1OJ3DRgtC/QZw==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/get-packed": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.13.0.tgz",
+      "integrity": "sha512-EgSim24sjIjqQDC57bgXD9l22/HCS93uQBbGpkzEOzxAVzEgpZVm7Fm1t8BVlRcT2P2zwGnRadIvxTbpQuDPTg==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8"
+      },
+      "dependencies": {
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
+      }
+    },
+    "@lerna/github-client": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.13.1.tgz",
+      "integrity": "sha512-iPLUp8FFoAKGURksYEYZzfuo9TRA+NepVlseRXFaWlmy36dCQN20AciINpoXiXGoHcEUHXUKHQvY3ARFdMlf3w==",
+      "dev": true,
+      "requires": {
+        "@lerna/child-process": "3.13.0",
+        "@octokit/plugin-enterprise-rest": "^2.1.1",
+        "@octokit/rest": "^16.16.0",
+        "git-url-parse": "^11.1.2",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/global-options": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.1.3.tgz",
-      "integrity": "sha512-LVeZU/Zgc0XkHdGMRYn+EmHfDmmYNwYRv3ta59iCVFXLVp7FRFWF7oB1ss/WRa9x/pYU0o6L8as/5DomLUGASA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/global-options/-/global-options-3.13.0.tgz",
+      "integrity": "sha512-SlZvh1gVRRzYLVluz9fryY1nJpZ0FHDGB66U9tFfvnnxmueckRQxLopn3tXj3NU1kc3QANT2I5BsQkOqZ4TEFQ==",
       "dev": true
     },
     "@lerna/has-npm-version": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.3.0.tgz",
-      "integrity": "sha512-GX7omRep1eBRZHgjZLRw3MpBJSdA5gPZFz95P7rxhpvsiG384Tdrr/cKFMhm0A09yq27Tk/nuYTaZIj7HsVE6g==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.13.0.tgz",
+      "integrity": "sha512-Oqu7DGLnrMENPm+bPFGOHnqxK8lCnuYr6bk3g/CoNn8/U0qgFvHcq6Iv8/Z04TsvleX+3/RgauSD2kMfRmbypg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
+        "@lerna/child-process": "3.13.0",
         "semver": "^5.5.0"
       }
     },
     "@lerna/import": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.6.0.tgz",
-      "integrity": "sha512-8jxNRbAaa4mvMJr0u+sy75gMFPyWfxLHEp+pDs73x1oqMZhpS8O5901QMnpZyRyOvJRhoBJd5hBX2dpsLxC6Xw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.13.1.tgz",
+      "integrity": "sha512-A1Vk1siYx1XkRl6w+zkaA0iptV5TIynVlHPR9S7NY0XAfhykjztYVvwtxarlh6+VcNrO9We6if0+FXCrfDEoIg==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/prompt": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "p-map-series": "^1.0.0"
       }
     },
     "@lerna/init": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.6.0.tgz",
-      "integrity": "sha512-MTLy3rmMdvpXRmDdoYiVPx7I8sXH4dquq/0MxntL5VxSVh/ZS1HsbrjyRqpdkUKWD9QguxR/w0pzOjVvCeM8CQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.13.1.tgz",
+      "integrity": "sha512-M59WACqim8WkH5FQEGOCEZ89NDxCKBfFTx4ZD5ig3LkGyJ8RdcJq5KEfpW/aESuRE9JrZLzVr0IjKbZSxzwEMA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.6.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/command": "3.13.1",
         "fs-extra": "^7.0.0",
         "p-map": "^1.2.0",
         "write-json-file": "^2.3.0"
       }
     },
     "@lerna/link": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.6.0.tgz",
-      "integrity": "sha512-Xk8TTAE4EWGyhxLuPxWdyS7i7vfsM5igb6tEyhZm94XUdlA4PmMOYe25BfO7SM/9LYroFknZeDyWAebye3r+PA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.13.1.tgz",
+      "integrity": "sha512-N3h3Fj1dcea+1RaAoAdy4g2m3fvU7m89HoUn5X/Zcw5n2kPoK8kTO+NfhNAatfRV8VtMXst8vbNrWQQtfm0FFw==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.6.0",
-        "@lerna/package-graph": "^3.6.0",
-        "@lerna/symlink-dependencies": "^3.6.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/package-graph": "3.13.0",
+        "@lerna/symlink-dependencies": "3.13.0",
         "p-map": "^1.2.0",
         "slash": "^1.0.0"
       }
     },
     "@lerna/list": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.6.0.tgz",
-      "integrity": "sha512-hlQOJkg8K3XXUVXotofP71XsgkhXkkmU/EkqlNg15D78MjzhT+p1wCbG5m89K3tzvjcWVeZwU6L0elaOIXVyCw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.13.1.tgz",
+      "integrity": "sha512-635iRbdgd9gNvYLLIbYdQCQLr+HioM5FGJLFS0g3DPGygr6iDR8KS47hzCRGH91LU9NcM1mD1RoT/AChF+QbiA==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.6.0",
-        "@lerna/filter-options": "^3.6.0",
-        "@lerna/listable": "^3.6.0",
-        "@lerna/output": "^3.6.0"
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/listable": "3.13.0",
+        "@lerna/output": "3.13.0"
       }
     },
     "@lerna/listable": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.6.0.tgz",
-      "integrity": "sha512-fz63+zlqrJ9KQxIiv0r7qtufM4DEinSayAuO8YJuooz+1ctIP7RvMEQNvYI/E9tDlUo9Q0de68b5HbKrpmA5rQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.13.0.tgz",
+      "integrity": "sha512-liYJ/WBUYP4N4MnSVZuLUgfa/jy3BZ02/1Om7xUY09xGVSuNVNEeB8uZUMSC+nHqFHIsMPZ8QK9HnmZb1E/eTA==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/batch-packages": "3.13.0",
         "chalk": "^2.3.1",
         "columnify": "^1.5.4"
       }
     },
     "@lerna/log-packed": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.6.0.tgz",
-      "integrity": "sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.13.0.tgz",
+      "integrity": "sha512-Rmjrcz+6aM6AEcEVWmurbo8+AnHOvYtDpoeMMJh9IZ9SmZr2ClXzmD7wSvjTQc8BwOaiWjjC/ukcT0UYA2m7wg==",
       "dev": true,
       "requires": {
         "byte-size": "^4.0.3",
         "columnify": "^1.5.4",
         "has-unicode": "^2.0.1",
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/npm-conf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.4.1.tgz",
-      "integrity": "sha512-i9G6DnbCqiAqxKx2rSXej/n14qxlV/XOebL6QZonxJKzNTB+Q2wglnhTXmfZXTPJfoqimLaY4NfAEtbOXRWOXQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.13.0.tgz",
+      "integrity": "sha512-Jg2kANsGnhg+fbPEzE0X9nX5oviEAvWj0nYyOkcE+cgWuT7W0zpnPXC4hA4C5IPQGhwhhh0IxhWNNHtjTuw53g==",
       "dev": true,
       "requires": {
         "config-chain": "^1.1.11",
@@ -397,201 +459,261 @@
       }
     },
     "@lerna/npm-dist-tag": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.6.0.tgz",
-      "integrity": "sha512-qX6IfQPX9Tum1LRjvjgj/yr2FYbc9dfHyeh7RI9zJ8pGncWbksBmnMcvoxF0Eu4+d7MjjIGfEnIp9LIl4MHSIA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.13.0.tgz",
+      "integrity": "sha512-mcuhw34JhSRFrbPn0vedbvgBTvveG52bR2lVE3M3tfE8gmR/cKS/EJFO4AUhfRKGCTFn9rjaSEzlFGYV87pemQ==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1",
-        "npm-registry-fetch": "^3.8.0"
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.9.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/npm-install": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.6.0.tgz",
-      "integrity": "sha512-RKV31VdrBZKjmKfq25JG4mIHJ8NAOsLKq/aYSaBs8zP+uwXH7RU39saVfv9ReKiAzhKE2ghOG2JeMdIHtYnPNA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.13.0.tgz",
+      "integrity": "sha512-qNyfts//isYQxore6fsPorNYJmPVKZ6tOThSH97tP0aV91zGMtrYRqlAoUnDwDdAjHPYEM16hNujg2wRmsqqIw==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.6.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/get-npm-exec-opts": "3.13.0",
         "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npmlog": "^4.1.2",
         "signal-exit": "^3.0.2",
         "write-pkg": "^3.1.0"
       }
     },
     "@lerna/npm-publish": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.6.0.tgz",
-      "integrity": "sha512-k4yF8ursajoGRlJeRh7xdeGN0HV/ALt5qImUnpTliux0213jqxA0YigiD8WSaXpvSqxSFyvh38DbJhhy9q+NuQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.13.0.tgz",
+      "integrity": "sha512-y4WO0XTaf9gNRkI7as6P2ItVDOxmYHwYto357fjybcnfXgMqEA94c3GJ++jU41j0A9vnmYC6/XxpTd9sVmH9tA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.6.0",
-        "@lerna/has-npm-version": "^3.3.0",
-        "@lerna/log-packed": "^3.6.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "figgy-pudding": "^3.5.1",
         "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
-        "p-map": "^1.2.0"
+        "libnpmpublish": "^1.1.1",
+        "npmlog": "^4.1.2",
+        "pify": "^3.0.0",
+        "read-package-json": "^2.0.13"
       }
     },
     "@lerna/npm-run-script": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.6.0.tgz",
-      "integrity": "sha512-6DRNFma30ex9r1a8mMDXziSRHf1/mo//hnvW1Zc1ctBh+7PU4I8n3A2ht/+742vtoTQH93Iqs3QSJl2KOLSsYg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.13.0.tgz",
+      "integrity": "sha512-hiL3/VeVp+NFatBjkGN8mUdX24EfZx9rQlSie0CMgtjc7iZrtd0jCguLomSCRHYjJuvqgbp+LLYo7nHVykfkaQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.6.0",
-        "libnpm": "^2.0.1"
+        "@lerna/child-process": "3.13.0",
+        "@lerna/get-npm-exec-opts": "3.13.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/output": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.6.0.tgz",
-      "integrity": "sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.13.0.tgz",
+      "integrity": "sha512-7ZnQ9nvUDu/WD+bNsypmPG5MwZBwu86iRoiW6C1WBuXXDxM5cnIAC1m2WxHeFnjyMrYlRXM9PzOQ9VDD+C15Rg==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
+      }
+    },
+    "@lerna/pack-directory": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.13.1.tgz",
+      "integrity": "sha512-kXnyqrkQbCIZOf1054N88+8h0ItC7tUN5v9ca/aWpx298gsURpxUx/1TIKqijL5TOnHMyIkj0YJmnH/PyBVLKA==",
+      "dev": true,
+      "requires": {
+        "@lerna/get-packed": "3.13.0",
+        "@lerna/package": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-packlist": "^1.4.1",
+        "npmlog": "^4.1.2",
+        "tar": "^4.4.8",
+        "temp-write": "^3.4.0"
+      },
+      "dependencies": {
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "@lerna/package": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.6.0.tgz",
-      "integrity": "sha512-XbXcjwPKA1V640mqjEicpBriO6QcNtocdfLAtEUP4uCKkRx5r9h7DdznQMCoSJYJF6Gh/PpLokPUItfMhJP3Hg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.13.0.tgz",
+      "integrity": "sha512-kSKO0RJQy093BufCQnkhf1jB4kZnBvL7kK5Ewolhk5gwejN+Jofjd8DGRVUDUJfQ0CkW1o6GbUeZvs8w8VIZDg==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1",
+        "load-json-file": "^4.0.0",
+        "npm-package-arg": "^6.1.0",
         "write-pkg": "^3.1.0"
       }
     },
     "@lerna/package-graph": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.6.0.tgz",
-      "integrity": "sha512-Xtldh3DTiC3cPDrs6OY5URiuRXGPMIN6uFKcx59rOu3TkqYRt346jRyX+hm85996Y/pboo3+JuQlonvuEP/9QQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.13.0.tgz",
+      "integrity": "sha512-3mRF1zuqFE1HEFmMMAIggXy+f+9cvHhW/jzaPEVyrPNLKsyfJQtpTNzeI04nfRvbAh+Gd2aNksvaW/w3xGJnnw==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.6.0",
-        "libnpm": "^2.0.1",
+        "@lerna/validation-error": "3.13.0",
+        "npm-package-arg": "^6.1.0",
         "semver": "^5.5.0"
       }
     },
     "@lerna/project": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.6.0.tgz",
-      "integrity": "sha512-pEOZF1igGFqs+qWog6cJWqVyBUX21xSqrlcgeN0yzqzI36VMHozmf/u7dgclIb5MylWk5Yp87KCKswBF4hrcuQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.13.1.tgz",
+      "integrity": "sha512-/GoCrpsCCTyb9sizk1+pMBrIYchtb+F1uCOn3cjn9yenyG/MfYEnlfrbV5k/UDud0Ei75YBLbmwCbigHkAKazQ==",
       "dev": true,
       "requires": {
-        "@lerna/package": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
-        "cosmiconfig": "^5.0.2",
+        "@lerna/package": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "cosmiconfig": "^5.1.0",
         "dedent": "^0.7.0",
         "dot-prop": "^4.2.0",
         "glob-parent": "^3.1.0",
         "globby": "^8.0.1",
-        "libnpm": "^2.0.1",
         "load-json-file": "^4.0.0",
+        "npmlog": "^4.1.2",
         "p-map": "^1.2.0",
         "resolve-from": "^4.0.0",
         "write-json-file": "^2.3.0"
       }
     },
     "@lerna/prompt": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.6.0.tgz",
-      "integrity": "sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.13.0.tgz",
+      "integrity": "sha512-P+lWSFokdyvYpkwC3it9cE0IF2U5yy2mOUbGvvE4iDb9K7TyXGE+7lwtx2thtPvBAfIb7O13POMkv7df03HJeA==",
       "dev": true,
       "requires": {
         "inquirer": "^6.2.0",
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/publish": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.6.0.tgz",
-      "integrity": "sha512-F2bT96ZS7NJfid6T4a6TSanpVUQ4VOuhjPBPX2hagt5gnocm7lluvAFR7dl/cbEgmKIg2zJQnfAPTYjrtxXMVg==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.13.1.tgz",
+      "integrity": "sha512-KhCJ9UDx76HWCF03i5TD7z5lX+2yklHh5SyO8eDaLptgdLDQ0Z78lfGj3JhewHU2l46FztmqxL/ss0IkWHDL+g==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.6.0",
-        "@lerna/check-working-tree": "^3.6.0",
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/collect-updates": "^3.6.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/describe-ref": "^3.6.0",
-        "@lerna/get-npm-exec-opts": "^3.6.0",
-        "@lerna/npm-conf": "^3.4.1",
-        "@lerna/npm-dist-tag": "^3.6.0",
-        "@lerna/npm-publish": "^3.6.0",
-        "@lerna/output": "^3.6.0",
-        "@lerna/prompt": "^3.6.0",
-        "@lerna/run-lifecycle": "^3.6.0",
-        "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.6.0",
-        "@lerna/version": "^3.6.0",
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/check-working-tree": "3.13.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/describe-ref": "3.13.0",
+        "@lerna/log-packed": "3.13.0",
+        "@lerna/npm-conf": "3.13.0",
+        "@lerna/npm-dist-tag": "3.13.0",
+        "@lerna/npm-publish": "3.13.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/pack-directory": "3.13.1",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/pulse-till-done": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
+        "@lerna/version": "3.13.1",
+        "figgy-pudding": "^3.5.1",
         "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
-        "npm-registry-fetch": "^3.8.0",
+        "libnpmaccess": "^3.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.9.0",
+        "npmlog": "^4.1.2",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-pipe": "^1.2.0",
         "p-reduce": "^1.0.0",
+        "pacote": "^9.5.0",
         "semver": "^5.5.0"
       }
     },
+    "@lerna/pulse-till-done": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/pulse-till-done/-/pulse-till-done-3.13.0.tgz",
+      "integrity": "sha512-1SOHpy7ZNTPulzIbargrgaJX387csN7cF1cLOGZiJQA6VqnS5eWs2CIrG8i8wmaUavj2QlQ5oEbRMVVXSsGrzA==",
+      "dev": true,
+      "requires": {
+        "npmlog": "^4.1.2"
+      }
+    },
     "@lerna/resolve-symlink": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz",
-      "integrity": "sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.13.0.tgz",
+      "integrity": "sha512-Lc0USSFxwDxUs5JvIisS8JegjA6SHSAWJCMvi2osZx6wVRkEDlWG2B1JAfXUzCMNfHoZX0/XX9iYZ+4JIpjAtg==",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
-        "libnpm": "^2.0.1",
+        "npmlog": "^4.1.2",
         "read-cmd-shim": "^1.0.1"
       }
     },
     "@lerna/rimraf-dir": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.6.0.tgz",
-      "integrity": "sha512-2CfyWP1lqxDET+SfwGlLUfgqGF4vz9TYDrmb7Zi//g7IFCo899uU2vWOrEcdWTgbKE3Qgwwfk9c008w5MWUhog==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.13.0.tgz",
+      "integrity": "sha512-kte+pMemulre8cmPqljxIYjCmdLByz8DgHBHXB49kz2EiPf8JJ+hJFt0PzEubEyJZ2YE2EVAx5Tv5+NfGNUQyQ==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "libnpm": "^2.0.1",
+        "@lerna/child-process": "3.13.0",
+        "npmlog": "^4.1.2",
         "path-exists": "^3.0.0",
         "rimraf": "^2.6.2"
       }
     },
     "@lerna/run": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.6.0.tgz",
-      "integrity": "sha512-OYa5pQTOiES/h9rg8vwnt0nYU/wLKUQmFYhMUxdX3lXYpoIcQ28PR7qPG1CVhex4KAU2OW42a7vnm5MAOoScDg==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.13.1.tgz",
+      "integrity": "sha512-nv1oj7bsqppWm1M4ifN+/IIbVu9F4RixrbQD2okqDGYne4RQPAXyb5cEZuAzY/wyGTWWiVaZ1zpj5ogPWvH0bw==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.6.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/filter-options": "^3.6.0",
-        "@lerna/npm-run-script": "^3.6.0",
-        "@lerna/output": "^3.6.0",
-        "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/timer": "^3.5.0",
-        "@lerna/validation-error": "^3.6.0",
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/filter-options": "3.13.0",
+        "@lerna/npm-run-script": "3.13.0",
+        "@lerna/output": "3.13.0",
+        "@lerna/run-parallel-batches": "3.13.0",
+        "@lerna/timer": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
         "p-map": "^1.2.0"
       }
     },
     "@lerna/run-lifecycle": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.6.0.tgz",
-      "integrity": "sha512-/1+vAZnckgKwHVgWG0plVO24erNWUduz9htMOO9wuOfglTnHlMRqDc3s9B/OIKxGDkyzEvxqzfzq3c6JqEolRQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.13.0.tgz",
+      "integrity": "sha512-oyiaL1biZdjpmjh6X/5C4w07wNFyiwXSSHH5GQB4Ay4BPwgq9oNhCcxRoi0UVZlZ1YwzSW8sTwLgj8emkIo3Yg==",
       "dev": true,
       "requires": {
-        "@lerna/npm-conf": "^3.4.1",
-        "libnpm": "^2.0.1"
+        "@lerna/npm-conf": "3.13.0",
+        "figgy-pudding": "^3.5.1",
+        "npm-lifecycle": "^2.1.0",
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/run-parallel-batches": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.0.0.tgz",
-      "integrity": "sha512-Mj1ravlXF7AkkewKd9YFq9BtVrsStNrvVLedD/b2wIVbNqcxp8lS68vehXVOzoL/VWNEDotvqCQtyDBilCodGw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-parallel-batches/-/run-parallel-batches-3.13.0.tgz",
+      "integrity": "sha512-bICFBR+cYVF1FFW+Tlm0EhWDioTUTM6dOiVziDEGE1UZha1dFkMYqzqdSf4bQzfLS31UW/KBd/2z8jy2OIjEjg==",
       "dev": true,
       "requires": {
         "p-map": "^1.2.0",
@@ -599,27 +721,26 @@
       }
     },
     "@lerna/symlink-binary": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.6.0.tgz",
-      "integrity": "sha512-h69AQBBWgZOEzQ1RJEYQ7Ou6llrJNhNNkpqT6k8qSWZ93iXyFmLE4hWoxMXXHFmxmQ0CqjEYKmeLV1Dr5DKT4g==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.13.0.tgz",
+      "integrity": "sha512-obc4Y6jxywkdaCe+DB0uTxYqP0IQ8mFWvN+k/YMbwH4G2h7M7lCBWgPy8e7xw/50+1II9tT2sxgx+jMus1sTJg==",
       "dev": true,
       "requires": {
-        "@lerna/create-symlink": "^3.6.0",
-        "@lerna/package": "^3.6.0",
+        "@lerna/create-symlink": "3.13.0",
+        "@lerna/package": "3.13.0",
         "fs-extra": "^7.0.0",
-        "p-map": "^1.2.0",
-        "read-pkg": "^3.0.0"
+        "p-map": "^1.2.0"
       }
     },
     "@lerna/symlink-dependencies": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.6.0.tgz",
-      "integrity": "sha512-mLpbWLidAU5Xi7bc9Fj8Yt/9XvDczzWocnS/yEe0E6RqWXh2KK+4VR9H24rLywBAWTv2s4GEXrb/ofbPb8gwBQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.13.0.tgz",
+      "integrity": "sha512-7CyN5WYEPkbPLbqHBIQg/YiimBzb5cIGQB0E9IkLs3+racq2vmUNQZn38LOaazQacAA83seB+zWSxlI6H+eXSg==",
       "dev": true,
       "requires": {
-        "@lerna/create-symlink": "^3.6.0",
-        "@lerna/resolve-symlink": "^3.6.0",
-        "@lerna/symlink-binary": "^3.6.0",
+        "@lerna/create-symlink": "3.13.0",
+        "@lerna/resolve-symlink": "3.13.0",
+        "@lerna/symlink-binary": "3.13.0",
         "fs-extra": "^7.0.0",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
@@ -627,40 +748,41 @@
       }
     },
     "@lerna/timer": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.5.0.tgz",
-      "integrity": "sha512-TAb99hqQN6E3JBGtG9iyZNPq1/DbmqgBOeNrKtdJsGvIeX/NGLgUDWMrj2h04V4O+jpBFmSf6HIld6triKmxCA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.13.0.tgz",
+      "integrity": "sha512-RHWrDl8U4XNPqY5MQHkToWS9jHPnkLZEt5VD+uunCKTfzlxGnRCr3/zVr8VGy/uENMYpVP3wJa4RKGY6M0vkRw==",
       "dev": true
     },
     "@lerna/validation-error": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.6.0.tgz",
-      "integrity": "sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.13.0.tgz",
+      "integrity": "sha512-SiJP75nwB8GhgwLKQfdkSnDufAaCbkZWJqEDlKOUPUvVOplRGnfL+BPQZH5nvq2BYSRXsksXWZ4UHVnQZI/HYA==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
       }
     },
     "@lerna/version": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.6.0.tgz",
-      "integrity": "sha512-V1f3fNM5ELGHmF824Wc8ah505SMpfiBqOHAIiW+u9soH/3W/t256c1P9UeaDh5blWAk3HeZMzbpRZ9Nlpf6aQA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.13.1.tgz",
+      "integrity": "sha512-WpfKc5jZBBOJ6bFS4atPJEbHSiywQ/Gcd+vrwaEGyQHWHQZnPTvhqLuq3q9fIb9sbuhH5pSY6eehhuBrKqTnjg==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.6.0",
-        "@lerna/check-working-tree": "^3.6.0",
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/collect-updates": "^3.6.0",
-        "@lerna/command": "^3.6.0",
-        "@lerna/conventional-commits": "^3.6.0",
-        "@lerna/output": "^3.6.0",
-        "@lerna/prompt": "^3.6.0",
-        "@lerna/run-lifecycle": "^3.6.0",
-        "@lerna/validation-error": "^3.6.0",
+        "@lerna/batch-packages": "3.13.0",
+        "@lerna/check-working-tree": "3.13.0",
+        "@lerna/child-process": "3.13.0",
+        "@lerna/collect-updates": "3.13.0",
+        "@lerna/command": "3.13.1",
+        "@lerna/conventional-commits": "3.13.0",
+        "@lerna/github-client": "3.13.1",
+        "@lerna/output": "3.13.0",
+        "@lerna/prompt": "3.13.0",
+        "@lerna/run-lifecycle": "3.13.0",
+        "@lerna/validation-error": "3.13.0",
         "chalk": "^2.3.1",
         "dedent": "^0.7.0",
-        "libnpm": "^2.0.1",
         "minimatch": "^3.0.4",
+        "npmlog": "^4.1.2",
         "p-map": "^1.2.0",
         "p-pipe": "^1.2.0",
         "p-reduce": "^1.0.0",
@@ -671,12 +793,12 @@
       }
     },
     "@lerna/write-log-file": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.6.0.tgz",
-      "integrity": "sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.13.0.tgz",
+      "integrity": "sha512-RibeMnDPvlL8bFYW5C8cs4mbI3AHfQef73tnJCQ/SgrXZHehmHnsyWUiE7qDQCAo+B1RfTapvSyFF69iPj326A==",
       "dev": true,
       "requires": {
-        "libnpm": "^2.0.1",
+        "npmlog": "^4.1.2",
         "write-file-atomic": "^2.3.0"
       }
     },
@@ -695,6 +817,53 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
+    },
+    "@octokit/endpoint": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
+      "integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.2.0",
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      }
+    },
+    "@octokit/plugin-enterprise-rest": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.1.2.tgz",
+      "integrity": "sha512-EWKrEqhSgzqWXI9DuEsEI691PNJppm/a4zW62//te27I8pYI5zSNVR3wtNUk0NWPlvs7054YzGZochwbUbhI8A==",
+      "dev": true
+    },
+    "@octokit/request": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.0.tgz",
+      "integrity": "sha512-Bm2P0duVRUeKhyepNyFg5GX+yhCK71fqdtpsw5Rz+PQPjSha8HYwPMF5QfpzpD8b6/Xl3xhTgu3V90W362gZ1A==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^3.1.1",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "universal-user-agent": "^2.0.1"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.16.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.16.4.tgz",
+      "integrity": "sha512-9Itw0hQgEf26hg4IOsI7HYKbJBRYaTAAD0pA9ZxXyXjzTUU36Wx+EWkl8w4PNSdX2/79Ggdl6ekD5z1h3jyc7A==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "2.4.0",
+        "before-after-hook": "^1.4.0",
+        "btoa-lite": "^1.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
+      }
     },
     "@zeit/schemas": {
       "version": "2.6.0",
@@ -967,12 +1136,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "asynckit": {
@@ -1069,18 +1238,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bin-links": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
-      "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.0",
-        "cmd-shim": "^2.0.2",
-        "gentle-fs": "^2.0.0",
-        "graceful-fs": "^4.1.11",
-        "write-file-atomic": "^2.3.0"
-      }
+    "before-after-hook": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+      "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
+      "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
@@ -1190,16 +1352,16 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtins": {
@@ -1227,25 +1389,42 @@
       "dev": true
     },
     "cacache": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-      "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "figgy-pudding": "^3.1.0",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.3",
+        "bluebird": "^3.5.3",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
         "rimraf": "^2.6.2",
-        "ssri": "^6.0.0",
-        "unique-filename": "^1.1.0",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "cache-base": {
@@ -1667,9 +1846,9 @@
       "dev": true
     },
     "conventional-changelog-angular": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.2.tgz",
-      "integrity": "sha512-yx7m7lVrXmt4nKWQgWZqxSALEiAKZhOAcbxdUaU9575mB0CzXVbgrgpfSnSP7OqWDUTYGD0YVJ0MSRdyOPgAwA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
+      "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
@@ -1677,12 +1856,12 @@
       }
     },
     "conventional-changelog-core": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.5.tgz",
-      "integrity": "sha512-iwqAotS4zk0wA4S84YY1JCUG7X3LxaRjJxuUo6GI4dZuIy243j5nOg/Ora35ExT4DOiw5dQbMMQvw2SUjh6moQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
+      "integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
       "dev": true,
       "requires": {
-        "conventional-changelog-writer": "^4.0.2",
+        "conventional-changelog-writer": "^4.0.3",
         "conventional-commits-parser": "^3.0.1",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
@@ -1704,15 +1883,15 @@
       "dev": true
     },
     "conventional-changelog-writer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz",
-      "integrity": "sha512-d8/FQY/fix2xXEBUhOo8u3DCbyEw3UOQgYHxLsPDw+wHUDma/GQGAGsGtoH876WyNs32fViHmTOUrgRKVLvBug==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
+      "integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
       "dev": true,
       "requires": {
         "compare-func": "^1.3.1",
         "conventional-commits-filter": "^2.0.1",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.0.2",
+        "handlebars": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.2.1",
         "meow": "^4.0.0",
@@ -1789,14 +1968,15 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-      "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
+      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
         "js-yaml": "^3.9.0",
+        "lodash.get": "^4.4.2",
         "parse-json": "^4.0.0"
       }
     },
@@ -1923,6 +2103,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
+      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==",
+      "dev": true
+    },
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
@@ -2042,9 +2228,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
@@ -2097,9 +2283,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
       "dev": true
     },
     "es6-promisify": {
@@ -2482,9 +2668,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.4.tgz",
-      "integrity": "sha512-FjK2nCGI/McyzgNtTESqaWP3trPvHyRyoyY70hxjc3oKPNmDe8taohLZpoVKoUjW85tbU5txaYUZCNtVzygl1g==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
+      "integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
       "dev": true,
       "requires": {
         "@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -2583,19 +2769,13 @@
         }
       }
     },
-    "find-npm-prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
-      "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
-      "dev": true
-    },
     "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -2611,13 +2791,13 @@
       }
     },
     "flush-write-stream": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "for-in": {
@@ -2682,17 +2862,6 @@
         "minipass": "^2.2.1"
       }
     },
-    "fs-vacuum": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
-      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "path-is-inside": "^1.0.1",
-        "rimraf": "^2.5.2"
-      }
-    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -2750,22 +2919,6 @@
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
       "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "dev": true
-    },
-    "gentle-fs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
-      "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.2",
-        "fs-vacuum": "^1.2.10",
-        "graceful-fs": "^4.1.11",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "path-is-inside": "^1.0.2",
-        "read-cmd-shim": "^1.0.1",
-        "slide": "^1.1.6"
-      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -3033,6 +3186,25 @@
         "semver": "^5.5.0"
       }
     },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "dev": true,
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
     "gitconfiglocal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gitconfiglocal/-/gitconfiglocal-1.0.0.tgz",
@@ -3079,13 +3251,13 @@
       "dev": true
     },
     "globby": {
-      "version": "8.0.1",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
-      "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+      "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
       "dev": true,
       "requires": {
         "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
+        "dir-glob": "2.0.0",
         "fast-glob": "^2.0.2",
         "glob": "^7.1.2",
         "ignore": "^3.3.5",
@@ -3106,9 +3278,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-      "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
       "dev": true,
       "requires": {
         "async": "^2.5.0",
@@ -3468,15 +3640,6 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-ci": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
@@ -3616,6 +3779,15 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "dev": true,
+      "requires": {
+        "protocols": "^1.1.0"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3775,28 +3947,28 @@
       }
     },
     "lerna": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.6.0.tgz",
-      "integrity": "sha512-iQFAgrgtv18SI5LtQBBca0WVeYvk2r8eYgiEQtcZBT63T5R9RVv+snsviIiOp0z6gD43tcyiWXiLvBdp1IY/Rg==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.13.1.tgz",
+      "integrity": "sha512-7kSz8LLozVsoUNTJzJzy+b8TnV9YdviR2Ee2PwGZSlVw3T1Rn7kOAPZjEi+3IWnOPC96zMPHVmjCmzQ4uubalw==",
       "dev": true,
       "requires": {
-        "@lerna/add": "^3.6.0",
-        "@lerna/bootstrap": "^3.6.0",
-        "@lerna/changed": "^3.6.0",
-        "@lerna/clean": "^3.6.0",
-        "@lerna/cli": "^3.6.0",
-        "@lerna/create": "^3.6.0",
-        "@lerna/diff": "^3.6.0",
-        "@lerna/exec": "^3.6.0",
-        "@lerna/import": "^3.6.0",
-        "@lerna/init": "^3.6.0",
-        "@lerna/link": "^3.6.0",
-        "@lerna/list": "^3.6.0",
-        "@lerna/publish": "^3.6.0",
-        "@lerna/run": "^3.6.0",
-        "@lerna/version": "^3.6.0",
+        "@lerna/add": "3.13.1",
+        "@lerna/bootstrap": "3.13.1",
+        "@lerna/changed": "3.13.1",
+        "@lerna/clean": "3.13.1",
+        "@lerna/cli": "3.13.0",
+        "@lerna/create": "3.13.1",
+        "@lerna/diff": "3.13.1",
+        "@lerna/exec": "3.13.1",
+        "@lerna/import": "3.13.1",
+        "@lerna/init": "3.13.1",
+        "@lerna/link": "3.13.1",
+        "@lerna/list": "3.13.1",
+        "@lerna/publish": "3.13.1",
+        "@lerna/run": "3.13.1",
+        "@lerna/version": "3.13.1",
         "import-local": "^1.0.0",
-        "libnpm": "^2.0.1"
+        "npmlog": "^4.1.2"
       }
     },
     "levn": {
@@ -3807,34 +3979,6 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
-      }
-    },
-    "libnpm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-2.0.1.tgz",
-      "integrity": "sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==",
-      "dev": true,
-      "requires": {
-        "bin-links": "^1.1.2",
-        "bluebird": "^3.5.3",
-        "find-npm-prefix": "^1.0.2",
-        "libnpmaccess": "^3.0.1",
-        "libnpmconfig": "^1.2.1",
-        "libnpmhook": "^5.0.2",
-        "libnpmorg": "^1.0.0",
-        "libnpmpublish": "^1.1.0",
-        "libnpmsearch": "^2.0.0",
-        "libnpmteam": "^1.0.1",
-        "lock-verify": "^2.0.2",
-        "npm-lifecycle": "^2.1.0",
-        "npm-logical-tree": "^1.2.1",
-        "npm-package-arg": "^6.1.0",
-        "npm-profile": "^4.0.1",
-        "npm-registry-fetch": "^3.8.0",
-        "npmlog": "^4.1.2",
-        "pacote": "^9.2.3",
-        "read-package-json": "^2.0.13",
-        "stringify-package": "^1.0.0"
       }
     },
     "libnpmaccess": {
@@ -3857,61 +4001,10 @@
         }
       }
     },
-    "libnpmconfig": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
-      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
-      "dev": true,
-      "requires": {
-        "figgy-pudding": "^3.5.1",
-        "find-up": "^3.0.0",
-        "ini": "^1.3.5"
-      }
-    },
-    "libnpmhook": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.2.tgz",
-      "integrity": "sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==",
-      "dev": true,
-      "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.4.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
-      },
-      "dependencies": {
-        "aproba": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-          "dev": true
-        }
-      }
-    },
-    "libnpmorg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz",
-      "integrity": "sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==",
-      "dev": true,
-      "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.4.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
-      },
-      "dependencies": {
-        "aproba": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-          "dev": true
-        }
-      }
-    },
     "libnpmpublish": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.0.tgz",
-      "integrity": "sha512-mQ3LT2EWlpJ6Q8mgHTNqarQVCgcY32l6xadPVPMcjWLtVLz7II4WlWkzlbYg1nHGAf+xyABDwS+3aNUiRLkyaA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.1.tgz",
+      "integrity": "sha512-nefbvJd/wY38zdt+b9SHL6171vqBrMtZ56Gsgfd0duEKb/pB8rDT4/ObUQLrHz1tOfht1flt2zM+UGaemzAG5g==",
       "dev": true,
       "requires": {
         "aproba": "^2.0.0",
@@ -3923,37 +4016,6 @@
         "npm-registry-fetch": "^3.8.0",
         "semver": "^5.5.1",
         "ssri": "^6.0.1"
-      },
-      "dependencies": {
-        "aproba": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
-          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-          "dev": true
-        }
-      }
-    },
-    "libnpmsearch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz",
-      "integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
-      "dev": true,
-      "requires": {
-        "figgy-pudding": "^3.5.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
-      }
-    },
-    "libnpmteam": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz",
-      "integrity": "sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==",
-      "dev": true,
-      "requires": {
-        "aproba": "^2.0.0",
-        "figgy-pudding": "^3.4.1",
-        "get-stream": "^4.0.0",
-        "npm-registry-fetch": "^3.8.0"
       },
       "dependencies": {
         "aproba": {
@@ -3977,23 +4039,13 @@
       }
     },
     "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^3.0.0",
+        "p-locate": "^2.0.0",
         "path-exists": "^3.0.0"
-      }
-    },
-    "lock-verify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
-      "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
-      "dev": true,
-      "requires": {
-        "npm-package-arg": "^5.1.2 || 6",
-        "semver": "^5.4.1"
       }
     },
     "lodash": {
@@ -4012,6 +4064,18 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "lodash.sortby": {
@@ -4039,6 +4103,12 @@
         "lodash._reinterpolate": "~3.0.0"
       }
     },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -4058,6 +4128,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "macos-release": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+      "dev": true
     },
     "make-dir": {
       "version": "1.3.0",
@@ -4118,14 +4194,14 @@
       }
     },
     "mem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
       "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^1.0.0",
-        "p-is-promise": "^1.1.0"
+        "p-is-promise": "^2.0.0"
       }
     },
     "meow": {
@@ -4432,6 +4508,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
+    },
     "node-fetch-npm": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.2.tgz",
@@ -4481,21 +4563,27 @@
       }
     },
     "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+      "dev": true
+    },
     "npm-bundled": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
       "dev": true
     },
     "npm-lifecycle": {
@@ -4514,12 +4602,6 @@
         "which": "^1.3.1"
       }
     },
-    "npm-logical-tree": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
-      "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
-      "dev": true
-    },
     "npm-package-arg": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
@@ -4533,9 +4615,9 @@
       }
     },
     "npm-packlist": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
-      "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+      "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
@@ -4553,21 +4635,10 @@
         "semver": "^5.4.1"
       }
     },
-    "npm-profile": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz",
-      "integrity": "sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.2 || 2",
-        "figgy-pudding": "^3.4.1",
-        "npm-registry-fetch": "^3.8.0"
-      }
-    },
     "npm-registry-fetch": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.8.0.tgz",
-      "integrity": "sha512-hrw8UMD+Nob3Kl3h8Z/YjmKamb1gf7D1ZZch2otrIXM3uFLB5vjEY6DhMlq80z/zZet6eETLbOXcuQudCB3Zpw==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
+      "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",
@@ -4666,6 +4737,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
+    },
     "on-headers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
@@ -4729,37 +4806,24 @@
       "dev": true
     },
     "os-locale": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-      "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^0.10.0",
+        "execa": "^1.0.0",
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        }
+      }
+    },
+    "os-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "dev": true,
+      "requires": {
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
       }
     },
     "os-tmpdir": {
@@ -4791,27 +4855,27 @@
       "dev": true
     },
     "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+      "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
       "dev": true
     },
     "p-limit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
-      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -4842,9 +4906,9 @@
       "dev": true
     },
     "p-try": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
     "p-waterfall": {
@@ -4857,17 +4921,17 @@
       }
     },
     "pacote": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.2.3.tgz",
-      "integrity": "sha512-Y3+yY3nBRAxMlZWvr62XLJxOwCmG9UmkGZkFurWHoCjqF0cZL72cTOCRJTvWw8T4OhJS2RTg13x4oYYriauvEw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.0.tgz",
+      "integrity": "sha512-aUplXozRbzhaJO48FaaeClmN+2Mwt741MC6M3bevIGZwdCaP7frXzbUOfOWa91FPHoLITzG0hYaKY363lxO3bg==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.2",
-        "cacache": "^11.2.0",
+        "bluebird": "^3.5.3",
+        "cacache": "^11.3.2",
         "figgy-pudding": "^3.5.1",
         "get-stream": "^4.1.0",
         "glob": "^7.1.3",
-        "lru-cache": "^4.1.3",
+        "lru-cache": "^5.1.1",
         "make-fetch-happen": "^4.0.1",
         "minimatch": "^3.0.4",
         "minipass": "^2.3.5",
@@ -4886,11 +4950,20 @@
         "safe-buffer": "^5.1.2",
         "semver": "^5.6.0",
         "ssri": "^6.0.1",
-        "tar": "^4.4.6",
+        "tar": "^4.4.8",
         "unique-filename": "^1.1.1",
         "which": "^1.3.1"
       },
       "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
         "tar": {
           "version": "4.4.8",
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
@@ -4941,6 +5014,28 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "dev": true,
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -4975,6 +5070,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -5026,51 +5127,6 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        }
       }
     },
     "pluralize": {
@@ -5147,6 +5203,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+      "dev": true
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
       "dev": true
     },
     "protoduck": {
@@ -5285,9 +5347,9 @@
       }
     },
     "read-package-tree": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.1.tgz",
-      "integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.2.2.tgz",
+      "integrity": "sha512-rW3XWUUkhdKmN2JKB4FL563YAgtINifso5KShykufR03nJ5loGFlkUMe1g/yxmqX073SoYYTsgXu7XdDinKZuA==",
       "dev": true,
       "requires": {
         "debuglog": "^1.0.1",
@@ -5316,51 +5378,6 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        }
       }
     },
     "readable-stream": {
@@ -5527,6 +5544,15 @@
           "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
           "dev": true
         }
+      }
+    },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
       }
     },
     "resolve-cwd": {
@@ -5789,9 +5815,9 @@
       "dev": true
     },
     "smart-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.1.tgz",
-      "integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw==",
       "dev": true
     },
     "snapdragon": {
@@ -5917,13 +5943,13 @@
       }
     },
     "socks": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.2.tgz",
-      "integrity": "sha512-g6wjBnnMOZpE0ym6e0uHSddz9p3a+WsBaaYQaBaSCJYvrC4IXykQR9MNGjLQf38e9iIIhp3b1/Zk8YZI3KGJ0Q==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.2.3.tgz",
+      "integrity": "sha512-+2r83WaRT3PXYoO/1z+RDEBE7Z2f9YcdQnJ0K/ncXXbV5gJ6wYfNAebYFYiiUjM6E4JyXnPY8cimwyvFYHVUUA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.5",
-        "smart-buffer": "^4.0.1"
+        "smart-buffer": "4.0.2"
       }
     },
     "socks-proxy-agent": {
@@ -5997,9 +6023,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
       "dev": true
     },
     "split": {
@@ -6036,9 +6062,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -6117,12 +6143,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "stringify-package": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
-      "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -6543,6 +6563,15 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "universal-user-agent": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.3.tgz",
+      "integrity": "sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6612,6 +6641,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
       "dev": true
     },
     "use": {
@@ -6760,6 +6795,38 @@
         }
       }
     },
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.10.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        }
+      }
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -6792,9 +6859,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -6870,10 +6937,53 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
           "dev": true
         },
         "string-width": {
@@ -6908,9 +7018,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-prettier": "^3.0.1",
     "expect.js": "^0.3.1",
-    "lerna": "^3.6.0",
+    "lerna": "^3.13.1",
     "mocha": "^5.2.0",
     "prettier": "^1.15.3",
     "rimraf": "^2.6.2",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-cli",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/convert/package-lock.json
+++ b/packages/convert/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-convert",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,34 +17,11 @@
         "minimist": "^1.2.0"
       }
     },
-    "messageformat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.0.5.tgz",
-      "integrity": "sha512-iT9/DUx75LqDGepfhKJpCxsCxlMFlyW/E7pI1KZE+TcT+bDcoLJfnwamq5qyRWiFo+eND5joxik9QlzWhqYgIg==",
-      "dev": true,
-      "requires": {
-        "make-plural": "^4.3.0",
-        "messageformat-parser": "^3.0.0",
-        "reserved-words": "^0.1.2"
-      }
-    },
-    "messageformat-parser": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/messageformat-parser/-/messageformat-parser-3.0.0.tgz",
-      "integrity": "sha512-5KfDWGAHz5kzfKH5V4M7+o3CIFiykCfFDaLK+Ck2fkaxYfLWwKZMioxrSsMRnkfMr0ZaaC0gcxyOUb2d0GCy4A==",
-      "dev": true
-    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "optional": true
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
-      "dev": true
     }
   }
 }

--- a/packages/loader-example/package-lock.json
+++ b/packages/loader-example/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-loader-example",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1002,11 +1002,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1019,15 +1021,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1130,7 +1135,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1140,6 +1146,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1152,17 +1159,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1179,6 +1189,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1251,7 +1262,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1261,6 +1273,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1366,6 +1379,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1789,14 +1803,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "make-plural": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
-      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -1836,29 +1842,6 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
-    },
-    "messageformat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.0.5.tgz",
-      "integrity": "sha512-iT9/DUx75LqDGepfhKJpCxsCxlMFlyW/E7pI1KZE+TcT+bDcoLJfnwamq5qyRWiFo+eND5joxik9QlzWhqYgIg==",
-      "requires": {
-        "make-plural": "^4.3.0",
-        "messageformat-parser": "^3.0.0",
-        "reserved-words": "^0.1.2"
-      }
-    },
-    "messageformat-loader": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/messageformat-loader/-/messageformat-loader-0.7.0.tgz",
-      "integrity": "sha512-oLh02DaFp+Fx4f8DY0k3pDjDBXnZxiC5L2qLUVJfbgOxwe70qG2i4fnuR0bDldCsIYSnHI594EVyvS5XGyiqMg==",
-      "requires": {
-        "loader-utils": "^1.1.0"
-      }
-    },
-    "messageformat-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-3.0.0.tgz",
-      "integrity": "sha512-5KfDWGAHz5kzfKH5V4M7+o3CIFiykCfFDaLK+Ck2fkaxYfLWwKZMioxrSsMRnkfMr0ZaaC0gcxyOUb2d0GCy4A=="
     },
     "micromatch": {
       "version": "3.1.10",
@@ -2373,11 +2356,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE="
     },
     "resolve-url": {
       "version": "0.2.1",

--- a/packages/loader/package-lock.json
+++ b/packages/loader/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-loader",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,42 +32,10 @@
         "json5": "^1.0.1"
       }
     },
-    "make-plural": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
-      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
-    "messageformat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.0.5.tgz",
-      "integrity": "sha512-iT9/DUx75LqDGepfhKJpCxsCxlMFlyW/E7pI1KZE+TcT+bDcoLJfnwamq5qyRWiFo+eND5joxik9QlzWhqYgIg==",
-      "dev": true,
-      "requires": {
-        "make-plural": "^4.3.0",
-        "messageformat-parser": "^3.0.0",
-        "reserved-words": "^0.1.2"
-      }
-    },
-    "messageformat-parser": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/messageformat-parser/-/messageformat-parser-3.0.0.tgz",
-      "integrity": "sha512-5KfDWGAHz5kzfKH5V4M7+o3CIFiykCfFDaLK+Ck2fkaxYfLWwKZMioxrSsMRnkfMr0ZaaC0gcxyOUb2d0GCy4A==",
-      "dev": true
-    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
-      "dev": true
     },
     "yaml": {
       "version": "1.2.0",

--- a/packages/messageformat/package-lock.json
+++ b/packages/messageformat/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -759,11 +759,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "messageformat-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.0.0.tgz",
-      "integrity": "sha512-jhIvKWiNOdfpGGy5QcqPG00vpwBJIqIxvKouVowoJbRlEyUvl1RQf3lRMKCv5rT/YSpNyD3Nf+rgZMMMCPqGtg=="
     },
     "miller-rabin": {
       "version": "4.0.1",

--- a/packages/parser/package-lock.json
+++ b/packages/parser/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-parser",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -5,7 +5,7 @@ if (typeof require !== 'undefined') {
 
 describe('Formatters', () => {
   describe('date', () => {
-    const tzOffsetInMs = (new Date()).getTimezoneOffset() * 60 * 1000;
+    const tzOffsetInMs = new Date().getTimezoneOffset() * 60 * 1000;
 
     let mf;
     beforeEach(() => {

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -5,6 +5,8 @@ if (typeof require !== 'undefined') {
 
 describe('Formatters', () => {
   describe('date', () => {
+    const tzOffsetInMs = (new Date()).getTimezoneOffset() * 60 * 1000;
+
     let mf;
     beforeEach(() => {
       mf = new MessageFormat(['en', 'fi']);
@@ -12,7 +14,7 @@ describe('Formatters', () => {
 
     it('default', () => {
       const msg = mf.compile('Today is {T, date}');
-      const data = { T: Date.parse('2016-02-21') };
+      const data = { T: Date.parse('2016-02-21') + tzOffsetInMs };
       expect(msg(data)).to.eql('Today is Feb 21, 2016');
     });
 
@@ -24,7 +26,7 @@ describe('Formatters', () => {
 
     it('argument', () => {
       const msg = mf.compile('Unix time started on {T, date, full}');
-      const data = { T: 0 };
+      const data = { T: tzOffsetInMs };
       expect(msg(data)).to.eql(
         'Unix time started on Thursday, January 1, 1970'
       );


### PR DESCRIPTION
Hello!  I was trying to get this to run on my system and noticed when I ran `npm install` (as well as `npm install --no-save`, which I _think_ made it install the exact dependencies in `package-lock.json`, but I could be wrong) it complained about a high severity vulnerability involving [prototype pollution in handlebars](https://nodesecurity.io/advisories/755) (I'm not sure if that link will actually work, it's currently timing out for me).

Anyways, it suggested I run `npm audit fix` and I did, and the vulnerabilities were no more!

So 36c4f47 addresses that.

However, aside from that--and regardless of whether 36c4f47 is applied--I also noticed that `npm test` fails on my system, specifically on two formatter tests that test date output.  It seems that when displaying dates, either MessageFormat or Node (I'm using 10.15.0 on Windows) is converting them to the local timezone.  I'm in GMT-5h, which meant that the dates were being displayed as the day before they were expected to (since the time portion for the dates was midnight).  I "fixed" this in 4a8ca30 by using [`Date.prototype.getTimezoneOffset()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset) to compensate for the difference in time, so that the times displayed are correct regardless of the system's local timezone.

That said, I'm not sure if this is the right fix/workaround.

Since both of the commits in this PR address entirely different things, I can split them into two separate PRs if you want, or I can discard one or both if you think my fix wasn't the right solution.