### PR TITLE
Make custom formatters importable + shape their args

### DIFF
--- a/docs/custom-formatters.md
+++ b/docs/custom-formatters.md
@@ -40,7 +40,59 @@ msg({ VAR: 'big' }); // 'This is BIG in en-GB.'
 ```
 
 For compiled modules (e.g. when using with the [Webpack loader](webpack.md) or [Rollup plugin](rollup.md)),
-formatters may also be defined as `{ formatter: CustomFormatter; id: string; module: string }`, which will result in them being imported to the module as the named export `id` of the module `module`.
+formatters may also be defined as an object with the following properties:
 
-This is intended to allow for third-party formatters to be more easily used,
-and to work around the limitations of stringified functions needing to be completely independent of their surrounding context.
+- `formatter: CustomFormatter` – The formatter function, for live use
+- `id: string` and `module: string` should both be defined if either is, to provide for importing the formatter as `id` from `module` in the compiled module.
+  This is intended to allow for third-party formatters to be more easily used,
+  and to work around the limitations of stringified functions needing to be completely independent of their surrounding context.
+- `arg` defines shape in which any argument object will get passed to the formatter, using one of the following values:
+  - `'string'` (default) will pass any argument as a trimmed `string`.
+  - `'raw'` provides an `Array` of values, which will be `string` for literals, but may include e.g. runtime variable values.
+  - `'options'` requires its value to be literal, but will then parse that as a `Record<string, string | number | boolean | null>` shape,
+    using a very simple parser that first splits the string on each `,` and for each pair considers trimmed content before the first `:` as the key and the rest as the (also trimmed) value.
+    If the value matches `true`, `false`, `null`, or the JSON representation of a number, it will be parsed as the corresponding type.
+    No form of escaping is provided for.
+
+Putting all that together, if we had this module available:
+
+```js
+// '@messageformat/upcase'
+
+export function formatter(value, locale, override) {
+  const lc = (override && override.locale) || locale;
+  return String(value).toLocaleUpperCase(lc);
+}
+
+export const upcase = {
+  formatter,
+  arg: 'options',
+  id: 'formatter',
+  module: '@messageformat/upcase'
+};
+```
+
+We can use it like this:
+
+```js
+import MessageFormat from '@messageformat/core';
+import compileModule from '@messageformat/core/compile-module';
+import { upcase } from '@messageformat/upcase';
+
+const mf = new MessageFormat('en', { customFormatters: { upcase } });
+const msgSet = {
+  here: 'This is {x, upcase} here',
+  fin: 'This is {x, upcase, locale: fi} in Finnish'
+};
+compileModule(mf, msgSet);
+```
+
+Resulting in this compiled module:
+
+```js
+import { formatter as upcase } from '@messageformat/upcase';
+export default {
+  here: d => 'This is ' + upcase(d.x, 'en') + ' here',
+  fin: d => 'This is ' + upcase(d.x, 'en', { locale: 'fi' }) + ' in Finnish'
+};
+```

--- a/docs/custom-formatters.md
+++ b/docs/custom-formatters.md
@@ -23,10 +23,6 @@ In JavaScript, a custom formatter may be defined as a function that is called wi
 - The current **`locale`** code as a string
 - The **`arg`** value, or `null` if it is not set
 
-When using with the [Webpack loader](webpack.md), [Rollup plugin](rollup.md) or any other build-time tool that will stringify the compiled form of the messages,
-formatter functions **must** be independent of the their surrounding context.
-If a formatter needs to use an external dependency, it should explicitly `import()` it within its body.
-
 To define and add your own formatter, use the `customFormatters` option of the MessageFormat constructor:
 
 ```js
@@ -42,3 +38,9 @@ const mf = new MessageFormat('en-GB', {
 const msg = mf.compile('This is {VAR, upcase} in {_, locale}.');
 msg({ VAR: 'big' }); // 'This is BIG in en-GB.'
 ```
+
+For compiled modules (e.g. when using with the [Webpack loader](webpack.md) or [Rollup plugin](rollup.md)),
+formatters may also be defined as `{ formatter: CustomFormatter; id: string; module: string }`, which will result in them being imported to the module as the named export `id` of the module `module`.
+
+This is intended to allow for third-party formatters to be more easily used,
+and to work around the limitations of stringified functions needing to be completely independent of their surrounding context.

--- a/examples/custom-formatter/README.md
+++ b/examples/custom-formatter/README.md
@@ -1,0 +1,19 @@
+# Rollup Example
+
+This uses [rollup-plugin-messageformat](http://messageformat.github.io/messageformat/rollup/) to compile `src/messages.yaml`, using a custom number formatter implementation.
+
+To build the example, run this command at the root of the repository:
+
+```
+npx lerna run build --scope custom-formatter-example
+```
+
+That will produce `dist/main.js` under this directory.
+
+To see the output in a terminal, run it with Node.js:
+
+```
+node dist/main.js
+```
+
+To see the output in a browser, open `index.html` in a browser and inspect the browser's console.

--- a/examples/custom-formatter/number.js
+++ b/examples/custom-formatter/number.js
@@ -1,0 +1,4 @@
+export function number(value, locale, options = {}) {
+  const nf = new Intl.NumberFormat(locale, options);
+  return nf.format(value);
+}

--- a/examples/custom-formatter/package.json
+++ b/examples/custom-formatter/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "custom-formatter-example",
+  "private": true,
+  "scripts": {
+    "build": "rollup -c",
+    "start": "node dist/main"
+  }
+}

--- a/examples/custom-formatter/rollup.config.js
+++ b/examples/custom-formatter/rollup.config.js
@@ -1,0 +1,22 @@
+import alias from '@rollup/plugin-alias';
+import messageformat from 'rollup-plugin-messageformat';
+import { number } from './number';
+
+export default {
+  input: 'src/main.js',
+  output: { dir: 'dist' },
+  plugins: [
+    alias({ entries: { '@number': './number.js' } }),
+    messageformat({
+      customFormatters: {
+        number: {
+          formatter: number,
+          arg: 'options',
+          id: 'number',
+          module: '@number'
+        }
+      },
+      locales: ['en']
+    })
+  ]
+};

--- a/examples/custom-formatter/src/main.js
+++ b/examples/custom-formatter/src/main.js
@@ -1,0 +1,5 @@
+import messages from './messages.properties';
+
+console.log(messages.money({ n: 123.456 }));
+console.log(messages.round({ n: 654321 }));
+console.log(messages.speed({ n: 42 }));

--- a/examples/custom-formatter/src/messages.properties
+++ b/examples/custom-formatter/src/messages.properties
@@ -1,0 +1,3 @@
+money: Your balance is {n, number, style: currency, currency: EUR}
+round: That's about {n, number, maximumSignificantDigits: 3}
+speed: Your speed was {n, number, style: unit, unit: kilometer-per-hour}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@commitlint/config-conventional": "^12.0.1",
         "@microsoft/api-documenter": "^7.11.0",
         "@microsoft/api-extractor": "^7.12.0",
+        "@rollup/plugin-alias": "^3.1.2",
         "@rollup/plugin-commonjs": "^17.1.0",
         "@rollup/plugin-node-resolve": "^11.2.0",
         "@rollup/plugin-typescript": "^8.2.0",
@@ -5429,6 +5430,30 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-alias": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
+      "integrity": "sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==",
+      "dev": true,
+      "dependencies": {
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-alias/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -26492,6 +26517,23 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^6.0.0"
+      }
+    },
+    "@rollup/plugin-alias": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.2.tgz",
+      "integrity": "sha512-wzDnQ6v7CcoRzS0qVwFPrFdYA4Qlr+ookA217Y2Z3DPZE1R8jrFNM3jvGgOf6o6DMjbnQIn5lCIJgHPe1Bt3uw==",
+      "dev": true,
+      "requires": {
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        }
       }
     },
     "@rollup/plugin-commonjs": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@commitlint/config-conventional": "^12.0.1",
     "@microsoft/api-documenter": "^7.11.0",
     "@microsoft/api-extractor": "^7.12.0",
+    "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-commonjs": "^17.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@rollup/plugin-typescript": "^8.2.0",

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -39,11 +39,8 @@ describe('compileModule()', function () {
     );
   });
 
-  it('can be instantiated multiple times for multiple languages', async function () {
-    const mf = {
-      en: new MessageFormat('en'),
-      ru: new MessageFormat('ru')
-    };
+  it('can be instantiated multiple times', async function () {
+    const mf = { en: new MessageFormat('en'), ru: new MessageFormat('ru') };
     const cf = {
       en: await getModule(mf.en, {
         msg: '{count} {count, plural, other{users}}'
@@ -62,121 +59,180 @@ describe('compileModule()', function () {
     expect(cf.ru.msg({ count: 13 })).toBe('13 пользователей');
   });
 
-  const customFormatters = { lc: (v, lc) => lc };
-
-  it('can support multiple languages', async function () {
-    const mf = new MessageFormat(['en', 'fr', 'ru'], { customFormatters });
-    const cf = await getModule(mf, {
-      fr: 'Locale: {_, lc}',
-      ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
-    });
-    expect(cf.fr({})).toBe('Locale: fr');
-    expect(cf.ru({ count: 12 })).toBe('3');
-  });
-
-  it('defaults to supporting only English', async function () {
-    const mf = new MessageFormat(null, { customFormatters });
-    const cf = await getModule(mf, {
-      xx: 'Locale: {_, lc}',
-      fr: 'Locale: {_, lc}'
-    });
-    expect(cf.xx({})).toBe('Locale: en');
-    expect(cf.fr({})).toBe('Locale: en');
-  });
-
-  it('supports all languages with locale "*"', async function () {
-    const mf = new MessageFormat('*', { customFormatters });
-    const cf = await getModule(mf, {
-      fr: 'Locale: {_, lc}',
-      xx: 'Locale: {_, lc}',
-      ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
-    });
-    expect(cf.fr({})).toBe('Locale: fr');
-    expect(cf.xx({})).toBe('Locale: en');
-    expect(cf.ru({ count: 12 })).toBe('3');
-  });
-
-  it('should support custom formatter functions', async function () {
-    const mf = new MessageFormat('en', {
-      customFormatters: { uppercase: v => String(v).toUpperCase() }
-    });
-    const msg = await getModule(mf, {
-      0: 'This is {VAR,uppercase}.',
-      1: 'Other string'
-    });
-    expect(msg[0]({ VAR: 'big' })).toBe('This is BIG.');
-  });
-
-  if (NODE_VERSION >= 12) {
-    it('supports number formatters', async function () {
-      const mf = new MessageFormat('en');
-      const msg = await getModule(mf, {
-        0: 'Your balance is {VAR, number, ¤#,##0.00;(¤#,##0.00)}.',
-        1: 'The sparrow flew {VAR, number, :: measure-unit/length-meter unit-width-full-name}'
+  describe('multiple languages', () => {
+    it('basic support', async function () {
+      const mf = new MessageFormat(['en', 'fr', 'ru'], {
+        customFormatters: { lc: (v, lc) => lc }
       });
-      expect(msg[0]({ VAR: -3.27 })).toBe('Your balance is ($3.27).');
-      expect(msg[1]({ VAR: 42 })).toBe('The sparrow flew 42 meters');
+      const cf = await getModule(mf, {
+        fr: 'Locale: {_, lc}',
+        ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
+      });
+      expect(cf.fr({})).toBe('Locale: fr');
+      expect(cf.ru({ count: 12 })).toBe('3');
     });
-  }
 
-  it('should import cardinal-only plural by default', async () => {
-    const mf = new MessageFormat('en');
-    const msg = '{foo, plural, one{one} other{other}}';
-    const src = compileModule(mf, { msg });
-    expect(src).toMatch(
-      /import { en } from "@messageformat\/runtime\/lib\/cardinals"/
-    );
+    it('defaults to supporting only English', async function () {
+      const mf = new MessageFormat(null, {
+        customFormatters: { lc: (v, lc) => lc }
+      });
+      const cf = await getModule(mf, {
+        xx: 'Locale: {_, lc}',
+        fr: 'Locale: {_, lc}'
+      });
+      expect(cf.xx({})).toBe('Locale: en');
+      expect(cf.fr({})).toBe('Locale: en');
+    });
+
+    it('supports all languages with locale "*"', async function () {
+      const mf = new MessageFormat('*', {
+        customFormatters: { lc: (v, lc) => lc }
+      });
+      const cf = await getModule(mf, {
+        fr: 'Locale: {_, lc}',
+        xx: 'Locale: {_, lc}',
+        ru: '{count, plural, one{1} few{2} many{3} other{x:#}}'
+      });
+      expect(cf.fr({})).toBe('Locale: fr');
+      expect(cf.xx({})).toBe('Locale: en');
+      expect(cf.ru({ count: 12 })).toBe('3');
+    });
   });
 
-  it('should import combined plural if required', async () => {
-    const mf = new MessageFormat('en');
-    const msg = '{foo, selectordinal, one{one} other{other}}';
-    const src = compileModule(mf, { msg });
-    expect(src).toMatch(
-      /import { en } from "@messageformat\/runtime\/lib\/plurals"/
-    );
+  describe('custom plurals', () => {
+    it('should import cardinal-only plural by default', async () => {
+      const mf = new MessageFormat('en');
+      const msg = '{foo, plural, one{one} other{other}}';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(
+        /import { en } from "@messageformat\/runtime\/lib\/cardinals"/
+      );
+    });
+
+    it('should import combined plural if required', async () => {
+      const mf = new MessageFormat('en');
+      const msg = '{foo, selectordinal, one{one} other{other}}';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(
+        /import { en } from "@messageformat\/runtime\/lib\/plurals"/
+      );
+    });
+
+    it('should inline custom plural by default', async () => {
+      const lc: PluralFunction = function lc() {
+        return 'other';
+      };
+      const mf = new MessageFormat(lc);
+      const msg = '{foo, plural, one{one} other{other}}';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(/\bfunction lc\b/);
+    });
+
+    it('should import custom plural if defined with module', async () => {
+      const lc: PluralFunction = () => 'other';
+      lc.module = 'custom-module';
+      const mf = new MessageFormat(lc);
+      const msg = '{foo, plural, one{one} other{other}}';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(/import { lc } from "custom-module"/);
+    });
   });
 
-  it('should inline custom plural by default', async () => {
-    const lc: PluralFunction = function lc() {
-      return 'other';
-    };
-    const mf = new MessageFormat(lc);
-    const msg = '{foo, plural, one{one} other{other}}';
-    const src = compileModule(mf, { msg });
-    expect(src).toMatch(/\bfunction lc\b/);
-  });
+  describe('custom formatters', () => {
+    it('basic support', async function () {
+      const mf = new MessageFormat('en', {
+        customFormatters: { uppercase: v => String(v).toUpperCase() }
+      });
+      const msg = await getModule(mf, {
+        0: 'This is {VAR,uppercase}.',
+        1: 'Other string'
+      });
+      expect(msg[0]({ VAR: 'big' })).toBe('This is BIG.');
+    });
 
-  it('should import custom plural if defined with module', async () => {
-    const lc: PluralFunction = () => 'other';
-    lc.module = 'custom-module';
-    const mf = new MessageFormat(lc);
-    const msg = '{foo, plural, one{one} other{other}}';
-    const src = compileModule(mf, { msg });
-    expect(src).toMatch(/import { lc } from "custom-module"/);
-  });
+    if (NODE_VERSION >= 12) {
+      it('supports number formatters', async function () {
+        const mf = new MessageFormat('en');
+        const msg = await getModule(mf, {
+          0: 'Your balance is {VAR, number, ¤#,##0.00;(¤#,##0.00)}.',
+          1: 'The sparrow flew {VAR, number, :: measure-unit/length-meter unit-width-full-name}'
+        });
+        expect(msg[0]({ VAR: -3.27 })).toBe('Your balance is ($3.27).');
+        expect(msg[1]({ VAR: 42 })).toBe('The sparrow flew 42 meters');
+      });
+    }
 
-  it('should import custom formatter if defined with module; id == key', async () => {
-    const cf = {
-      formatter: (v: unknown) => String(v).toUpperCase(),
-      id: 'up',
-      module: 'upmod'
-    };
-    const mf = new MessageFormat('en', { customFormatters: { up: cf } });
-    const msg = '{foo, up}';
-    const src = compileModule(mf, { msg });
-    expect(src).toMatch(/import { up } from "upmod"/);
-  });
+    it('import from module; id == key', async () => {
+      const upcase = {
+        formatter: (v: unknown) => String(v).toUpperCase(),
+        id: 'upcase',
+        module: 'upmod'
+      };
+      const mf = new MessageFormat('en', { customFormatters: { upcase } });
+      const msg = '{foo, upcase}';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(/import { upcase } from "upmod"/);
+    });
 
-  it('should import custom formatter if defined with module; id != key', async () => {
-    const cf = {
-      formatter: (v: unknown) => String(v).toUpperCase(),
-      id: 'upper',
-      module: 'upmod'
-    };
-    const mf = new MessageFormat('en', { customFormatters: { up: cf } });
-    const msg = '{foo, up}';
-    const src = compileModule(mf, { msg });
-    expect(src).toMatch(/import { upper as up } from "upmod"/);
+    it('import from module; id != key', async () => {
+      const upcase = {
+        formatter: (v: unknown) => String(v).toUpperCase(),
+        id: 'upperCase',
+        module: 'upmod'
+      };
+      const mf = new MessageFormat('en', { customFormatters: { upcase } });
+      const msg = '{foo, upcase}';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(/import { upperCase as upcase } from "upmod"/);
+    });
+
+    it('defaults to string arg', () => {
+      const upcase = {
+        formatter: (v: unknown) => String(v).toUpperCase()
+      };
+      const mf = new MessageFormat('en', { customFormatters: { upcase } });
+      const msg = '{foo, upcase, arg {x} }';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(
+        /upcase\([^)]+, \(" arg " \+ d\.x \+ " "\).trim\(\)\)/
+      );
+    });
+
+    it('arg: "raw"', () => {
+      const upcase = {
+        formatter: (v: unknown) => String(v).toUpperCase(),
+        arg: 'raw'
+      } as const;
+      const mf = new MessageFormat('en', { customFormatters: { upcase } });
+      const msg = '{foo, upcase, arg {x} }';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(/upcase\([^)]+, \[" arg ", d\.x, " "\]\)/);
+    });
+
+    it('arg: "options"', () => {
+      const upcase = {
+        formatter: (v: unknown) => String(v).toUpperCase(),
+        arg: 'options'
+      } as const;
+      const mf = new MessageFormat('en', { customFormatters: { upcase } });
+      const msg =
+        '{foo, upcase, num: 1, foo:foo,foo:bar, true:true, false:  false,\tnull\n:\n\nnull }';
+      const src = compileModule(mf, { msg });
+      expect(src).toMatch(
+        /upcase\([^)]+, {"num":1,"foo":"bar","true":true,"false":false,"null":null}\)/
+      );
+    });
+
+    it('arg: "options" requires literal value', () => {
+      const upcase = {
+        formatter: (v: unknown) => String(v).toUpperCase(),
+        arg: 'options'
+      } as const;
+      const mf = new MessageFormat('en', { customFormatters: { upcase } });
+      const msg = '{foo, upcase, arg:1,foo:{x} }';
+      expect(() => compileModule(mf, { msg })).toThrow(
+        'Expected literal options for upcase formatter'
+      );
+    });
   });
 });

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -124,7 +124,7 @@ describe('compileModule()', function () {
     const msg = '{foo, plural, one{one} other{other}}';
     const src = compileModule(mf, { msg });
     expect(src).toMatch(
-      /import { en } from '@messageformat\/runtime\/lib\/cardinals'/
+      /import { en } from "@messageformat\/runtime\/lib\/cardinals"/
     );
   });
 
@@ -133,7 +133,7 @@ describe('compileModule()', function () {
     const msg = '{foo, selectordinal, one{one} other{other}}';
     const src = compileModule(mf, { msg });
     expect(src).toMatch(
-      /import { en } from '@messageformat\/runtime\/lib\/plurals'/
+      /import { en } from "@messageformat\/runtime\/lib\/plurals"/
     );
   });
 
@@ -153,6 +153,29 @@ describe('compileModule()', function () {
     const mf = new MessageFormat(lc);
     const msg = '{foo, plural, one{one} other{other}}';
     const src = compileModule(mf, { msg });
-    expect(src).toMatch(/import { lc } from 'custom-module'/);
+    expect(src).toMatch(/import { lc } from "custom-module"/);
+  });
+
+  it('should import custom formatter if defined with module', async () => {
+    const cf = {
+      formatter: (v: unknown) => String(v).toUpperCase(),
+      module: 'upmod'
+    };
+    const mf = new MessageFormat('en', { customFormatters: { up: cf } });
+    const msg = '{foo, up}';
+    const src = compileModule(mf, { msg });
+    expect(src).toMatch(/import { up } from "upmod"/);
+  });
+
+  it('should import custom formatter if defined with module & id', async () => {
+    const cf = {
+      formatter: (v: unknown) => String(v).toUpperCase(),
+      id: 'upper',
+      module: 'upmod'
+    };
+    const mf = new MessageFormat('en', { customFormatters: { up: cf } });
+    const msg = '{foo, up}';
+    const src = compileModule(mf, { msg });
+    expect(src).toMatch(/import { upper as up } from "upmod"/);
   });
 });

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -241,5 +241,28 @@ describe('compileModule()', function () {
       const cf = await getModule(mf, { msg: 'one and one is {one, number}' });
       expect(cf.msg({ one: 1 })).toBe('one and one is 3');
     });
+
+    it('complains if trying to use a reserved word as key', () => {
+      const number = (v: unknown) => Number(v) + 2;
+      const mf = new MessageFormat('en', {
+        customFormatters: { switch: number }
+      });
+      const msg = '{foo, switch}';
+      expect(() => compileModule(mf, { msg })).toThrow(
+        'Reserved word used as formatter identifier: switch'
+      );
+    });
+
+    it('complains if trying to override a plural function', () => {
+      const number = (v: unknown) => Number(v) + 2;
+      const mf = new MessageFormat('en', {
+        customFormatters: { en: number }
+      });
+      const msg1 = '{foo, plural, other{fff}}';
+      const msg2 = '{foo, en}';
+      expect(() => compileModule(mf, { msg1, msg2 })).toThrow(
+        'Cannot override locale runtime function as formatter: en'
+      );
+    });
   });
 });

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -156,9 +156,10 @@ describe('compileModule()', function () {
     expect(src).toMatch(/import { lc } from "custom-module"/);
   });
 
-  it('should import custom formatter if defined with module', async () => {
+  it('should import custom formatter if defined with module; id == key', async () => {
     const cf = {
       formatter: (v: unknown) => String(v).toUpperCase(),
+      id: 'up',
       module: 'upmod'
     };
     const mf = new MessageFormat('en', { customFormatters: { up: cf } });
@@ -167,7 +168,7 @@ describe('compileModule()', function () {
     expect(src).toMatch(/import { up } from "upmod"/);
   });
 
-  it('should import custom formatter if defined with module & id', async () => {
+  it('should import custom formatter if defined with module; id != key', async () => {
     const cf = {
       formatter: (v: unknown) => String(v).toUpperCase(),
       id: 'upper',

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -234,5 +234,12 @@ describe('compileModule()', function () {
         'Expected literal options for upcase formatter'
       );
     });
+
+    it('allows overriding default formatters', async () => {
+      const number = (v: unknown) => Number(v) + 2;
+      const mf = new MessageFormat('en', { customFormatters: { number } });
+      const cf = await getModule(mf, { msg: 'one and one is {one, number}' });
+      expect(cf.msg({ one: 1 })).toBe('one and one is 3');
+    });
   });
 });

--- a/packages/core/src/compile-module.ts
+++ b/packages/core/src/compile-module.ts
@@ -23,13 +23,14 @@ export type MessageModule<
     };
 
 function stringifyRuntime(runtime: RuntimeMap) {
-  const imports: { [key: string]: string[] } = {};
-  const vars: { [key: string]: string } = {};
+  const imports: Record<string, string[]> = {};
+  const vars: Record<string, string> = {};
 
   for (const [name, fn] of Object.entries(runtime)) {
     if (fn.module) {
+      const alias = fn.id && fn.id !== name ? `${fn.id} as ${name}` : name;
       const prev = imports[fn.module];
-      imports[fn.module] = prev ? [...prev, name] : [name];
+      imports[fn.module] = prev ? [...prev, alias] : [alias];
     } else {
       vars[name] = String(fn);
     }
@@ -37,7 +38,7 @@ function stringifyRuntime(runtime: RuntimeMap) {
 
   const is = Object.entries(imports).map(
     ([module, names]) =>
-      `import { ${names.sort().join(', ')} } from '${module}';`
+      `import { ${names.sort().join(', ')} } from ${JSON.stringify(module)};`
   );
   const vs = Object.entries(vars).map(([id, value]) =>
     new RegExp(`^function ${id}\\b`).test(value)

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -210,10 +210,10 @@ export default class Compiler {
   }
 
   runtimeIncludes(key: string, type: RuntimeType) {
-    const prev = this.runtime[key];
-    if (!prev || prev.type === type) return prev;
     if (identifier(key) !== key)
       throw new SyntaxError(`Reserved word used as ${type} identifier: ${key}`);
+    const prev = this.runtime[key];
+    if (!prev || prev.type === type) return prev;
     throw new TypeError(
       `Cannot override ${prev.type} runtime function as ${type}: ${key}`
     );

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -18,6 +18,12 @@ export type MessageFunction<ReturnType extends 'string' | 'values'> = (
   param?: Record<string, unknown>
 ) => ReturnType extends 'string' ? string : unknown[];
 
+export type CustomFormatter = (
+  value: unknown,
+  locale: string,
+  arg: string | null
+) => unknown;
+
 /**
  * Options for the MessageFormat constructor
  *
@@ -47,11 +53,9 @@ export interface MessageFormatOptions<
    * for more details.
    */
   customFormatters?: {
-    [key: string]: (
-      value: unknown,
-      locale: string,
-      arg: string | null
-    ) => string;
+    [key: string]:
+      | CustomFormatter
+      | { formatter: CustomFormatter; id: string; module: string };
   };
 
   /**

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -55,7 +55,12 @@ export interface MessageFormatOptions<
   customFormatters?: {
     [key: string]:
       | CustomFormatter
-      | { formatter: CustomFormatter; id: string; module: string };
+      | {
+          formatter: CustomFormatter;
+          arg?: 'string' | 'raw' | 'options';
+          id?: string;
+          module?: string;
+        };
   };
 
   /**

--- a/packages/rollup-plugin/src/index.test.ts
+++ b/packages/rollup-plugin/src/index.test.ts
@@ -124,8 +124,8 @@ describe('transform', () => {
     const res = transform(src, 'fi.properties');
     expect(res).toMatchObject({
       code: source`
-        import { number, plural } from '@messageformat/runtime';
-        import { fi } from '@messageformat/runtime/lib/cardinals';
+        import { number, plural } from "@messageformat/runtime";
+        import { fi } from "@messageformat/runtime/lib/cardinals";
         export default {
           key: (d) => "value " + plural(d.foo, 0, fi, { one: "1", other: number("fi", d.foo, 0) })
         }`


### PR DESCRIPTION
Closes #229 

This effectively provides a way for custom formatters to be made reusable, and e.g. published as npm modules. To do that, we add an object form to the values that may be passed to `options.customFormatters`.

As an example, if we had this module available:

```js
// number.js
export function number(value, locale, options = {}) {
  const nf = new Intl.NumberFormat(locale, options);
  return nf.format(value);
}
```

We could use it like this:

```js
// rollup.config.js
import alias from '@rollup/plugin-alias';
import messageformat from 'rollup-plugin-messageformat';
import { number } from './number';

export default {
  input: 'src/main.js',
  output: { dir: 'dist' },
  plugins: [
    alias({ entries: { '@number': './number.js' } }),
    messageformat({
      customFormatters: {
        number: { formatter: number, arg: 'options', id: 'number', module: '@number' }
      },
      locales: ['en']
    })
  ]
};
```

```
# src/messages.properties
money = Your balance is {n, number, style: currency, currency: EUR}
round = That's about {n, number, maximumSignificantDigits: 3}
speed = Your speed was {n, number, style: unit, unit: kilometer-per-hour}
```

```js
// src/main.js
import messages from './messages.properties';

console.log(messages.money({ n: 123.456 }));
console.log(messages.round({ n: 654321 }));
console.log(messages.speed({ n: 42 }));
```

Resulting in a compiled bundle like this:

```js
// dist/main.js
function number(value, locale, options = {}) {
  const nf = new Intl.NumberFormat(locale, options);
  return nf.format(value);
}

var messages = {
  money: (d) => "Your balance is " + number(d.n, "en", {"style":"currency","currency":"EUR"}),
  round: (d) => "That's about " + number(d.n, "en", {"maximumSignificantDigits":3}),
  speed: (d) => "Your speed was " + number(d.n, "en", {"style":"unit","unit":"kilometer-per-hour"})
};

console.log(messages.money({ n: 123.456 }));
console.log(messages.round({ n: 654321 }));
console.log(messages.speed({ n: 42 }));
```

Which would produce this output when executed:

```
Your balance is €123.46
That's about 654,000
Your speed was 42 km/h
```

See the updated `docs/custom-formatters.md` for more details, or `examples/custom-formatter/` for a full working example of the above.

**Edit:** Updated example to match actual code.