### PR TITLE
Added typings for messageformat-runtime/messages

### DIFF
--- a/packages/runtime/messages.d.ts
+++ b/packages/runtime/messages.d.ts
@@ -1,0 +1,45 @@
+declare module 'messageformat-runtime/messages' {
+  class Messages {
+    public availableLocales: string[];
+
+    public locale: string | null;
+
+    public defaultLocale: string | null;
+
+    constructor(locales: MessageData, defaultLocale: string);
+
+    public addMessages(data: object, lc?: string, keypath?: string[]): Messages;
+
+    public resolveLocale(lc: string): string | null;
+
+    public getFallback(lc?: string): string[];
+
+    public setFallback(lc: string, fallback: string[] | null): Messages;
+
+    public hasMessage(
+      key: string | string[],
+      lc?: string,
+      fallback?: boolean
+    ): boolean;
+
+    public hasObject(
+      key: string | string[],
+      lc?: string,
+      fallback?: boolean
+    ): boolean;
+
+    public get(
+      key: string | string[],
+      props?: object,
+      lc?: string
+    ): string | object;
+  }
+
+  export interface MessageData {
+    [locale: string]: {
+      [key: string]: string;
+    };
+  }
+
+  export default Messages;
+}


### PR DESCRIPTION
As requested in #255 by @eemeli , the typing I created as PR for the current master branch. 

If you expect them to have a different layout (maybe you want the comments stripped here?), let me know.