### PR TITLE
Fixed typo when setting default locale, removed double export

### DIFF
--- a/packages/messages/src/messages.js
+++ b/packages/messages/src/messages.js
@@ -8,8 +8,6 @@
  * @module messageformat-messages
  */
 
-module.exports = Messages;
-
 /**
  * @alias module:messageformat-messages
  *
@@ -75,7 +73,7 @@ class Messages {
       }
     });
     this.locale = defaultLocale;
-    this._defaultLocale = this._locale;
+    this._defaultLocale = this.locale;
   }
 
   /**


### PR DESCRIPTION
The default locale was not set correctly due to a missing underscore (this was also the case with the js version of this file). I've also removed the double export, as that resulted in a "Cannot access 'Messages' before initialization", which seems logical.