### PR TITLE
fix(cli): Do not drop initial keys for single-message input files

### DIFF
--- a/packages/cli/lib/read-input.js
+++ b/packages/cli/lib/read-input.js
@@ -66,8 +66,11 @@ module.exports = function readInput(include, extensions, sep) {
 
   while (input && typeof input === 'object') {
     const keys = Object.keys(input);
-    if (keys.length === 1) input = input[keys[0]];
-    else break;
+    if (keys.length === 1) {
+      const child = input[keys[0]];
+      if (!child || typeof child !== 'object') break;
+      input = child;
+    } else break;
   }
   return input;
 };


### PR DESCRIPTION
This is a minimal fix for the clearly-buggy behaviour reported by @cdaringe in #339, where a single top-level key is lost. I think this is a patch-level update, while fixing the general case of the CLI's weird default behaviour would be a breaking change.