### PR TITLE
feat(core): Rename "strictNumberSign" option as "strict"

### DIFF
--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -83,7 +83,7 @@ export default class Compiler {
     const parserOptions = {
       cardinal: plural.cardinals,
       ordinal: plural.ordinals,
-      strict: this.options.strictNumberSign
+      strict: this.options.strict
     };
     this.arguments = [];
     const r = parse(src, parserOptions).map(token => this.token(token, null));
@@ -146,7 +146,7 @@ export default class Compiler {
 
       case 'select':
         fn = 'select';
-        if (pluralToken && this.options.strictNumberSign) pluralToken = null;
+        if (pluralToken && this.options.strict) pluralToken = null;
         args.push(this.cases(token, pluralToken));
         this.setRuntimeFn('select');
         break;
@@ -176,8 +176,7 @@ export default class Compiler {
           default:
             args.push(JSON.stringify(this.plural.locale));
             if (token.param) {
-              if (pluralToken && this.options.strictNumberSign)
-                pluralToken = null;
+              if (pluralToken && this.options.strict) pluralToken = null;
               const s = token.param.map(tok => this.token(tok, pluralToken));
               args.push('(' + (s.join(' + ') || '""') + ').trim()');
               if (token.key === 'number')
@@ -195,7 +194,7 @@ export default class Compiler {
           property('d', pluralToken.arg),
           pluralToken.pluralOffset || 0
         ];
-        if (this.options.strictNumberSign) {
+        if (this.options.strict) {
           fn = 'strictNumber';
           args.push(JSON.stringify(pluralToken.arg));
           this.setRuntimeFn('strictNumber');
@@ -297,7 +296,7 @@ export default class Compiler {
 
     args.push(JSON.stringify(locale));
     if (param && param.length > 0) {
-      if (plural && this.options.strictNumberSign) plural = null;
+      if (plural && this.options.strict) plural = null;
       const s = param.map(tok => this.token(tok, plural));
       args.push('(' + (s.join(' + ') || '""') + ').trim()');
     }
@@ -358,7 +357,7 @@ export default class Compiler {
       return key;
     }
 
-    if (plural && this.options.strictNumberSign) plural = null;
+    if (plural && this.options.strict) plural = null;
     const s = param.map(tok => this.token(tok, plural));
     args.push('(' + (s.join(' + ') || '""') + ').trim()');
     args.push(JSON.stringify(this.options.currency));

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -62,12 +62,15 @@ export interface MessageFormatOptions {
   returnType?: 'string' | 'values';
 
   /**
-   * Allow `#` only directly within a plural or selectordinal case, rather than
-   * in any inner select case as well.
+   * Follow the ICU MessageFormat spec more closely, but not allowing custom
+   * formatters and by allowing`#` only directly within a plural or
+   * selectordinal case, rather than in any inner select case as well. See the
+   * {@link http://messageformat.github.io/messageformat/api/parser.parseoptions.strict/ | parser option}
+   * for more details.
    *
    * Default: `false`
    */
-  strictNumberSign?: boolean;
+  strict?: boolean;
 }
 
 /**
@@ -172,7 +175,7 @@ export default class MessageFormat {
         customFormatters: {},
         requireAllArguments: false,
         returnType: 'string',
-        strictNumberSign: false
+        strict: (options && (options as any).strictNumberSign) || false
       },
       options
     );

--- a/test/fixtures/messageformat.ts
+++ b/test/fixtures/messageformat.ts
@@ -397,7 +397,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
       }
     ],
 
-    strictNumberSign: [
+    strict: [
       {
         src: '{X, plural, one{#} other{{Y, select, other{#}}}}',
         exp: [
@@ -406,7 +406,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
         ]
       },
       {
-        options: { strictNumberSign: false },
+        options: { strict: false },
         src: '{X, plural, one{#} other{{Y, select, other{#}}}}',
         exp: [
           [{ X: 3, Y: 5 }, '3'],
@@ -414,7 +414,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
         ]
       },
       {
-        options: { strictNumberSign: true },
+        options: { strict: true },
         src: '{X, plural, one{#} other{{Y, select, other{#}}}}',
         exp: [
           [{ X: 3, Y: 5 }, '#'],
@@ -429,7 +429,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
         ]
       },
       {
-        options: { strictNumberSign: false },
+        options: { strict: false },
         src: "{X, plural, one{#} other{{Y, select, other{'#'}}}}",
         exp: [
           [{ X: 3, Y: 5 }, '#'],
@@ -437,7 +437,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
         ]
       },
       {
-        options: { strictNumberSign: true },
+        options: { strict: true },
         src: "{X, plural, one{#} other{{Y, select, other{'#'}}}}",
         exp: [
           [{ X: 3, Y: 5 }, "'#'"],
@@ -445,7 +445,7 @@ export const getTestCases = (MF: typeof MessageFormat) =>
         ]
       },
       {
-        options: { strictNumberSign: true },
+        options: { strict: true },
         src:
           'I have {FRIENDS, plural, one{one friend} other{# friends but {ENEMIES, plural, offset:1 ' +
           '=0{no enemies} =1{one nemesis} one{two enemies} other{one nemesis and # enemies}}}}.',


### PR DESCRIPTION
This follows from an earlier [similar change](http://messageformat.github.io/messageformat/api/parser.parseoptions.strict/) made to the parser.

The actual behaviour of the option is not changed; previously setting `strictNumberSign: true` was in fact also disabling custom formatters.

Fallback handling in the MessageFormat constructor will allow previous users of the option to be unaffected at least for now, even though this is not documented.