### PR TITLE
Use fat-arrow notation for message functions

### DIFF
--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -87,12 +87,16 @@ export default class Compiler {
     };
     this.arguments = [];
     const r = parse(src, parserOptions).map(token => this.token(token, null));
-    let reqArgs = '';
-    if (this.options.requireAllArguments && this.arguments.length > 0) {
+    const hasArgs = this.arguments.length > 0;
+    const res = this.concatenate(r, true);
+
+    if (this.options.requireAllArguments && hasArgs) {
       this.setRuntimeFn('reqArgs');
-      reqArgs = `reqArgs(${JSON.stringify(this.arguments)}, d); `;
+      const reqArgs = JSON.stringify(this.arguments);
+      return `(d) => { reqArgs(${reqArgs}, d); return ${res}; }`;
     }
-    return `function(d) { ${reqArgs}return ${this.concatenate(r, true)}; }`;
+
+    return `(${hasArgs ? 'd' : ''}) => ${res}`;
   }
 
   cases(token: Select, pluralToken: Select | null) {

--- a/packages/react/src/__fixtures__/messages_en.js
+++ b/packages/react/src/__fixtures__/messages_en.js
@@ -1,30 +1,9 @@
-var en = function (n, ord) {
-  var s = String(n).split('.'), v0 = !s[1], t0 = Number(s[0]) == n,
-      n10 = t0 && s[0].slice(-1), n100 = t0 && s[0].slice(-2);
-  if (ord) return (n10 == 1 && n100 != 11) ? 'one'
-      : (n10 == 2 && n100 != 12) ? 'two'
-      : (n10 == 3 && n100 != 13) ? 'few'
-      : 'other';
-  return (n == 1 && v0) ? 'one' : 'other';
-};
-var number = function (value, name, offset) {
-  if (!offset) return value;
-  if (isNaN(value)) throw new Error('Can\'t apply offset:' + offset + ' to argument `' + name +
-                                    '` with non-numerical value ' + JSON.stringify(value) + '.');
-  return value - offset;
-};
-var plural = function (value, offset, lcfunc, data, isOrdinal) {
-  if ({}.hasOwnProperty.call(data, value)) return data[value];
-  if (offset) value -= offset;
-  var key = lcfunc(value, isOrdinal);
-  if (key in data) return data[key];
-  return data.other;
-};
-
+import { number, plural } from '@messageformat/runtime';
+import { en } from '@messageformat/runtime/lib/cardinals';
 export default {
-  confirm: function(d) { return "Are you sure?"; },
+  confirm: () => "Are you sure?",
   errors: {
-    wrong_length: function(d) { return "Your message is the wrong length (should be " + plural(d.length, 0, en, { one: "1 character", other: number(d.length, "length") + " characters" }) + ")"; },
-    equal_to: function(d) { return "The value must be equal to " + d.count; }
+    wrong_length: (d) => "Your message is the wrong length (should be " + plural(d.length, 0, en, { one: "1 character", other: number("en", d.length, 0) + " characters" }) + ")",
+    equal_to: (d) => "The value must be equal to " + d.count
   }
 }

--- a/packages/react/src/__fixtures__/messages_fi.js
+++ b/packages/react/src/__fixtures__/messages_fi.js
@@ -1,25 +1,8 @@
-var fi = function (n, ord) {
-  var s = String(n).split('.'), v0 = !s[1];
-  if (ord) return 'other';
-  return (n == 1 && v0) ? 'one' : 'other';
-};
-var number = function (value, name, offset) {
-  if (!offset) return value;
-  if (isNaN(value)) throw new Error('Can\'t apply offset:' + offset + ' to argument `' + name +
-                                    '` with non-numerical value ' + JSON.stringify(value) + '.');
-  return value - offset;
-};
-var plural = function (value, offset, lcfunc, data, isOrdinal) {
-  if ({}.hasOwnProperty.call(data, value)) return data[value];
-  if (offset) value -= offset;
-  var key = lcfunc(value, isOrdinal);
-  if (key in data) return data[key];
-  return data.other;
-};
-
+import { number, plural } from '@messageformat/runtime';
+import { fi } from '@messageformat/runtime/lib/cardinals';
 export default {
-  confirm: function(d) { return "Oletko varma?"; },
+  confirm: () => "Oletko varma?",
   errors: {
-    wrong_length: function(d) { return "Viestisi on väärän pituinen (pitäisi olla " + plural(d.length, 0, fi, { one: "1 merkki", other: number(d.length, "length") + " merkkiä" }) + ")"; }
+    wrong_length: (d) => "Viestisi on väärän pituinen (pitäisi olla " + plural(d.length, 0, fi, { one: "1 merkki", other: number("fi", d.length, 0) + " merkkiä" }) + ")"
   }
 }

--- a/packages/react/src/examples.test.tsx
+++ b/packages/react/src/examples.test.tsx
@@ -12,7 +12,15 @@ import {
   useMessageGetter
 } from '@messageformat/react';
 
-// actually precompiled with messageformat-cli
+/**
+ * Precompiled with @messageformat/cli
+ *
+ * ```
+ * cd packages/react/src/__fixtures__/
+ * messageformat messages_en.properties -l en > messages_en.js
+ * messageformat messages_fi.properties -l fi > messages_fi.js
+ * ```
+ */
 import en from './__fixtures__/messages_en';
 import fi from './__fixtures__/messages_fi';
 

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -60,10 +60,10 @@ import { plural, number } from '@messageformat/runtime';
 import { fr as fr$1 } from '@messageformat/runtime/lib/cardinals';
 
 var fr = {
-  message_intro: function(d) { return plural(d.count, 0, fr$1, {
+  message_intro: (d) => plural(d.count, 0, fr$1, {
     one: "Votre message se trouve ici.",
     other: "Vos " + number("fr", d.count, 0) + " messages se trouvent ici."
-  }) + "\\n"; }
+  }) + "\\n"
 };
 
 fr.message_intro({ count: 3 });

--- a/packages/rollup-plugin/src/__snapshots__/rollup.test.ts.snap
+++ b/packages/rollup-plugin/src/__snapshots__/rollup.test.ts.snap
@@ -5,11 +5,11 @@ exports[`.properties with Latin-1 encoding 1`] = `
 import { fi } from '@messageformat/runtime/lib/plurals';
 
 var messages = {
-  simple: function(d) { return \\"Yksinkertainen viesti.\\"; },
-  \\"var\\": function(d) { return \\"Viesti jossa \\" + d.X + \\".\\"; },
-  plural: function(d) { return \\"Sinulla \\" + plural(d.N, 0, fi, { \\"0\\": \\"ei ole viestejä\\", one: \\"on 1 viesti\\", other: \\"on \\" + number(\\"fi\\", d.N, 0) + \\" viestiä\\" }) + \\".\\"; },
-  select: function(d) { return select(d.GENDER, { other: \\"Hän\\" }) + \\" lähetti sinulle viestin.\\"; },
-  ordinal: function(d) { return plural(d.N, 0, fi, { other: number(\\"fi\\", d.N, 0) + \\".\\" }, 1) + \\" viesti.\\"; }
+  simple: () => \\"Yksinkertainen viesti.\\",
+  \\"var\\": (d) => \\"Viesti jossa \\" + d.X + \\".\\",
+  plural: (d) => \\"Sinulla \\" + plural(d.N, 0, fi, { \\"0\\": \\"ei ole viestejä\\", one: \\"on 1 viesti\\", other: \\"on \\" + number(\\"fi\\", d.N, 0) + \\" viestiä\\" }) + \\".\\",
+  select: (d) => select(d.GENDER, { other: \\"Hän\\" }) + \\" lähetti sinulle viestin.\\",
+  ordinal: (d) => plural(d.N, 0, fi, { other: number(\\"fi\\", d.N, 0) + \\".\\" }, 1) + \\" viesti.\\"
 };
 
 console.log(messages);
@@ -21,7 +21,7 @@ exports[`README sample 1`] = `
 import { fr as fr$1 } from '@messageformat/runtime/lib/cardinals';
 
 var fr = {
-  message_intro: function(d) { return plural(d.count, 0, fr$1, { one: \\"Votre message se trouve ici.\\", other: \\"Vos \\" + number(\\"fr\\", d.count, 0) + \\" messages se trouvent ici.\\" }) + \\"\\\\n\\"; }
+  message_intro: (d) => plural(d.count, 0, fr$1, { one: \\"Votre message se trouve ici.\\", other: \\"Vos \\" + number(\\"fr\\", d.count, 0) + \\" messages se trouvent ici.\\" }) + \\"\\\\n\\"
 };
 
 fr.message_intro({ count: 3 });
@@ -34,18 +34,18 @@ import { en, fi } from '@messageformat/runtime/lib/plurals';
 
 var messages = {
   en: {
-    simple: function(d) { return \\"A simple message.\\"; },
-    \\"var\\": function(d) { return \\"Message with \\" + d.X + \\".\\"; },
-    plural: function(d) { return \\"You have \\" + plural(d.N, 0, en, { \\"0\\": \\"no messages\\", one: \\"1 message\\", other: number(\\"en\\", d.N, 0) + \\" messages\\" }) + \\".\\"; },
-    select: function(d) { return select(d.GENDER, { male: \\"He has\\", female: \\"She has\\", other: \\"They have\\" }) + \\" sent you a message.\\"; },
-    ordinal: function(d) { return \\"The \\" + plural(d.N, 0, en, { one: \\"1st\\", two: \\"2nd\\", few: \\"3rd\\", other: number(\\"en\\", d.N, 0) + \\"th\\" }, 1) + \\" message.\\"; }
+    simple: () => \\"A simple message.\\",
+    \\"var\\": (d) => \\"Message with \\" + d.X + \\".\\",
+    plural: (d) => \\"You have \\" + plural(d.N, 0, en, { \\"0\\": \\"no messages\\", one: \\"1 message\\", other: number(\\"en\\", d.N, 0) + \\" messages\\" }) + \\".\\",
+    select: (d) => select(d.GENDER, { male: \\"He has\\", female: \\"She has\\", other: \\"They have\\" }) + \\" sent you a message.\\",
+    ordinal: (d) => \\"The \\" + plural(d.N, 0, en, { one: \\"1st\\", two: \\"2nd\\", few: \\"3rd\\", other: number(\\"en\\", d.N, 0) + \\"th\\" }, 1) + \\" message.\\"
   },
   fi: {
-    simple: function(d) { return \\"Yksinkertainen viesti.\\"; },
-    \\"var\\": function(d) { return \\"Viesti jossa \\" + d.X + \\".\\"; },
-    plural: function(d) { return \\"Sinulla \\" + plural(d.N, 0, fi, { \\"0\\": \\"ei ole viestejä\\", one: \\"on 1 viesti\\", other: \\"on \\" + number(\\"fi\\", d.N, 0) + \\" viestiä\\" }) + \\".\\"; },
-    select: function(d) { return select(d.GENDER, { other: \\"Hän\\" }) + \\" lähetti sinulle viestin.\\"; },
-    ordinal: function(d) { return plural(d.N, 0, fi, { other: number(\\"fi\\", d.N, 0) + \\".\\" }, 1) + \\" viesti.\\"; }
+    simple: () => \\"Yksinkertainen viesti.\\",
+    \\"var\\": (d) => \\"Viesti jossa \\" + d.X + \\".\\",
+    plural: (d) => \\"Sinulla \\" + plural(d.N, 0, fi, { \\"0\\": \\"ei ole viestejä\\", one: \\"on 1 viesti\\", other: \\"on \\" + number(\\"fi\\", d.N, 0) + \\" viestiä\\" }) + \\".\\",
+    select: (d) => select(d.GENDER, { other: \\"Hän\\" }) + \\" lähetti sinulle viestin.\\",
+    ordinal: (d) => plural(d.N, 0, fi, { other: number(\\"fi\\", d.N, 0) + \\".\\" }, 1) + \\" viesti.\\"
   }
 };
 
@@ -59,18 +59,18 @@ import { en, fi } from '@messageformat/runtime/lib/plurals';
 
 var messages = {
   en: {
-    simple: function(d) { return \\"A simple message.\\"; },
-    \\"var\\": function(d) { return \\"Message with \\" + d.X + \\".\\"; },
-    plural: function(d) { return \\"You have \\" + plural(d.N, 0, en, { \\"0\\": \\"no messages\\", one: \\"1 message\\", other: number(\\"en\\", d.N, 0) + \\" messages\\" }) + \\".\\"; },
-    select: function(d) { return select(d.GENDER, { male: \\"He has\\", female: \\"She has\\", other: \\"They have\\" }) + \\" sent you a message.\\"; },
-    ordinal: function(d) { return \\"The \\" + plural(d.N, 0, en, { one: \\"1st\\", two: \\"2nd\\", few: \\"3rd\\", other: number(\\"en\\", d.N, 0) + \\"th\\" }, 1) + \\" message.\\"; }
+    simple: () => \\"A simple message.\\",
+    \\"var\\": (d) => \\"Message with \\" + d.X + \\".\\",
+    plural: (d) => \\"You have \\" + plural(d.N, 0, en, { \\"0\\": \\"no messages\\", one: \\"1 message\\", other: number(\\"en\\", d.N, 0) + \\" messages\\" }) + \\".\\",
+    select: (d) => select(d.GENDER, { male: \\"He has\\", female: \\"She has\\", other: \\"They have\\" }) + \\" sent you a message.\\",
+    ordinal: (d) => \\"The \\" + plural(d.N, 0, en, { one: \\"1st\\", two: \\"2nd\\", few: \\"3rd\\", other: number(\\"en\\", d.N, 0) + \\"th\\" }, 1) + \\" message.\\"
   },
   fi: {
-    simple: function(d) { return \\"Yksinkertainen viesti.\\"; },
-    \\"var\\": function(d) { return \\"Viesti jossa \\" + d.X + \\".\\"; },
-    plural: function(d) { return \\"Sinulla \\" + plural(d.N, 0, fi, { \\"0\\": \\"ei ole viestejä\\", one: \\"on 1 viesti\\", other: \\"on \\" + number(\\"fi\\", d.N, 0) + \\" viestiä\\" }) + \\".\\"; },
-    select: function(d) { return select(d.GENDER, { other: \\"Hän\\" }) + \\" lähetti sinulle viestin.\\"; },
-    ordinal: function(d) { return plural(d.N, 0, fi, { other: number(\\"fi\\", d.N, 0) + \\".\\" }, 1) + \\" viesti.\\"; }
+    simple: () => \\"Yksinkertainen viesti.\\",
+    \\"var\\": (d) => \\"Viesti jossa \\" + d.X + \\".\\",
+    plural: (d) => \\"Sinulla \\" + plural(d.N, 0, fi, { \\"0\\": \\"ei ole viestejä\\", one: \\"on 1 viesti\\", other: \\"on \\" + number(\\"fi\\", d.N, 0) + \\" viestiä\\" }) + \\".\\",
+    select: (d) => select(d.GENDER, { other: \\"Hän\\" }) + \\" lähetti sinulle viestin.\\",
+    ordinal: (d) => plural(d.N, 0, fi, { other: number(\\"fi\\", d.N, 0) + \\".\\" }, 1) + \\" viesti.\\"
   }
 };
 

--- a/packages/rollup-plugin/src/index.test.ts
+++ b/packages/rollup-plugin/src/index.test.ts
@@ -8,7 +8,7 @@ const jsonSrc = '{"key":{"inner":"value {foo}"}}';
 const code = `
 export default {
   key: {
-    inner: function(d) { return "value " + d.foo; }
+    inner: (d) => "value " + d.foo
   }
 }`;
 
@@ -126,7 +126,7 @@ describe('transform', () => {
         import { number, plural } from '@messageformat/runtime';
         import { fi } from '@messageformat/runtime/lib/cardinals';
         export default {
-          key: function(d) { return "value " + plural(d.foo, 0, fi, { one: "1", other: number("fi", d.foo, 0) }); }
+          key: (d) => "value " + plural(d.foo, 0, fi, { one: "1", other: number("fi", d.foo, 0) })
         }`
     });
   });


### PR DESCRIPTION
This changes the JS representation of compiled messages as follows:

```
A simple message.

was: function(d) { return "A simple message."; }
now: () => "A simple message."
```

```
Message with {X}.

was: function(d) { return "Message with " + d.X + "."; }
now: (d) => "Message with " + d.X + "."
```

In addition to using a terser expression of the function, the `d` argument is left out when not used. Therefore it becomes possible to use the function's `length` property to determine if it requires at least some argument.

Using a template literal instead of + for concatenation would only save an additional single character, so it's probably not worth the complexity that it would introduce.