### PR TITLE
Add requireAllArguments option to compiler

### DIFF
--- a/packages/messageformat/src/compiler.js
+++ b/packages/messageformat/src/compiler.js
@@ -50,8 +50,14 @@ export default class Compiler {
       ordinal: plural.ordinals,
       strict: this.options.strictNumberSign
     };
+    this.arguments = [];
     const r = parse(src, parserOptions).map(token => this.token(token));
-    return `function(d) { return ${this.concatenate(r, true)}; }`;
+    let reqArgs = '';
+    if (this.options.requireAllArguments && this.arguments.length > 0) {
+      this.setRuntimeFn('reqArgs');
+      reqArgs = `reqArgs(${JSON.stringify(this.arguments)}, d); `;
+    }
+    return `function(d) { ${reqArgs}return ${this.concatenate(r, true)}; }`;
   }
 
   cases(token, pluralToken) {
@@ -85,6 +91,7 @@ export default class Compiler {
     if (typeof token == 'string') return JSON.stringify(token);
 
     let fn;
+    this.arguments.push(token.arg);
     let args = [property('d', token.arg)];
     switch (token.type) {
       case 'argument':

--- a/packages/messageformat/src/messageformat.js
+++ b/packages/messageformat/src/messageformat.js
@@ -49,7 +49,7 @@ export default class MessageFormat {
    * @property {Object} [customFormatters] - Map of custom formatting functions
    *   to include. See the {@tutorial guide} for more details.
    * @property {boolean} [requireAllArguments=false] - Require all message
-   *   arguments to be set with a non-empty value
+   *   arguments to be set with a defined value
    * @property {('string'|'values')} [returnType='string'] - Return type of
    *   compiled functions; either a concatenated string or an array (possibly
    *   hierarchical) of values

--- a/packages/messageformat/src/messageformat.js
+++ b/packages/messageformat/src/messageformat.js
@@ -41,9 +41,6 @@ export default class MessageFormat {
   /**
    * @typedef {Object} MessageFormat~Options - The shape of the options object
    *   that may be used as the second argument of the constructor.
-   * @property {('string'|'values')} [returnType='string'] - Return type of
-   *   compiled functions; either a concatenated string or an array (possibly
-   *   hierarchical) of values
    * @property {boolean} [biDiSupport=false] - Add Unicode control characters to
    *   all input parts to preserve the integrity of the output when mixing LTR
    *   and RTL text
@@ -51,6 +48,11 @@ export default class MessageFormat {
    *   `{V, number, currency}`
    * @property {Object} [customFormatters] - Map of custom formatting functions
    *   to include. See the {@tutorial guide} for more details.
+   * @property {boolean} [requireAllArguments=false] - Require all message
+   *   arguments to be set with a non-empty value
+   * @property {('string'|'values')} [returnType='string'] - Return type of
+   *   compiled functions; either a concatenated string or an array (possibly
+   *   hierarchical) of values
    * @property {boolean} [strictNumberSign=false] - Allow `#` only directly
    *   within a plural or selectordinal case, rather than in any inner select
    *   case as well.

--- a/packages/runtime/src/runtime.mjs
+++ b/packages/runtime/src/runtime.mjs
@@ -65,3 +65,17 @@ export function plural(value, offset, lcfunc, data, isOrdinal) {
 export function select(value, data) {
   return {}.hasOwnProperty.call(data, value) ? data[value] : data.other;
 }
+
+/**
+ * Checks that all required arguments are set to defined values
+ *
+ * Throws on failure; otherwise returns undefined
+ *
+ * @param {string[]} keys - The required keys
+ * @param {Object.<string,string>} data - The data object being checked
+ */
+export function reqArgs(keys, data) {
+  for (var i = 0; i < keys.length; ++i)
+    if (!data || data[keys[i]] === undefined)
+      throw new Error(`Message requires argument '${keys[i]}'`);
+}

--- a/test/messageformat.js
+++ b/test/messageformat.js
@@ -563,6 +563,64 @@ describe('Real World Uses', function() {
 });
 
 describe('Options', () => {
+  describe('requireAllArguments: true', () => {
+    const mf = new MessageFormat('en', { requireAllArguments: true });
+    const noFoo = "Message requires argument 'foo'";
+
+    it('no arguments object', () => {
+      const msg = mf.compile('{foo}');
+      expect(() => msg()).to.throw(noFoo);
+    });
+
+    it('empty arguments object', () => {
+      const msg = mf.compile('{foo}');
+      expect(() => msg({})).to.throw(noFoo);
+    });
+
+    it('undefined value', () => {
+      const msg = mf.compile('{foo}');
+      expect(() => msg({ foo: undefined })).to.throw(noFoo);
+    });
+
+    it('null value', () => {
+      const msg = mf.compile('{foo}');
+      expect(msg({ foo: null })).to.eql(null);
+    });
+
+    it('empty string value', () => {
+      const msg = mf.compile('{foo}');
+      expect(msg({ foo: '' })).to.eql('');
+    });
+
+    it('missing second argument', () => {
+      const msg = mf.compile('{bar} {foo}');
+      expect(() => msg({ bar: 'BAR' })).to.throw(noFoo);
+    });
+
+    it('missing select argument (default to other)', () => {
+      const mf0 = new MessageFormat('en');
+      const msg = mf0.compile('{foo, select, other{FOO}}');
+      expect(msg({})).to.eql('FOO');
+    });
+
+    it('missing select argument', () => {
+      const msg = mf.compile('{foo, select, other{FOO}}');
+      expect(() => msg({})).to.throw(noFoo);
+    });
+
+    it('missing argument inside select case (default ignored)', () => {
+      const mf0 = new MessageFormat('en');
+      const msg = mf0.compile('{bar, select, bar{{foo}} other{OTHER}}');
+      expect(msg({ bar: null })).to.eql('OTHER');
+      expect(msg({ bar: 'bar' })).to.eql(undefined);
+    });
+
+    it('missing argument inside select case', () => {
+      const msg = mf.compile('{bar, select, bar{{foo}} other{OTHER}}');
+      expect(() => msg({ bar: null })).to.throw(noFoo);
+    });
+  });
+
   describe('returnType: "values"', () => {
     const mf = new MessageFormat('en', { returnType: 'values' });
 


### PR DESCRIPTION
Fixes #193 

This adds an option `requireAllArguments` to `new MessageFormat` that checks during runtime that each message function that's called with parameters has some defined values for those parameters:

```js
const mf = new MessageFormat('en', { requireAllArguments: true })
const msg = mf.compile('This is {foo}')
const data = { bar: 'BAR' }

msg(data) // throws Error: "Message requires argument 'foo'"
```

The check that's made in e.g. the above case is `!!data && data.foo === undefined`, so using `{ foo: null }` would not throw.

I would welcome comments on the option name, the check that's used, and the general approach that's used here. Also important to note: As is, all of the parameters are required, even if they're in cases not used by the current message. In other words, this too will throw an error:

```js
const mf = new MessageFormat('en', { requireAllArguments: true })
const msg = mf.compile('{bar, select, foo{{foo}} other{OTHER} }')

msg({ bar: 'BAR' }) // throws Error: "Message requires argument 'foo'"
```