### PR TITLE
Add `rollup-plugin-messageformat` to README's list of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This monorepo consists of the following packages that make up our JS implementat
 - [@messageformat/number-skeleton](packages/number-skeleton) - Tools for working with [ICU NumberFormat skeletons]
 - [@messageformat/parser](packages/parser/) - Parses MessageFormat source strings into an AST
 - [@messageformat/react](packages/react/) - React hooks and other bindings for messages
-- [@messageformat/rollup-plugin](packages/rollup-plugin/) - Rollup plugin for JSON, YAML, & .properties files
+- [@messageformat/rollup-plugin](packages/rollup-plugin/) - Rollup plugin for JSON, YAML, & .properties message files
 - [@messageformat/runtime](packages/runtime/) - Runtime dependencies of compiled message modules
 - [@messageformat/website](packages/website/) - The source of our [documentation site](https://messageformat.github.io/messageformat/v3/)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This monorepo consists of the following packages that make up our JS implementat
 - [@messageformat/number-skeleton](packages/number-skeleton) - Tools for working with [ICU NumberFormat skeletons]
 - [@messageformat/parser](packages/parser/) - Parses MessageFormat source strings into an AST
 - [@messageformat/react](packages/react/) - React hooks and other bindings for messages
+- [@messageformat/rollup-plugin](packages/rollup-plugin/) - Rollup plugin for JSON, YAML, & .properties files
 - [@messageformat/runtime](packages/runtime/) - Runtime dependencies of compiled message modules
 - [@messageformat/website](packages/website/) - The source of our [documentation site](https://messageformat.github.io/messageformat/v3/)
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This monorepo consists of the following packages that make up our JS implementat
 - [@messageformat/number-skeleton](packages/number-skeleton) - Tools for working with [ICU NumberFormat skeletons]
 - [@messageformat/parser](packages/parser/) - Parses MessageFormat source strings into an AST
 - [@messageformat/react](packages/react/) - React hooks and other bindings for messages
-- [@messageformat/rollup-plugin](packages/rollup-plugin/) - Rollup plugin for JSON, YAML, & .properties message files
 - [@messageformat/runtime](packages/runtime/) - Runtime dependencies of compiled message modules
 - [@messageformat/website](packages/website/) - The source of our [documentation site](https://messageformat.github.io/messageformat/v3/)
+- [rollup-plugin-messageformat](packages/rollup-plugin/) - Rollup plugin for JSON, YAML, & .properties message files
 
 [icu dateformat skeletons]: http://userguide.icu-project.org/formatparse/datetime
 [icu numberformat skeletons]: https://github.com/unicode-org/icu/blob/master/docs/userguide/format_parse/numbers/skeletons.md


### PR DESCRIPTION
Note: I'm not sure if this is supposed to be `@messageformat/rollup-plugin` -- I did it this way to match the [top-level package.json](https://github.com/messageformat/messageformat/blob/df713b1714837b92e2bf4c07d5323c21c78df278/package.json#L41-L52)

Also definitely squash merge to remove all my intermediate commits -- I was using the online GitHub editor and couldn't find an amend button :)