### PR TITLE
Use a string param in the select runtime function

### DIFF
--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -74,7 +74,7 @@ export function plural(
  * @param data The object from which results are looked up
  * @returns The result of the select statement
  */
-export function select(value: number, data: { [key: string]: unknown }) {
+export function select(value: string, data: { [key: string]: unknown }) {
   return {}.hasOwnProperty.call(data, value) ? data[value] : data.other;
 }
 


### PR DESCRIPTION
The select function should have a string type for the `value` parameter. Since it cannot be type checked, it doesn't throw any error, except when using the cli's output in ts files.