### PR TITLE
Add check to detect test env when consumer is running tests

### DIFF
--- a/packages/react/src/message-provider.ts
+++ b/packages/react/src/message-provider.ts
@@ -65,7 +65,9 @@ function getOnError(
     throw new MessageError(path, code, asId);
   }
   function msgWarning(path: string[], code: ErrorCode) {
-    console.warn(errorMessages[code], path);
+    if (process.env.NODE_ENV !== "test") {
+      console.warn(errorMessages[code], path);
+    }
     return asId(path);
   }
 

--- a/packages/react/src/use-message.test.tsx
+++ b/packages/react/src/use-message.test.tsx
@@ -27,6 +27,8 @@ const cases = [
 ];
 
 for (const { title, locale, messages } of cases) {
+  process.env.NODE_ENV = "mockTest"
+
   describe(title, () => {
     test('Array id', () => {
       const component = renderer.create(


### PR DESCRIPTION
When the consumers of the library `messageformat/react` is writing tests for their component, which uses `useMessage` – a lot of `console.warn` is shown all over if there is no message provided.

Example:

```js
// component.jsx
function Component() {
  // We would get an console.warn here for both tests.
  // Since the second text is missing in the first test block and vice versa in the second test block
  const firstText = useMessage("first.text");
  const secondText = useMessage("second.text");
  return (
    <div>
      <p>{firstText}</p>
      <p>{secondText}</p>
    </div>
  );
}

// component.test.jsx
import { screen, render } from "@testing-library/react";
import { MessageProvider } from "@messageformat/react";

// just an example of how a consumers custom rendered could look like
function customRender(ui, options) {
  return render(
    <MessageProvider locale="sv" messages={options.messages}>
      {ui}
    </MessageProvider>
  );
}

test("first text is rendered", () => {
  customRender(<Component />, {
    message: {
      "first.text": "first text value"
    }
  });
  // here console.warns would be shown
  expect(screen.getByText("first text value")).toBeInTheDocument();
});

test("second text is rendered", () => {
  customRender(<Component />, {
    message: {
      "second.text": "second text value"
    }
  });
  // here console.warns would be shown
  expect(screen.getByText("second text value")).toBeInTheDocument();
});
```

With this small fix, no warnings would be shown for consumers tests
