### PR TITLE
Fix pathSep types

### DIFF
--- a/packages/react/src/message-provider.ts
+++ b/packages/react/src/message-provider.ts
@@ -51,7 +51,7 @@ export interface MessageProviderProps {
    * By default, `.` in a `<Message id>` splits the path into parts, such that e.g. `'a.b'` is equivalent to `['a', 'b']`.
    * Use this option to customize or disable this behaviour (by setting it to `null`).
    */
-  pathSep?: string;
+  pathSep?: string | null;
 }
 
 function getOnError(


### PR DESCRIPTION
The `@messageformat/react` package `MessageProvider` prop `pathSep` types only allow `string` and `undefined` values, while the documentation states that `null` is also a valid value. This fixes the issue by adding the missing type.