### PR TITLE
Always format # in plurals as number

### DIFF
--- a/packages/messageformat/src/compiler.js
+++ b/packages/messageformat/src/compiler.js
@@ -112,8 +112,12 @@ export default class Compiler {
       case 'octothorpe':
         if (!plural) return '"#"';
         fn = 'number';
-        args = [propname(plural.arg, 'd'), JSON.stringify(plural.arg)];
-        if (plural.offset) args.push(plural.offset);
+        args = [
+          JSON.stringify(this.lc),
+          propname(plural.arg, 'd'),
+          plural.offset || '0',
+          JSON.stringify(plural.arg)
+        ];
         this.runtime.number = true;
         break;
     }

--- a/packages/messageformat/src/runtime.js
+++ b/packages/messageformat/src/runtime.js
@@ -1,4 +1,11 @@
+/* eslint-env browser */
+
 import { funcname, propname } from './utils';
+
+/** @private */
+function _nf(lc) {
+  return _nf[lc] || (_nf[lc] = new Intl.NumberFormat(lc));
+}
 
 /** A set of utility functions that are called by the compiled Javascript
  *  functions, these are included locally in the output of {@link
@@ -23,7 +30,7 @@ export default class Runtime {
    * @returns {string} The result of applying the offset to the input value
    */
   static defaultNumber = function(lc, value, offset, name) {
-    var f = new Intl.NumberFormat(lc).format(value - offset);
+    var f = _nf(lc).format(value - offset);
     if (f === 'NaN' && offset)
       throw new Error('`' + name + '` or its offset is not a number');
     return f;
@@ -31,7 +38,7 @@ export default class Runtime {
 
   /** @private */
   static strictNumber = function(lc, value, offset, name) {
-    var f = new Intl.NumberFormat(lc).format(value - offset);
+    var f = _nf(lc).format(value - offset);
     if (f === 'NaN')
       throw new Error('`' + name + '` or its offset is not a number');
     return f;
@@ -103,6 +110,8 @@ export default class Runtime {
     const rtKeys = Object.keys(this.compiler.runtime);
     for (let i = 0; i < rtKeys.length; ++i) {
       const fn = rtKeys[i];
+      // Cache for Intl.NumberFormat; name may change during minification
+      if (fn === 'number') obj[_nf.name] = _nf;
       obj[fn] = this[fn];
     }
     if (Object.keys(this.compiler.formatters).length > 0) {

--- a/packages/messageformat/src/runtime.js
+++ b/packages/messageformat/src/runtime.js
@@ -9,43 +9,32 @@ import { funcname, propname } from './utils';
  * @param {MessageFormat} mf - A MessageFormat instance
  */
 export default class Runtime {
-  /** Utility function for `#` in plural rules
+  /**
+   * Utility function for `#` in plural rules
    *
-   *  Will throw an Error if `value` has a non-numeric value and `offset` is
-   *  non-zero or the `strictNumberSign` option is set.
+   * Will throw an Error if `value` has a non-numeric value and the
+   * `strictNumberSign` option is set
    *
    * @function Runtime#number
+   * @param {string} lc - The current locale
    * @param {number} value - The value to operate on
+   * @param {number} offset - An offset, set by the surrounding context
    * @param {string} name - The name of the argument, used for error reporting
-   * @param {number} [offset=0] - An optional offset, set by the surrounding context
-   * @returns {number|string} The result of applying the offset to the input value
+   * @returns {string} The result of applying the offset to the input value
    */
-  static defaultNumber = function(value, name, offset) {
-    if (!offset) return value;
-    if (isNaN(value))
-      throw new Error(
-        "Can't apply offset:" +
-          offset +
-          ' to argument `' +
-          name +
-          '` with non-numerical value ' +
-          JSON.stringify(value) +
-          '.'
-      );
-    return value - offset;
+  static defaultNumber = function(lc, value, offset, name) {
+    var f = new Intl.NumberFormat(lc).format(value - offset);
+    if (f === 'NaN' && offset)
+      throw new Error('`' + name + '` or its offset is not a number');
+    return f;
   };
 
   /** @private */
-  static strictNumber = function(value, name, offset) {
-    if (isNaN(value))
-      throw new Error(
-        'Argument `' +
-          name +
-          '` has non-numerical value ' +
-          JSON.stringify(value) +
-          '.'
-      );
-    return value - (offset || 0);
+  static strictNumber = function(lc, value, offset, name) {
+    var f = new Intl.NumberFormat(lc).format(value - offset);
+    if (f === 'NaN')
+      throw new Error('`' + name + '` or its offset is not a number');
+    return f;
   };
 
   constructor({ strictNumberSign }, compiler, pluralFuncs) {

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -111,8 +111,8 @@ describe('compile()', function() {
 
     it('false by default', function() {
       const mf = new MessageFormat('en');
-      expect(mf.compile(msg)({ X: 3, Y: 5 })).to.equal(3);
-      expect(mf.compile(msg)({ X: 'x' })).to.equal('x');
+      expect(mf.compile(msg)({ X: 3, Y: 5 })).to.equal('3');
+      expect(mf.compile(msg)({ X: 'x' })).to.equal('NaN');
       expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.equal('#');
       expect(mf.compile(msg2)({ X: 'x' })).to.equal('#');
     });
@@ -120,16 +120,17 @@ describe('compile()', function() {
     it('{ strictNumberSign: true }', function() {
       const mf = new MessageFormat('en', { strictNumberSign: true });
       expect(mf.compile(msg)({ X: 3, Y: 5 })).to.equal('#');
-      expect(function() {
-        mf.compile(msg)({ X: 'x' });
-      }).to.throw(/\bX\b.*non-numerical value/);
+      expect(() => mf.compile(msg)({ X: 'x' })).to.throw(/\bX\b.*not a number/);
       expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.equal("'#'");
+      expect(() => mf.compile(msg2)({ X: 'x' })).to.throw(
+        /\bX\b.*not a number/
+      );
     });
 
     it('{ strictNumberSign: false }', function() {
       const mf = new MessageFormat('en', { strictNumberSign: false });
-      expect(mf.compile(msg)({ X: 3, Y: 5 })).to.equal(3);
-      expect(mf.compile(msg)({ X: 'x' })).to.equal('x');
+      expect(mf.compile(msg)({ X: 3, Y: 5 })).to.equal('3');
+      expect(mf.compile(msg)({ X: 'x' })).to.equal('NaN');
       expect(mf.compile(msg2)({ X: 3, Y: 5 })).to.equal('#');
       expect(mf.compile(msg2)({ X: 'x' })).to.equal('#');
     });
@@ -476,15 +477,9 @@ describe('Basic Message Formatting', function() {
     expect(mfunc({ FRIENDS: 0, ENEMIES: 0 })).to.eql(
       'I have 0 friends but no enemies.'
     );
-    expect(function() {
-      var x = mfunc({});
-    }).to.throw(/\bENEMIES\b.*non-numerical value/);
-    expect(function() {
-      var x = mfunc({ FRIENDS: 0 });
-    }).to.throw(/\bENEMIES\b.*non-numerical value/);
-    expect(mfunc({ ENEMIES: 1 })).to.eql(
-      'I have undefined friends but one nemesis.'
-    );
+    expect(() => mfunc({})).to.throw(/\bENEMIES\b.*not a number/);
+    expect(() => mfunc({ FRIENDS: 0 })).to.throw(/\bENEMIES\b.*not a number/);
+    expect(mfunc({ ENEMIES: 1 })).to.eql('I have NaN friends but one nemesis.');
   });
 
   it('should not expose prototype members - selects', function() {


### PR DESCRIPTION
Fixes #246 

BREAKING CHANGE: Previously, non-numeric values used as plural arguments could be referred to using `#` while keeping their original value. With this change, they now get converted to numbers and then formatted, probably coming out as `"NaN"` instead.

The number formatter relies on Intl.NumberFormat being available, and caches its instances.