### PR TITLE
feat(core): Support locale variants in messages object

### DIFF
--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -368,7 +368,7 @@ describe('compileModule()', function () {
       expect(m['es-MX']['key']()).toEqual('en-MX');
     });
 
-    it('date regression specification', async () => {
+    it('date regression specification', () => {
       const mf = new MessageFormat('*');
       const mp = {
         'en-US': {

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -329,4 +329,63 @@ describe('compileModule()', function () {
       );
     });
   });
+
+  describe('locale variants', () => {
+    it('valid variants', async () => {
+      const mf = new MessageFormat("*");
+      const mp = {
+        "en-US": {
+          key: 'en-US'
+        },
+        "es-MX": {
+          key: "en-MX"
+        },
+        "es-ES": {
+          key: "en-ES"
+        }
+      }
+
+      const m = await getModule(mf, mp);
+
+      expect(m['en-US']['key']()).toEqual("en-US");
+      expect(m['es-MX']['key']()).toEqual("en-MX");
+      expect(m['es-ES']['key']()).toEqual("en-ES");
+    });
+
+    it('valid variants', async () => {
+      const mf = new MessageFormat("*");
+      const mp = {
+        "en-US": {
+          key: 'en-US'
+        },
+        "es-MX": {
+          key: "en-MX"
+        },
+        "es-ES": {
+          key: "en-ES"
+        }
+      }
+
+      const m = await getModule(mf, mp);
+      expect(m['en-US']['key']()).toEqual("en-US");
+      expect(m['es-MX']['key']()).toEqual("en-MX");
+      expect(m['es-ES']['key']()).toEqual("en-ES");
+    });
+
+    it('mixed variants', async () => {
+      const mf = new MessageFormat("*");
+      const mp = {
+        "en": {
+          key: 'en'
+        },
+        "es-MX": {
+          key: "en-MX"
+        },
+      }
+
+      const m = await getModule(mf, mp);
+      expect(m['en']['key']()).toEqual("en");
+      expect(m['es-MX']['key']()).toEqual("en-MX");
+    });
+  })
 });

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -352,26 +352,6 @@ describe('compileModule()', function () {
       expect(m['es-ES']['key']()).toEqual('en-ES');
     });
 
-    it('valid variants', async () => {
-      const mf = new MessageFormat('*');
-      const mp = {
-        'en-US': {
-          key: 'en-US'
-        },
-        'es-MX': {
-          key: 'en-MX'
-        },
-        'es-ES': {
-          key: 'en-ES'
-        }
-      };
-
-      const m = await getModule(mf, mp);
-      expect(m['en-US']['key']()).toEqual('en-US');
-      expect(m['es-MX']['key']()).toEqual('en-MX');
-      expect(m['es-ES']['key']()).toEqual('en-ES');
-    });
-
     it('mixed variants', async () => {
       const mf = new MessageFormat('*');
       const mp = {

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -332,77 +332,77 @@ describe('compileModule()', function () {
 
   describe('locale variants', () => {
     it('valid variants', async () => {
-      const mf = new MessageFormat("*");
+      const mf = new MessageFormat('*');
       const mp = {
-        "en-US": {
+        'en-US': {
           key: 'en-US'
         },
-        "es-MX": {
-          key: "en-MX"
+        'es-MX': {
+          key: 'en-MX'
         },
-        "es-ES": {
-          key: "en-ES"
+        'es-ES': {
+          key: 'en-ES'
         }
-      }
+      };
 
       const m = await getModule(mf, mp);
 
-      expect(m['en-US']['key']()).toEqual("en-US");
-      expect(m['es-MX']['key']()).toEqual("en-MX");
-      expect(m['es-ES']['key']()).toEqual("en-ES");
+      expect(m['en-US']['key']()).toEqual('en-US');
+      expect(m['es-MX']['key']()).toEqual('en-MX');
+      expect(m['es-ES']['key']()).toEqual('en-ES');
     });
 
     it('valid variants', async () => {
-      const mf = new MessageFormat("*");
+      const mf = new MessageFormat('*');
       const mp = {
-        "en-US": {
+        'en-US': {
           key: 'en-US'
         },
-        "es-MX": {
-          key: "en-MX"
+        'es-MX': {
+          key: 'en-MX'
         },
-        "es-ES": {
-          key: "en-ES"
+        'es-ES': {
+          key: 'en-ES'
         }
-      }
+      };
 
       const m = await getModule(mf, mp);
-      expect(m['en-US']['key']()).toEqual("en-US");
-      expect(m['es-MX']['key']()).toEqual("en-MX");
-      expect(m['es-ES']['key']()).toEqual("en-ES");
+      expect(m['en-US']['key']()).toEqual('en-US');
+      expect(m['es-MX']['key']()).toEqual('en-MX');
+      expect(m['es-ES']['key']()).toEqual('en-ES');
     });
 
     it('mixed variants', async () => {
-      const mf = new MessageFormat("*");
+      const mf = new MessageFormat('*');
       const mp = {
-        "en": {
+        en: {
           key: 'en'
         },
-        "es-MX": {
-          key: "en-MX"
-        },
-      }
+        'es-MX': {
+          key: 'en-MX'
+        }
+      };
 
       const m = await getModule(mf, mp);
-      expect(m['en']['key']()).toEqual("en");
-      expect(m['es-MX']['key']()).toEqual("en-MX");
+      expect(m['en']['key']()).toEqual('en');
+      expect(m['es-MX']['key']()).toEqual('en-MX');
     });
 
     it('date regression specification', async () => {
-      const mf = new MessageFormat("*");
+      const mf = new MessageFormat('*');
       const mp = {
-        "en-US": {
-          utilsDate: "{date, date, ::EEEMMMd}"
+        'en-US': {
+          utilsDate: '{date, date, ::EEEMMMd}'
         },
-        "es-MX": {
-          utilsDate: "{date, date, ::EEEMMMd}"
-        },
-      }
+        'es-MX': {
+          utilsDate: '{date, date, ::EEEMMMd}'
+        }
+      };
 
       const result = compileModule(mf, mp);
 
       expect(result).toMatch(`new Intl.DateTimeFormat("en", opt);`);
       expect(result).toMatch(`new Intl.DateTimeFormat("es", opt);`);
     });
-  })
+  });
 });

--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -387,5 +387,22 @@ describe('compileModule()', function () {
       expect(m['en']['key']()).toEqual("en");
       expect(m['es-MX']['key']()).toEqual("en-MX");
     });
+
+    it('date regression specification', async () => {
+      const mf = new MessageFormat("*");
+      const mp = {
+        "en-US": {
+          utilsDate: "{date, date, ::EEEMMMd}"
+        },
+        "es-MX": {
+          utilsDate: "{date, date, ::EEEMMMd}"
+        },
+      }
+
+      const result = compileModule(mf, mp);
+
+      expect(result).toMatch(`new Intl.DateTimeFormat("en", opt);`);
+      expect(result).toMatch(`new Intl.DateTimeFormat("es", opt);`);
+    });
   })
 });

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -12,7 +12,7 @@ import * as Formatters from '@messageformat/runtime/lib/formatters';
 import { identifier, property } from 'safe-identifier';
 import { biDiMarkText } from './bidi-mark-text';
 import { MessageFormatOptions } from './messageformat';
-import { PluralObject } from './plurals';
+import { PluralObject, normalize } from './plurals';
 
 const RUNTIME_MODULE = '@messageformat/runtime';
 const CARDINAL_MODULE = '@messageformat/runtime/lib/cardinals';
@@ -74,7 +74,8 @@ export default class Compiler {
     if (typeof src === 'object') {
       const result: StringStructure = {};
       for (const key of Object.keys(src)) {
-        const pl = (plurals && plurals[key]) || plural;
+        const normalizedPluralsKey = key.length > 2 ? normalize(key) : key;
+        const pl = (plurals && plurals[normalizedPluralsKey])  || plural;
         result[key] = this.compile(src[key], pl, plurals);
       }
       return result;

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -75,7 +75,7 @@ export default class Compiler {
       const result: StringStructure = {};
       for (const key of Object.keys(src)) {
         const normalizedPluralsKey = key.length > 2 ? normalize(key) : key;
-        const pl = (plurals && plurals[normalizedPluralsKey])  || plural;
+        const pl = (plurals && plurals[normalizedPluralsKey]) || plural;
         result[key] = this.compile(src[key], pl, plurals);
       }
       return result;

--- a/packages/core/src/plurals.ts
+++ b/packages/core/src/plurals.ts
@@ -3,7 +3,7 @@ import * as PluralCategories from 'make-plural/pluralCategories';
 import * as Plurals from 'make-plural/plurals';
 import { identifier } from 'safe-identifier';
 
-function normalize(locale: string) {
+export function normalize(locale: string) {
   if (typeof locale !== 'string' || locale.length < 2)
     throw new RangeError(`Invalid language tag: ${locale}`);
 

--- a/packages/date-skeleton/src/get-date-formatter.test.ts
+++ b/packages/date-skeleton/src/get-date-formatter.test.ts
@@ -120,7 +120,8 @@ describe('Options', () => {
     expect([
       '2 Dhuʻl-Hijjah 1426',
       'Dhuʻl-Hijjah 2, 1426',
-      'Dhuʻl-Hijjah 2, 1426 AH'
+      'Dhuʻl-Hijjah 2, 1426 AH',
+      '2 Dhuʻl-Hijjah 1426 AH'
     ]).toContain(fmt(date));
     expect(onError).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Ref: https://github.com/messageformat/messageformat/issues/359

It was discovered that when compiling against locale variants (e.g. `en-US`, `es-MX` etc etc...) output is generated against expectations. 

For example

```javascript
const MessageFormat = require("@messageformat/core");
const compileMessageModule = require("@messageformat/core/lib/compile-module");

const messagePacks = {
  "en-US": {
    utilsDate: "{date, date, ::EEEMMMd}"
  },
  "es-MX": {
    utilsDate: "{date, date, ::EEEMMMd}"
  },
};

const mf = new MessageFormat("*");
const result = compileMessageModule(mf, messagePacks);
```

Where result is

```javascript
const date_en_EEEMMMd_tmb11z = (function() {
  var opt = {"weekday":"short","month":"short","day":"numeric"};
  var dtf = new Intl.DateTimeFormat("en", opt);
//------------------------------------^ this is problematic
  return function(value) { return dtf.format(value); }
})();

export default {
  "en-US": {
    utilsDate: (d) => date_en_EEEMMMd_tmb11z(d.date)
  },
  "es-MX": {
    utilsDate: (d) => date_en_EEEMMMd_tmb11z(d.date)
  }
}
```

The expectation is instead

```javascript
const date_en_EEEMMMd_tmb11z = (function() {
  var opt = {"weekday":"short","month":"short","day":"numeric"};
  var dtf = new Intl.DateTimeFormat("en", opt);
  return function(value) { return dtf.format(value); }
})();

const date_es_EEEMMMd_m7z124 = (function() {
  var opt = {"weekday":"short","month":"short","day":"numeric"};
  var dtf = new Intl.DateTimeFormat("es", opt);
  return function(value) { return dtf.format(value); }
})();

export default {
  "en-US": {
    utilsDate: (d) => date_en_EEEMMMd_tmb11z(d.date)
  },
  "es-MX": {
    utilsDate: (d) => date_es_EEEMMMd_m7z124(d.date)
  }
}
```

Variants are an expected part of locale strings, so it makes sense to support them inside of imports. This bug was caught in our codebase because we want to maintain parity with the icu variant spec.

The patch proposed here is (i think) pretty un-controversial: if a given plural key can be normalized, perform the lookup based on the normalized value.