### PR TITLE
Doc fixes

### DIFF
--- a/docs/api/runtime.messages.md
+++ b/docs/api/runtime.messages.md
@@ -48,7 +48,7 @@ const msgSet = {
     e: 'Minä puhun vain suomea.'
   }
 };
-writeFileSync('messages.js', String(mf.compile(JSON.stringify(msgSet))));
+writeFileSync('messages.js', String(mf.compile(msgSet)));
 
 ```
 

--- a/docs/api/runtime.messages.md
+++ b/docs/api/runtime.messages.md
@@ -48,7 +48,7 @@ const msgSet = {
     e: 'Minä puhun vain suomea.'
   }
 };
-writeFileSync('messages.js', String(mf.compile(msgSet)));
+writeFileSync('messages.js', String(mf.compile(JSON.stringify(msgSet))));
 
 ```
 

--- a/docs/rollup.md
+++ b/docs/rollup.md
@@ -30,7 +30,7 @@ With this config:
 import messageformat from 'rollup-plugin-messageformat'
 
 export default {
-  entry: 'src/app.js',
+  input: 'src/app.js',
   external: /^@messageformat\/runtime\b/,
   output: { format: 'es' },
   plugins: [messageformat({ locales: ['en', 'fr'] })]

--- a/packages/runtime/src/messages.ts
+++ b/packages/runtime/src/messages.ts
@@ -46,6 +46,7 @@ export interface MessageData {
  * // build.js
  * import { writeFileSync } from 'fs';
  * import MessageFormat from '@messageformat/core';
+ * import compileModule from '@messageformat/core/compile-module'
  *
  * const mf = new MessageFormat(['en', 'fi']);
  * const msgSet = {
@@ -61,7 +62,7 @@ export interface MessageData {
  *     e: 'Minä puhun vain suomea.'
  *   }
  * };
- * writeFileSync('messages.js', String(mf.compile(msgSet)));
+ * writeFileSync('messages.js', compileModule(mf, msgSet));
  * ```
  *
  * ```js


### PR DESCRIPTION
Fixed `rollup.config.js` and the conversion to string for usage in compile. The emitted file `messages.js` in the `@messageformat/runtime ` example is also broken.