### PR TITLE
fix(runtime): Add missing esm/package.json

### DIFF
--- a/packages/runtime/esm/package.json
+++ b/packages/runtime/esm/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }


### PR DESCRIPTION
Fixes #303 
Closes #305

Ping @gamedevdan

In testing, I was able to duplicate the original reported issue with Webpack 5 and resolve it by adding the missing `esm/package.json` file that correctly identifies files within that folder as using ES rather than CommonJS modules.

Given that this should also enable `@messageformat/runtime/esm/...` content to be used in Node.js environments, it's much preferable to the alternative of removing the `"type"` from the module's root package.json file.