### PR TITLE
Remove type from package.json

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,7 +23,6 @@
     "lib/",
     "messages.js"
   ],
-  "type": "commonjs",
   "main": "./lib/runtime.js",
   "exports": {
     ".": [


### PR DESCRIPTION
This allows webpack and other bundlers to determine which module style to consume. Fixes https://github.com/messageformat/messageformat/issues/303