### PR TITLE
Add a second options argument for the MessageFormat constructor

### DIFF
--- a/packages/messageformat/index.d.ts
+++ b/packages/messageformat/index.d.ts
@@ -6,11 +6,19 @@ declare namespace MessageFormat {
   interface SrcObject {
     [key: string]: SrcMessage;
   }
+
+  interface Options {
+    biDiSupport?: boolean;
+    customFormatters?: { [name: string]: Formatter };
+    pluralKeyChecks?: boolean;
+    strictNumberSign?: boolean;
+  }
 }
 
 declare class MessageFormat {
   constructor(
-    message?: { [pluralFuncs: string]: Function } | string[] | string
+    locales?: { [locale: string]: Function } | string[] | string,
+    options?: MessageFormat.Options
   );
   addFormatters: (format: { [name: string]: MessageFormat.Formatter }) => this;
   disablePluralKeyChecks: () => this;

--- a/packages/messageformat/src/compiler.js
+++ b/packages/messageformat/src/compiler.js
@@ -1,5 +1,5 @@
 import { parse } from 'messageformat-parser';
-import { bidiMarkText, funcname, propname } from './utils';
+import { biDiMarkText, funcname, propname } from './utils';
 
 /** @private */
 export default class Compiler {
@@ -35,7 +35,7 @@ export default class Compiler {
     if (typeof src != 'object') {
       this.lc = lc;
       const pc = plurals[lc] || { cardinal: [], ordinal: [] };
-      pc.strict = !!this.mf.strictNumberSign;
+      pc.strict = !!this.mf.options.strictNumberSign;
       const r = parse(src, pc).map(token => this.token(token));
       return `function(d) { return ${r.join(' + ') || '""'}; }`;
     } else {
@@ -69,11 +69,13 @@ export default class Compiler {
     let args = [propname(token.arg, 'd')];
     switch (token.type) {
       case 'argument':
-        return this.mf.bidiSupport ? bidiMarkText(args[0], this.lc) : args[0];
+        return this.mf.options.biDiSupport
+          ? biDiMarkText(args[0], this.lc)
+          : args[0];
 
       case 'select':
         fn = 'select';
-        if (plural && this.mf.strictNumberSign) plural = null;
+        if (plural && this.mf.options.strictNumberSign) plural = null;
         args.push(this.cases(token, plural));
         this.runtime.select = true;
         break;
@@ -110,7 +112,7 @@ export default class Compiler {
           );
         args.push(JSON.stringify(this.lc));
         if (token.param) {
-          if (plural && this.mf.strictNumberSign) plural = null;
+          if (plural && this.mf.options.strictNumberSign) plural = null;
           const s = token.param.tokens.map(tok => this.token(tok, plural));
           args.push('(' + (s.join(' + ') || '""') + ').trim()');
         }

--- a/packages/messageformat/src/messageformat.js
+++ b/packages/messageformat/src/messageformat.js
@@ -61,13 +61,18 @@ export default class MessageFormat {
    * ```
    */
   constructor(locale) {
+    this.options = {
+      biDiSupport: false,
+      pluralKeyChecks: true,
+      strictNumberSign: false
+    };
     this.pluralFuncs = {};
     if (typeof locale === 'string') {
-      this.pluralFuncs[locale] = getPlural(locale);
+      this.pluralFuncs[locale] = getPlural(locale, this.options);
       this.defaultLocale = locale;
     } else if (Array.isArray(locale)) {
       locale.forEach(lc => {
-        this.pluralFuncs[lc] = getPlural(lc);
+        this.pluralFuncs[lc] = getPlural(lc, this.options);
       });
       this.defaultLocale = locale[0];
     } else {
@@ -85,6 +90,7 @@ export default class MessageFormat {
         this.hasCustomPluralFuncs = true;
       } else {
         this.defaultLocale = MessageFormat.defaultLocale;
+        this.hasCustomPluralFuncs = false;
       }
     }
     this.fmt = {};
@@ -160,7 +166,7 @@ export default class MessageFormat {
    * mf.compile(msg)({ X: 0 })  // '0 answers'
    */
   disablePluralKeyChecks() {
-    this.noPluralKeyChecks = true;
+    this.options.pluralKeyChecks = false;
     for (const lc in this.pluralFuncs) {
       const pf = this.pluralFuncs[lc];
       if (pf) {
@@ -194,7 +200,7 @@ export default class MessageFormat {
    *   // 'first >> SECOND >> THIRD'
    */
   setBiDiSupport(enable) {
-    this.bidiSupport = !!enable || typeof enable == 'undefined';
+    this.options.biDiSupport = !!enable || typeof enable == 'undefined';
     return this;
   }
 
@@ -232,8 +238,8 @@ export default class MessageFormat {
    * messages.pastry({ X: 3, P: 'pie' })  // '# pies'
    */
   setStrictNumberSign(enable) {
-    this.strictNumberSign = !!enable || typeof enable == 'undefined';
-    this.runtime.setStrictNumber(this.strictNumberSign);
+    this.options.strictNumberSign = !!enable || typeof enable == 'undefined';
+    this.runtime.setStrictNumber(this.options.strictNumberSign);
     return this;
   }
 
@@ -332,7 +338,7 @@ export default class MessageFormat {
     let pf = {};
     if (Object.keys(this.pluralFuncs).length === 0) {
       if (locale) {
-        const pfn0 = getPlural(locale, this.noPluralKeyChecks);
+        const pfn0 = getPlural(locale, this.options);
         if (!pfn0) {
           const lcs = JSON.stringify(locale);
           throw new Error(`Locale ${lcs} not found!`);
@@ -340,7 +346,7 @@ export default class MessageFormat {
         pf[locale] = pfn0;
       } else {
         locale = this.defaultLocale;
-        pf = getAllPlurals(this.noPluralKeyChecks);
+        pf = getAllPlurals(this.options);
       }
     } else if (locale) {
       const pfn1 = this.pluralFuncs[locale];

--- a/packages/messageformat/src/messageformat.js
+++ b/packages/messageformat/src/messageformat.js
@@ -55,17 +55,29 @@ export default class MessageFormat {
    * @class MessageFormat
    * @classdesc MessageFormat-to-JavaScript compiler
    * @param {string|string[]|Object} [locale] - The locale(s) to use
+   * @param {Object} [options] - Compiler options
+   * @param {boolean} [options.biDiSupport=false] - Add Unicode control
+   *   characters to all input parts to preserve the integrity of the output
+   *   when mixing LTR and RTL text
+   * @param {boolean} [options.pluralKeyChecks=true] - Validate plural and
+   *   selectordinal case keys according to the current locale
+   * @param {boolean} [options.strictNumberSign=false] - Allow `#` only directly
+   *   within a plural or selectordinal case, rather than in any inner select
+   *   case as well.
    *
    * ```
    * import MessageFormat from 'messageformat'
    * ```
    */
-  constructor(locale) {
-    this.options = {
-      biDiSupport: false,
-      pluralKeyChecks: true,
-      strictNumberSign: false
-    };
+  constructor(locale, options) {
+    this.options = Object.assign(
+      {
+        biDiSupport: false,
+        pluralKeyChecks: true,
+        strictNumberSign: false
+      },
+      options
+    );
     this.pluralFuncs = {};
     if (typeof locale === 'string') {
       this.pluralFuncs[locale] = getPlural(locale, this.options);

--- a/packages/messageformat/src/messageformat.js
+++ b/packages/messageformat/src/messageformat.js
@@ -59,6 +59,8 @@ export default class MessageFormat {
    * @param {boolean} [options.biDiSupport=false] - Add Unicode control
    *   characters to all input parts to preserve the integrity of the output
    *   when mixing LTR and RTL text
+   * @param {Object} [options.customFormatters] - Map of custom formatting
+   *   functions to include. See the {@tutorial guide} for more details.
    * @param {boolean} [options.pluralKeyChecks=true] - Validate plural and
    *   selectordinal case keys according to the current locale
    * @param {boolean} [options.strictNumberSign=false] - Allow `#` only directly
@@ -73,6 +75,7 @@ export default class MessageFormat {
     this.options = Object.assign(
       {
         biDiSupport: false,
+        customFormatters: null,
         pluralKeyChecks: true,
         strictNumberSign: false
       },
@@ -105,7 +108,7 @@ export default class MessageFormat {
         this.hasCustomPluralFuncs = false;
       }
     }
-    this.fmt = {};
+    this.fmt = Object.assign({}, this.options.customFormatters);
     this.runtime = new Runtime(this);
   }
 

--- a/packages/messageformat/src/plurals.js
+++ b/packages/messageformat/src/plurals.js
@@ -9,38 +9,38 @@ import plurals from 'make-plural/umd/plurals';
  * {@link http://github.com/eemeli/make-plural.js make-plural}
  */
 
-function wrapPluralFunc(lc, pf, noPluralKeyChecks) {
+function wrapPluralFunc(lc, pf, pluralKeyChecks) {
   var fn = function() {
     return pf.apply(this, arguments);
   };
   fn.toString = () => pf.toString();
-  if (noPluralKeyChecks) {
-    fn.cardinal = [];
-    fn.ordinal = [];
-  } else {
+  if (pluralKeyChecks) {
     const pc = pluralCategories[lc] || {};
     fn.cardinal = pc.cardinal;
     fn.ordinal = pc.ordinal;
+  } else {
+    fn.cardinal = [];
+    fn.ordinal = [];
   }
   return fn;
 }
 
-export function getPlural(locale, noPluralKeyChecks) {
+export function getPlural(locale, { pluralKeyChecks }) {
   for (let lc = String(locale); lc; lc = lc.replace(/[-_]?[^-_]*$/, '')) {
     const pf = plurals[lc];
-    if (pf) return wrapPluralFunc(lc, pf, noPluralKeyChecks);
+    if (pf) return wrapPluralFunc(lc, pf, pluralKeyChecks);
   }
   throw new Error(
     'Localisation function not found for locale ' + JSON.stringify(locale)
   );
 }
 
-export function getAllPlurals(noPluralKeyChecks) {
+export function getAllPlurals({ pluralKeyChecks }) {
   const locales = {};
   const keys = Object.keys(plurals);
   for (let i = 0; i < keys.length; ++i) {
     const lc = keys[i];
-    locales[lc] = wrapPluralFunc(lc, plurals[lc], noPluralKeyChecks);
+    locales[lc] = wrapPluralFunc(lc, plurals[lc], pluralKeyChecks);
   }
   return locales;
 }

--- a/packages/messageformat/src/runtime.js
+++ b/packages/messageformat/src/runtime.js
@@ -50,7 +50,7 @@ export default class Runtime {
 
   constructor(mf) {
     this.mf = mf;
-    this.setStrictNumber(mf.strictNumberSign);
+    this.setStrictNumber(mf.options.strictNumberSign);
   }
 
   /** Utility function for `{N, plural|selectordinal, ...}`

--- a/packages/messageformat/src/utils.js
+++ b/packages/messageformat/src/utils.js
@@ -106,7 +106,7 @@ const rtlRegExp = new RegExp('^' + rtlLanguages.join('|^'));
  *
  * @private
  */
-export function bidiMarkText(text, locale) {
+export function biDiMarkText(text, locale) {
   const isLocaleRTL = rtlRegExp.test(locale);
   const mark = JSON.stringify(isLocaleRTL ? '\u200F' : '\u200E');
   return `${mark} + ${text} + ${mark}`;

--- a/test/formatters.js
+++ b/test/formatters.js
@@ -161,6 +161,14 @@ describe('Formatters', function() {
       expect(msg({ VAR: -151200.42 })).to.eql('Countdown: -42:00:00.420.');
     });
 
+    it('should use formatting functions - set by customFormatters option', function() {
+      mf = new MessageFormat('en', {
+        customFormatters: { uppercase: v => v.toUpperCase() }
+      });
+      const msg = mf.compile('This is {VAR,uppercase}.');
+      expect(msg({ VAR: 'big' })).to.eql('This is BIG.');
+    });
+
     it('should use formatting functions - set by #addFormatters()', function() {
       mf.addFormatters({
         uppercase: function(v) {
@@ -171,11 +179,9 @@ describe('Formatters', function() {
       expect(msg({ VAR: 'big' })).to.eql('This is BIG.');
     });
 
-    it('should use formatting functions for object input - set by #addFormatters()', function() {
-      mf.addFormatters({
-        uppercase: function(v) {
-          return v.toUpperCase();
-        }
+    it('should use formatting functions for object input - set by customFormatters option', function() {
+      mf = new MessageFormat('en', {
+        customFormatters: { uppercase: v => v.toUpperCase() }
       });
       const msg = mf.compile(['This is {VAR,uppercase}.', 'Other string']);
       expect(msg[0]({ VAR: 'big' })).to.eql('This is BIG.');
@@ -183,11 +189,8 @@ describe('Formatters', function() {
 
     describe('arguments', function() {
       beforeEach(function() {
-        mf = new MessageFormat('en');
-        mf.addFormatters({
-          arg: function(v, lc, arg) {
-            return arg;
-          }
+        mf = new MessageFormat('en', {
+          customFormatters: { arg: (v, lc, arg) => arg }
         });
       });
 

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -205,13 +205,10 @@ describe('compile()', function() {
     expect(cf.ru({ count: 13 })).to.eql('13 пользователей');
   });
 
-  function printLocale(v, lc) {
-    return lc;
-  }
+  const customFormatters = { lc: (v, lc) => lc };
 
   it('can support multiple languages', function() {
-    mf = new MessageFormat(['en', 'fr', 'ru']);
-    mf.addFormatters({ lc: printLocale });
+    mf = new MessageFormat(['en', 'fr', 'ru'], { customFormatters });
     const cf = mf.compile({
       fr: 'Locale: {_, lc}',
       ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
@@ -221,8 +218,7 @@ describe('compile()', function() {
   });
 
   it('defaults to supporting all languages: compile({ fr, ru })', function() {
-    mf = new MessageFormat();
-    mf.addFormatters({ lc: printLocale });
+    mf = new MessageFormat(null, { customFormatters });
     const cf = mf.compile({
       fr: 'Locale: {_, lc}',
       xx: 'Locale: {_, lc}',
@@ -234,8 +230,7 @@ describe('compile()', function() {
   });
 
   it('defaults to supporting all languages: compile(src, locale)', function() {
-    mf = new MessageFormat();
-    mf.addFormatters({ lc: printLocale });
+    mf = new MessageFormat(null, { customFormatters });
     const cf0 = mf.compile('Locale: {_, lc}', 'fr');
     expect(cf0({})).to.eql('Locale: fr');
     const cf1 = mf.compile(


### PR DESCRIPTION
This adds a more JavaScript-ish way of configuring a MessageFormat instance, by adding a second options argument to the constructor. Its keys correspond pretty closely to the `addFormatters`, `disablePluralKeyChecks`, `setBiDiSupport`, and `setStrictNumberSign` methods.

The main purpose of this approach is to provide a bridge towards the work I've started in the [`next`](../tree/next) branch, where all of those methods are removed and other potentially breaking changes are helping to simplify the codebase.