### PR TITLE
Drop IE 11 testing & explicit support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "browserstack-local": "^1.4.8",
         "chai": "^4.2.0",
         "common-tags": "^2.0.0-alpha.1",
-        "core-js": "^3.8.0",
         "eslint": "^7.14.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-prettier": "^3.1.4",
@@ -8944,17 +8943,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {
@@ -23606,6 +23594,7 @@
       "optional": true
     },
     "packages/cli": {
+      "name": "@messageformat/cli",
       "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
@@ -23627,6 +23616,7 @@
       }
     },
     "packages/convert": {
+      "name": "@messageformat/convert",
       "version": "1.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
@@ -23637,6 +23627,7 @@
       }
     },
     "packages/core": {
+      "name": "@messageformat/core",
       "version": "3.0.0-beta.3",
       "license": "MIT",
       "dependencies": {
@@ -23649,14 +23640,17 @@
       }
     },
     "packages/date-skeleton": {
+      "name": "@messageformat/date-skeleton",
       "version": "1.0.0-beta.1",
       "license": "MIT"
     },
     "packages/number-skeleton": {
+      "name": "@messageformat/number-skeleton",
       "version": "1.0.0-beta.1",
       "license": "MIT"
     },
     "packages/parser": {
+      "name": "@messageformat/parser",
       "version": "5.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
@@ -23664,6 +23658,7 @@
       }
     },
     "packages/react": {
+      "name": "@messageformat/react",
       "version": "1.0.0-beta.1",
       "license": "MIT",
       "peerDependencies": {
@@ -23671,6 +23666,7 @@
       }
     },
     "packages/rollup-plugin": {
+      "name": "rollup-plugin-messageformat",
       "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
@@ -23683,6 +23679,7 @@
       }
     },
     "packages/runtime": {
+      "name": "@messageformat/runtime",
       "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
@@ -23690,6 +23687,7 @@
       }
     },
     "packages/webpack-loader": {
+      "name": "@messageformat/loader",
       "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
@@ -31040,12 +31038,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "browserstack-local": "^1.4.8",
     "chai": "^4.2.0",
     "common-tags": "^2.0.0-alpha.1",
-    "core-js": "^3.8.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/test/browser/src/browser-tests.ts
+++ b/test/browser/src/browser-tests.ts
@@ -3,9 +3,6 @@ import MessageFormat from '@messageformat/core';
 import { PluralFunction } from '@messageformat/core/src/plurals';
 import { getTestCases } from '../../fixtures/messageformat';
 
-// @ts-ignore
-const isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
-const isEdge = !isIE11 && !!window.StyleMedia;
 const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 const isSafari = 'safari' in window;
 
@@ -155,7 +152,6 @@ for (const [title, cases] of Object.entries(getTestCases(MessageFormat))) {
   describe(title, () => {
     for (const { locale, options, src, exp, skip } of cases) {
       if (skip) {
-        if (isIE11 && skip.includes('ie')) continue;
         if (isFirefox && skip.includes('ff')) continue;
         if (isSafari && skip.includes('safari')) continue;
         if (!isV2 && skip.includes('v1')) continue;

--- a/test/browser/src/ie11-polyfills.js
+++ b/test/browser/src/ie11-polyfills.js
@@ -1,7 +1,0 @@
-// Required by IE 11
-import 'core-js/es/array/includes';
-import 'core-js/es/function/name';
-import 'core-js/es/object/assign';
-import 'core-js/es/object/entries';
-import 'core-js/es/string/starts-with';
-import 'core-js/es/symbol/iterator';

--- a/test/browser/test.html
+++ b/test/browser/test.html
@@ -4,15 +4,12 @@
     <meta charset="utf-8" />
     <title>messageformat Test Suite</title>
     <link rel="stylesheet" href="../../node_modules/mocha/mocha.css" />
-    <script src="dist/ie11-polyfills.js"></script>
     <script src="../../node_modules/chai/chai.js"></script>
     <script src="../../node_modules/mocha-selenium-bridge/browser/reporter.js"></script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../packages/core/messageformat.js"></script>
     <script>
-      // navigator.webdriver isn't supported on IE 11
-      var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
-      if (isIE11 || navigator.webdriver) mocha.reporter(Bridge);
+      if (navigator.webdriver) mocha.reporter(Bridge);
       mocha.setup('bdd');
     </script>
     <script src="dist/browser-tests.js"></script>

--- a/test/browser/tests/ie.js
+++ b/test/browser/tests/ie.js
@@ -1,4 +1,0 @@
-const { testBrowser } = require('../browserstack-runner');
-
-const version = '11.0';
-it(`IE ${version}`, () => testBrowser('IE', version));

--- a/test/fixtures/formatters.ts
+++ b/test/fixtures/formatters.ts
@@ -41,7 +41,7 @@ export function dateSkeletonCases(): TestCase[] {
   return Object.entries(cases).map(([fmt, { exp, skip }]) => ({
     src: `{date, date, ::${fmt}}`,
     exp: [[{ date }, exp]],
-    skip: (skip || []).concat(['ie'])
+    skip
   }));
 }
 
@@ -102,7 +102,7 @@ export function numberPatternCases(): TestCase[] {
     '#,#@#': { value: 1234, lc: 'en', exp: '1,200' },
     '#,#50': { value: 1230, lc: 'en', exp: '1,250' },
     '#,##0.65': { value: 1.234, lc: 'en', exp: '1.3' },
-    '¤': { value: 12, lc: 'en', cur: 'CAD', exp: 'CA$12.00', skip: ['ie'] },
+    '¤': { value: 12, lc: 'en', cur: 'CAD', exp: 'CA$12.00' },
     '¤¤': {
       value: 12,
       lc: 'en',
@@ -110,13 +110,7 @@ export function numberPatternCases(): TestCase[] {
       exp: /^CAD\s12.00$/,
       skip: ['safari'] // Fixed in Safari 13
     },
-    '¤¤¤': {
-      value: 5,
-      lc: 'en',
-      cur: 'CAD',
-      exp: '5.00 Canadian dollars',
-      skip: ['ie']
-    },
+    '¤¤¤': { value: 5, lc: 'en', cur: 'CAD', exp: '5.00 Canadian dollars' },
     '¤¤¤¤¤': { value: 12, lc: 'en', cur: 'CAD', exp: '$12.00', skip: ['v1'] },
     '¤#,##0.00;(¤#,##0.00)': {
       value: -3.27,
@@ -157,7 +151,7 @@ export function numberSkeletonCases(): TestCase[] {
       exp: '42 meters',
       skip: ['v1']
     },
-    'currency/CAD': { value: 42, exp: 'CA$42.00', skip: ['ie', 'ff'] },
+    'currency/CAD': { value: 42, exp: 'CA$42.00', skip: ['ff'] },
     'currency/CAD unit-width-narrow': {
       value: 42,
       exp: '$42.00',
@@ -171,7 +165,7 @@ export function numberSkeletonCases(): TestCase[] {
       exp: '(CA$42.00)',
       skip: ['v1']
     },
-    'percent .00': { value: 42, exp: '42.00%', skip: ['ie'] }
+    'percent .00': { value: 42, exp: '42.00%' }
   };
   return Object.entries(cases).map(([fmt, { value, exp, skip }]) => ({
     src: `{value, number, :: ${fmt}}`,

--- a/test/fixtures/messageformat.ts
+++ b/test/fixtures/messageformat.ts
@@ -55,10 +55,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
 
     'Custom locales': [
       {
-        // Explicit function name required by IE 11
-        locale: function locale(_: number) {
-          return 'few';
-        },
+        locale: (_: number) => 'few',
         src: 'res: {val, plural, few{wasfew} other{failed}}',
         exp: [
           [{ val: 0 }, 'res: wasfew'],
@@ -70,10 +67,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
       },
 
       {
-        // Explicit function name required by IE 11
-        locale: function locale(_: number, ord: boolean) {
-          return ord ? 'few' : 'other';
-        },
+        locale: (_: number, ord: boolean) => ord ? 'few' : 'other',
         src: 'res: {val, selectordinal, few{wasfew} other{failed}}',
         exp: [
           [{ val: 0 }, 'res: wasfew'],

--- a/test/fixtures/messageformat.ts
+++ b/test/fixtures/messageformat.ts
@@ -461,18 +461,15 @@ export const getTestCases = (MF: typeof MessageFormat) =>
     'Date formatter': [
       {
         src: 'Today is {T, date}',
-        skip: ['ie'],
         exp: [[{ T: new Date(2016, 1, 21) }, 'Today is Feb 21, 2016']]
       },
       {
         locale: 'fi',
         src: 'Tänään on {T, date}',
-        skip: ['ie'],
         exp: [[{ T: new Date(2016, 1, 21) }, /^Tänään on .*2016/]]
       },
       {
         src: 'Unix time started on {T, date, full}',
-        skip: ['ie'],
         exp: [
           [
             { T: 0 },
@@ -482,7 +479,6 @@ export const getTestCases = (MF: typeof MessageFormat) =>
       },
       {
         src: '{sys} became operational on {d0, date, short}',
-        skip: ['ie'],
         exp: [
           [
             { sys: 'HAL 9000', d0: new Date(1999, 0, 12) },
@@ -532,13 +528,11 @@ export const getTestCases = (MF: typeof MessageFormat) =>
     'Time formatter': [
       {
         src: 'The time is now {T, time}',
-        skip: ['ie'],
         exp: [[{ T: 978384385000 }, /^The time is now \d\d?:\d\d:25 PM$/]]
       },
       {
         locale: 'fi',
         src: 'Kello on nyt {T, time}',
-        skip: ['ie'],
         exp: [[{ T: 978384385000 }, /^Kello on nyt \d\d?.\d\d.25/]]
       },
       (() => {
@@ -546,7 +540,6 @@ export const getTestCases = (MF: typeof MessageFormat) =>
         time.setMinutes(time.getMinutes() + time.getTimezoneOffset());
         return {
           src: 'The Eagle landed at {T, time, full} on {T, date, full}',
-          skip: ['ie'],
           exp: [
             [
               { T: time },

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -1,21 +1,12 @@
-import commonjs from '@rollup/plugin-commonjs';
-import resolve from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 
-export default [
-  {
-    input: 'browser/src/ie11-polyfills.js',
-    output: { file: 'browser/dist/ie11-polyfills.js', format: 'iife' },
-    plugins: [resolve(), commonjs()]
+export default {
+  input: 'browser/src/browser-tests.ts',
+  output: {
+    file: 'browser/dist/browser-tests.js',
+    format: 'iife',
+    globals: { chai: 'chai', '@messageformat/core': 'MessageFormat' }
   },
-  {
-    input: 'browser/src/browser-tests.ts',
-    output: {
-      file: 'browser/dist/browser-tests.js',
-      format: 'iife',
-      globals: { chai: 'chai', messageformat: 'MessageFormat' }
-    },
-    external: ['chai', '@messageformat/core'],
-    plugins: [typescript({ target: 'ES5' })]
-  }
-];
+  external: ['chai', '@messageformat/core'],
+  plugins: [typescript({ target: 'ES2017' })]
+};


### PR DESCRIPTION
With the change made in #309, the generated message modules would need to be transpiled by e.g. Babel for IE 11 support.

There's no reason to expect that to still work, but it's a hassle to maintain support for such an obsolete browser with limited `Intl` support. So let's not. This also lets us get rid of the polyfills required by IE 11.

The current/remaining minimum browser versions against which the full test suite is run includes:
- Chrome 78
- Edge 18
- Firefox 71
- Safari 12.1

That is of course in addition to running the tests against Node.js 10, 12 & 14.