### PR TITLE
Add option for array output

### DIFF
--- a/packages/messageformat/src/compiler.js
+++ b/packages/messageformat/src/compiler.js
@@ -37,7 +37,7 @@ export default class Compiler {
       const pc = plurals[lc] || { cardinal: [], ordinal: [] };
       pc.strict = !!this.mf.options.strictNumberSign;
       const r = parse(src, pc).map(token => this.token(token));
-      return `function(d) { return ${r.join(' + ') || '""'}; }`;
+      return `function(d) { return ${this.concatenate(r, true)}; }`;
     } else {
       const result = {};
       for (var key in src) {
@@ -54,11 +54,19 @@ export default class Compiler {
     const r = token.cases.map(({ key, tokens }) => {
       if (key === 'other') needOther = false;
       const s = tokens.map(tok => this.token(tok, plural));
-      return propname(key) + ': ' + (s.join(' + ') || '""');
+      return `${propname(key)}: ${this.concatenate(s, false)}`;
     });
     if (needOther)
       throw new Error("No 'other' form found in " + JSON.stringify(token));
     return `{ ${r.join(', ')} }`;
+  }
+
+  /** @private */
+  concatenate(tokens, root) {
+    const asValues = this.mf.options.returnType === 'values';
+    return asValues && (root || tokens.length > 1)
+      ? '[' + tokens.join(', ') + ']'
+      : tokens.join(' + ') || '""';
   }
 
   /** @private */

--- a/packages/messageformat/src/messageformat.js
+++ b/packages/messageformat/src/messageformat.js
@@ -67,6 +67,9 @@ export default class MessageFormat {
    * @classdesc MessageFormat-to-JavaScript compiler
    * @param {string|string[]|Object} [locale] - The locale(s) to use
    * @param {Object} [options] - Compiler options
+   * @param {('string'|'values')} [options.returnType='string'] - Return type of
+   *   compiled functions; either a concatenated string or an array (possibly
+   *   hierarchical) of values
    * @param {boolean} [options.biDiSupport=false] - Add Unicode control
    *   characters to all input parts to preserve the integrity of the output
    *   when mixing LTR and RTL text
@@ -85,6 +88,7 @@ export default class MessageFormat {
       {
         biDiSupport: false,
         customFormatters: {},
+        returnType: 'string',
         strictNumberSign: false
       },
       options

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -689,3 +689,46 @@ describe('Module/CommonJS support', function() {
     });
   }
 });
+
+describe('{ returnType: "values" }', function() {
+  var mf;
+  before(function() {
+    mf = new MessageFormat('en', { returnType: 'values' });
+  });
+
+  it('simple message', function() {
+    var msg = mf.compile('msg');
+    expect(msg()).to.eql(['msg']);
+  });
+
+  it('variable with string value', function() {
+    var msg = mf.compile('msg {foo}');
+    expect(msg({ foo: 'FOO' })).to.eql(['msg ', 'FOO']);
+  });
+
+  it('variable with object value', function() {
+    var msg = mf.compile('{foo} bar');
+    var foo = {};
+    expect(msg({ foo })[0]).to.equal(foo);
+  });
+
+  it('select string', function() {
+    var msg = mf.compile('msg {foo, select, FOO{bar} other{baz}}');
+    expect(msg({ foo: 'FOO' })).to.eql(['msg ', 'bar']);
+  });
+
+  it('select variable', function() {
+    var msg = mf.compile('msg {foo, select, FOO{{bar}} other{baz}}');
+    expect(msg({ foo: 'FOO', bar: 'BAR' })).to.eql(['msg ', 'BAR']);
+  });
+
+  it('select multiple', function() {
+    var msg = mf.compile('msg {foo, select, FOO{{bar} end} other{baz}}');
+    expect(msg({ foo: 'FOO', bar: 'BAR' })).to.eql(['msg ', ['BAR', ' end']]);
+  });
+
+  it('plural number', function() {
+    var msg = mf.compile('{num} {num, plural, one{one} other{#{num}}}');
+    expect(msg({ num: 42 })).to.eql([42, ' ', [42, 42]]);
+  });
+});


### PR DESCRIPTION
Fixes #241 

This adds a new method `MessageFormat#setArrayOutput()`, which makes compiled functions return arrays instead of strings, allowing for variable values to not be stringified. Some examples:

```js
const mf = new MessageFormat('en').setArrayOutput()

mf.compile('simple message')()
// ['simple message']

const obj = { foo: 'bar' }
mf.compile('objectively, {obj} is an object')({ obj })
// ['objectively, ', obj, ' is an object']

mf.compile('select {num, plural, one{one} other{#}}')({ num: 42 })
// ['select ', [42]]