### PR TITLE
Improve TypeScript types

### DIFF
--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -98,7 +98,7 @@ describe('compileModule()', function () {
 
   it('should support custom formatter functions', async function () {
     const mf = new MessageFormat('en', {
-      customFormatters: { uppercase: v => v.toUpperCase() }
+      customFormatters: { uppercase: v => String(v).toUpperCase() }
     });
     const msg = await getModule(mf, {
       0: 'This is {VAR,uppercase}.',

--- a/packages/core/src/compile-module.ts
+++ b/packages/core/src/compile-module.ts
@@ -10,12 +10,16 @@ export { MessageFunction, StringStructure };
  *
  * @public
  * @remarks
- * Use with `T` extending the {@link StringStructure} that was used as the module source.
+ * Use with `Shape` extending the {@link StringStructure} that was used as
+ * the module source.
  */
-export type MessageModule<T> = T extends string
-  ? MessageFunction
+export type MessageModule<
+  Shape,
+  ReturnType extends 'string' | 'values' = 'string'
+> = Shape extends string
+  ? MessageFunction<ReturnType>
   : {
-      [P in keyof T]: MessageModule<T[P]>;
+      [P in keyof Shape]: MessageModule<Shape[P], ReturnType>;
     };
 
 function stringifyRuntime(runtime: RuntimeMap) {
@@ -101,7 +105,7 @@ function stringifyObject(obj: string | StringStructure, level = 0): string {
  * @param messages - A hierarchical structure of ICU MessageFormat strings
  */
 export default function compileModule(
-  messageformat: MessageFormat,
+  messageformat: MessageFormat<'string' | 'values'>,
   messages: StringStructure
 ) {
   const { plurals } = messageformat;

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -21,7 +21,8 @@ const FORMATTER_MODULE = '@messageformat/runtime/lib/formatters';
 
 type RuntimeType = 'formatter' | 'locale' | 'runtime';
 interface RuntimeEntry {
-  (...args: any): string | void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (...args: any[]): unknown;
   module?: string | null;
   toString?: () => string;
   type?: RuntimeType;

--- a/packages/core/src/messageformat.test.ts
+++ b/packages/core/src/messageformat.test.ts
@@ -144,7 +144,9 @@ const isV2 =
   // @ts-ignore signDisplay introduced in Unified API proposal, i.e. "NumberFormat v2"
   (55).toLocaleString('en-US', { signDisplay: 'always' }) === '+55';
 
-for (const [title, cases] of Object.entries(getTestCases(MessageFormat))) {
+for (const [title, cases] of Object.entries(
+  getTestCases(MessageFormat.escape)
+)) {
   describe(title, () => {
     for (const { locale, options, src, exp, skip } of cases) {
       let desc: Mocha.SuiteFunction | Mocha.PendingSuiteFunction = describe;

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -14,7 +14,7 @@ export { PluralFunction };
  *
  * @public
  */
-export type MessageFunction = (param?: object) => string | any[];
+export type MessageFunction = (param?: Record<string, unknown>) => string | unknown[];
 
 /**
  * Options for the MessageFormat constructor
@@ -43,7 +43,7 @@ export interface MessageFormatOptions {
    * for more details.
    */
   customFormatters?: {
-    [key: string]: (value: any, locale: string, arg: string | null) => string;
+    [key: string]: (value: unknown, locale: string, arg: string | null) => string;
   };
 
   /**

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -14,14 +14,18 @@ export { PluralFunction };
  *
  * @public
  */
-export type MessageFunction = (param?: Record<string, unknown>) => string | unknown[];
+export type MessageFunction<ReturnType extends 'string' | 'values'> = (
+  param?: Record<string, unknown>
+) => ReturnType extends 'string' ? string : unknown[];
 
 /**
  * Options for the MessageFormat constructor
  *
  * @public
  */
-export interface MessageFormatOptions {
+export interface MessageFormatOptions<
+  ReturnType extends 'string' | 'values' = 'string' | 'values'
+> {
   /**
    * Add Unicode control characters to all input parts to preserve the
    * integrity of the output when mixing LTR and RTL text
@@ -43,7 +47,11 @@ export interface MessageFormatOptions {
    * for more details.
    */
   customFormatters?: {
-    [key: string]: (value: unknown, locale: string, arg: string | null) => string;
+    [key: string]: (
+      value: unknown,
+      locale: string,
+      arg: string | null
+    ) => string;
   };
 
   /**
@@ -54,12 +62,12 @@ export interface MessageFormatOptions {
   requireAllArguments?: boolean;
 
   /**
-   * Return type of compiled functions; either a concatenated string or an
-   * array (possibly hierarchical) of values
+   * Return type of compiled functions; either a concatenated `'string'` or an
+   * array (possibly hierarchical) of `'values'`.
    *
    * Default: `'string'`
    */
-  returnType?: 'string' | 'values';
+  returnType?: ReturnType;
 
   /**
    * Allow `#` only directly within a plural or selectordinal case, rather than
@@ -74,8 +82,9 @@ export interface MessageFormatOptions {
  * Returned by {@link MessageFormat.resolvedOptions}
  * @public
  */
-export interface ResolvedMessageFormatOptions
-  extends Required<MessageFormatOptions> {
+export interface ResolvedMessageFormatOptions<
+  ReturnType extends 'string' | 'values'
+> extends Required<MessageFormatOptions<ReturnType>> {
   /** The default locale */
   locale: string;
   /** All of the supported plurals */
@@ -104,7 +113,9 @@ export interface ResolvedMessageFormatOptions
  * msg({ RES: 2 })                    // 'They found 2 results.'
  * ```
  */
-export default class MessageFormat {
+export default class MessageFormat<
+  ReturnType extends 'string' | 'values' = 'string'
+> {
   /**
    * Used by the constructor when no `locale` argument is given.
    * Default: `'en'`
@@ -137,7 +148,7 @@ export default class MessageFormat {
   }
 
   /** @internal */
-  options: Required<MessageFormatOptions>;
+  options: Required<MessageFormatOptions<ReturnType>>;
 
   /** @internal */
   plurals: PluralObject[] = [];
@@ -163,7 +174,7 @@ export default class MessageFormat {
    */
   constructor(
     locale: string | PluralFunction | Array<string | PluralFunction> | null,
-    options?: MessageFormatOptions
+    options?: MessageFormatOptions<ReturnType>
   ) {
     this.options = Object.assign(
       {
@@ -194,7 +205,7 @@ export default class MessageFormat {
    * Returns a new object with properties reflecting the default locale,
    * plurals, and other options computed during initialization.
    */
-  resolvedOptions(): ResolvedMessageFormatOptions {
+  resolvedOptions(): ResolvedMessageFormatOptions<ReturnType> {
     return {
       ...this.options,
       locale: this.plurals[0].locale,
@@ -231,6 +242,6 @@ export default class MessageFormat {
       fnArgs.push(fmt);
     }
     const fn = new Function(...nfArgs, fnBody);
-    return fn(...fnArgs) as MessageFunction;
+    return fn(...fnArgs) as MessageFunction<ReturnType>;
   }
 }

--- a/packages/number-skeleton/src/errors.ts
+++ b/packages/number-skeleton/src/errors.ts
@@ -36,8 +36,8 @@ export class BadStemError extends NumberFormatError {
 /** @internal */
 export class MaskedValueError extends NumberFormatError {
   type: string;
-  prev: any;
-  constructor(type: string, prev: any) {
+  prev: unknown;
+  constructor(type: string, prev: unknown) {
     super('MASKED_VALUE', `Value for ${type} is set multiple times`);
     this.type = type;
     this.prev = prev;

--- a/packages/react/src/get-message.ts
+++ b/packages/react/src/get-message.ts
@@ -52,7 +52,7 @@ export function getMessage(
  * @param params - Parameters for a function message
  */
 export interface MessageGetterOptions {
-  baseParams?: any;
+  baseParams?: Record<string, unknown>;
   locale?: string | string[];
 }
 
@@ -75,7 +75,10 @@ export function getMessageGetter(
 ) {
   const { pathSep } = context;
   const pathPrefix = getPath(rootId, pathSep);
-  return function message(id?: string | string[], params?: any) {
+  return function message(
+    id?: string | string[],
+    params?: Record<string, unknown>
+  ) {
     const path = pathPrefix.concat(getPath(id, pathSep));
     const msg = getMessage(context, path, locale);
     if (typeof msg !== 'function') return msg;

--- a/packages/react/src/message-context.ts
+++ b/packages/react/src/message-context.ts
@@ -5,7 +5,12 @@ import { Context, createContext } from 'react';
 import { ErrorCode } from './message-error';
 
 /** @internal */
-export type MessageValue = string | number | boolean | ((props: any) => any);
+export type MessageValue =
+  | string
+  | number
+  | boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | ((props: any) => unknown);
 
 /** @internal */
 export interface MessageObject {
@@ -19,7 +24,7 @@ export interface MessageContext {
   messages: MessageObject;
 
   /** Always defined in MessageProvider children */
-  onError?: (path: string[], code: ErrorCode) => any;
+  onError?: (path: string[], code: ErrorCode) => unknown;
   pathSep: string | null;
 }
 

--- a/packages/react/src/message-provider.ts
+++ b/packages/react/src/message-provider.ts
@@ -1,4 +1,4 @@
-import { createElement, useContext, useMemo } from 'react';
+import { createElement, ReactNode, useContext, useMemo } from 'react';
 import { MessageContext, MessageObject, defaultValue } from './message-context';
 import { MessageError, ErrorCode, errorMessages } from './message-error';
 
@@ -9,7 +9,7 @@ import { FunctionComponentElement, ProviderProps } from 'react';
 
 /** @public */
 export interface MessageProviderProps {
-  children: any;
+  children: ReactNode;
 
   /**
    * A hierarchical object containing the messages as boolean, number, string or function values.
@@ -18,7 +18,7 @@ export interface MessageProviderProps {
   context?: MessageContext;
 
   /** @deprecated Use onError instead */
-  debug?: 'error' | 'warn' | ((msg: string) => any);
+  debug?: 'error' | 'warn' | ((msg: string) => unknown);
 
   /**
    * A key for the locale of the given messages.
@@ -45,7 +45,7 @@ export interface MessageProviderProps {
    * - `(error) => any`: A custom function that is called with an `Error` object with `code: string` and `path: string[]` fields set.
    *   The return falue is used as the replacement message.
    */
-  onError?: 'error' | 'silent' | 'warn' | ((error: MessageError) => any);
+  onError?: 'error' | 'silent' | 'warn' | ((error: MessageError) => unknown);
 
   /**
    * By default, `.` in a `<Message id>` splits the path into parts, such that e.g. `'a.b'` is equivalent to `['a', 'b']`.

--- a/packages/react/src/message.ts
+++ b/packages/react/src/message.ts
@@ -9,7 +9,7 @@ export interface MessageProps {
    * In this case, `params` will be ignored and `id` is optional.
    * If some other type of non-empty renderable node, it will be used as a fallback value if the message is not found.
    */
-  children?: any;
+  children?: unknown;
 
   /** The key or key path of the message. */
   id?: string | string[];
@@ -21,18 +21,18 @@ export interface MessageProps {
    * Parameters to pass to function messages as their first and only argument.
    * `params` will override `msgParams`, to allow for data keys such as `key` and `locale`.
    */
-  params?: any;
+  params?: unknown;
 
   /**
    * Parameters to pass to function messages as their first and only argument.
    * Overriden by `params`, to allow for data keys such as `key` and `locale`.
    */
-  [msgParamKey: string]: any;
+  [msgParamKey: string]: unknown;
 }
 
 // Just using { foo, ...bar } adds a polyfill with a boilerplate copyright
 // statement that would add 50% to the minified size of the whole library.
-function rest(props: { [key: string]: any }, exclude: string[]) {
+function rest(props: { [key: string]: unknown }, exclude: string[]) {
   const t: typeof props = {};
   for (const k of Object.keys(props)) if (!exclude.includes(k)) t[k] = props[k];
   return t;

--- a/packages/react/src/use-message.ts
+++ b/packages/react/src/use-message.ts
@@ -49,7 +49,7 @@ import { MessageContext } from './message-context';
  */
 export function useMessage(
   id: string | string[],
-  params?: any,
+  params?: unknown,
   locale?: string | string[]
 ) {
   const context = useContext(MessageContext);

--- a/packages/runtime/src/messages.ts
+++ b/packages/runtime/src/messages.ts
@@ -18,7 +18,9 @@
  *
  * @public
  */
-export type MessageFunction = (param?: object) => string | any[];
+export type MessageFunction = (
+  param?: Record<string, unknown>
+) => string | unknown[];
 
 /**
  * Hierarchical message object
@@ -288,7 +290,11 @@ export default class Messages {
    * @param props - Optional properties passed to the function
    * @param lc - If empty or undefined, defaults to `this.locale`
    */
-  get(key: string | string[], props?: object, locale?: string) {
+  get(
+    key: string | string[],
+    props?: Record<string, unknown>,
+    locale?: string
+  ) {
     const lc = locale || String(this.locale);
     let msg = _get(this._data[lc], key);
     if (msg) return typeof msg == 'function' ? msg(props) : msg;

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -58,7 +58,7 @@ export function plural(
   value: number,
   offset: number,
   lcfunc: (value: number, isOrdinal?: boolean) => string,
-  data: { [key: string]: any },
+  data: { [key: string]: unknown },
   isOrdinal?: boolean
 ) {
   if ({}.hasOwnProperty.call(data, value)) return data[value];
@@ -74,7 +74,7 @@ export function plural(
  * @param data The object from which results are looked up
  * @returns The result of the select statement
  */
-export function select(value: number, data: { [key: string]: any }) {
+export function select(value: number, data: { [key: string]: unknown }) {
   return {}.hasOwnProperty.call(data, value) ? data[value] : data.other;
 }
 
@@ -86,7 +86,7 @@ export function select(value: number, data: { [key: string]: any }) {
  * @param keys The required keys
  * @param data The data object being checked
  */
-export function reqArgs(keys: string[], data: { [key: string]: any }) {
+export function reqArgs(keys: string[], data: { [key: string]: unknown }) {
   for (let i = 0; i < keys.length; ++i)
     if (!data || data[keys[i]] === undefined)
       throw new Error(`Message requires argument '${keys[i]}'`);

--- a/test/browser/src/browser-tests.ts
+++ b/test/browser/src/browser-tests.ts
@@ -148,7 +148,9 @@ describe('compile() errors', () => {
   });
 });
 
-for (const [title, cases] of Object.entries(getTestCases(MessageFormat))) {
+for (const [title, cases] of Object.entries(
+  getTestCases(MessageFormat.escape)
+)) {
   describe(title, () => {
     for (const { locale, options, src, exp, skip } of cases) {
       if (skip) {

--- a/test/fixtures/messageformat.ts
+++ b/test/fixtures/messageformat.ts
@@ -17,7 +17,7 @@ export type TestCase = {
   >;
 };
 
-export const getTestCases = (MF: typeof MessageFormat) =>
+export const getTestCases = (escape: typeof MessageFormat['escape']) =>
   ({
     'Basic messages': [
       { src: 'This is a string.', exp: [[undefined, 'This is a string.']] },
@@ -91,10 +91,10 @@ export const getTestCases = (MF: typeof MessageFormat) =>
       { src: "I don''t know", exp: [[undefined, "I don't know"]] },
       { src: "'{'", exp: [[undefined, '{']] },
       { src: "'}'", exp: [[undefined, '}']] },
-      { src: MF.escape('{'), exp: [[undefined, '{']] },
-      { src: MF.escape('}'), exp: [[undefined, '}']] },
-      { src: MF.escape('#'), exp: [[undefined, '#']] },
-      { src: MF.escape('#', true), exp: [[undefined, "'#'"]] },
+      { src: escape('{'), exp: [[undefined, '{']] },
+      { src: escape('}'), exp: [[undefined, '}']] },
+      { src: escape('#'), exp: [[undefined, '#']] },
+      { src: escape('#', true), exp: [[undefined, "'#'"]] },
       { src: "'{{{'", exp: [[undefined, '{{{']] },
       { src: "'}}}'", exp: [[undefined, '}}}']] },
       { src: "'{{{'{test}'}}}'", exp: [[{ test: 4 }, '{{{4}}}']] },


### PR DESCRIPTION
Fixes #307 by using TS generics to specify the message function return type.

I was actually a bit surprised that this turned out to work in an actually type-safe fashion; there's now a `ReturnType` generic type on the MessageFormat class that defaults to `'string'`, but if the constructor gets called with an options object that includes `returnType: 'values'`, then that toggles the type as well, and that's then used to type the message function return type.

This PR also gets rid of most `any` typings, hopefully without causing any problems to external users.