### PR TITLE
Drop Node.js 10 tests/support due to its EOL

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,30 +9,37 @@ on:
 jobs:
   active:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with: { node-version: 14.x }
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
-      - run: npm run lint
-      - run: npx prettier --check .
+      - run: npm run build
 
   maintenance:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
+      - uses: actions/setup-node@v1
+        with: { node-version: 12.x }
       - run: npm install -g full-icu
       - run: echo "NODE_ICU_DATA=`node-full-icu-path 2>/dev/null`" >> $GITHUB_ENV
       - run: npm ci
       - run: npm test
       # https://github.com/actions/runner/issues/795
       - run: echo "NODE_ICU_DATA=" >> $GITHUB_ENV
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with: { node-version: 16.x }
+      - run: npm ci
+      - run: npm run lint
+      - run: npx prettier --check .

--- a/packages/core/src/messageformat.test.ts
+++ b/packages/core/src/messageformat.test.ts
@@ -159,7 +159,6 @@ describe('compile() errors', () => {
   });
 });
 
-const isNode10 = process.version.startsWith('v10');
 const isNode12 = process.version.startsWith('v12');
 const isV2 =
   // @ts-ignore signDisplay introduced in Unified API proposal, i.e. "NumberFormat v2"
@@ -172,7 +171,6 @@ for (const [title, cases] of Object.entries(
     for (const { locale, options, src, exp, skip } of cases) {
       let desc: Mocha.SuiteFunction | Mocha.PendingSuiteFunction = describe;
       if (skip) {
-        if (isNode10 && skip.includes('node10')) desc = describe.skip;
         if (isNode12 && skip.includes('node12')) desc = describe.skip;
         if (!isV2 && skip.includes('v1')) desc = describe.skip;
       }

--- a/test/fixtures/formatters.ts
+++ b/test/fixtures/formatters.ts
@@ -36,7 +36,7 @@ export function dateSkeletonCases(): TestCase[] {
     GrMMMdd: { exp: 'Jan 02, 2006 AD' },
     GMMd: { exp: '01/2 AD' },
     hamszzzz: { exp: /^3:0?4:0?5 PM [A-Z]/ },
-    Mk: { exp: '1, 15', skip: ['node10'] }
+    Mk: { exp: '1, 15' }
   };
   return Object.entries(cases).map(([fmt, { exp, skip }]) => ({
     src: `{date, date, ::${fmt}}`,
@@ -59,38 +59,38 @@ export function numberPatternCases(): TestCase[] {
       value: 1234.567,
       lc: 'fr',
       exp: /^1\s234,57$/,
-      skip: ['node10', 'node12']
+      skip: ['node12']
     },
     '#,##0.###': {
       value: 1234.567,
       lc: 'fr',
       exp: /^1\s234,567$/,
-      skip: ['node10', 'node12']
+      skip: ['node12']
     },
     '###0.#####': {
       value: 1234.567,
       lc: 'fr',
       exp: '1234,567',
-      skip: ['node10', 'node12']
+      skip: ['node12']
     },
     '###0.0000#': {
       value: 1234.567,
       lc: 'fr',
       exp: '1234,5670',
-      skip: ['node10', 'node12']
+      skip: ['node12']
     },
     '00000.0000': {
       value: 1234.567,
       lc: 'fr',
       exp: '01234,5670',
-      skip: ['node10', 'node12']
+      skip: ['node12']
     },
     '#,##0.00 ¤': {
       value: 1234.567,
       lc: 'fr',
       cur: 'EUR',
       exp: /^1\s234,57\s€$/,
-      skip: ['node10', 'node12']
+      skip: ['node12']
     },
     "'#'#": { value: 123, lc: 'en', exp: '#123' },
     //"# o''clock": { value: 12, lc: 'en', exp: "12 o'clock" },


### PR DESCRIPTION
BREAKING CHANGE: Tests for the library in Node.js 10 are dropped. No immediate changes should cause any part of the library not to work with Node.js 10, but that will no longer be verified by CI tests or otherwise.