### PR TITLE
fix(core): Do not select plurals for non-top level compilations

### DIFF
--- a/packages/core/src/compile-module.test.ts
+++ b/packages/core/src/compile-module.test.ts
@@ -329,4 +329,23 @@ describe('compileModule()', function () {
       );
     });
   });
+
+  describe('issue 361 regression', () => {
+    it('should produce the correct output given nested keys that look like plurals', () => {
+      const mf = new MessageFormat('*');
+
+      const messagePacks = {
+        en: {
+          es: 'Estimation Date: {date, date, ::EEEMMMd}',
+          fi: 'Financial Incentive Date: {date, date, ::EEEMMMd}'
+        }
+      };
+
+      const result = compileModule(mf, messagePacks);
+
+      expect(result).toMatch(`new Intl.DateTimeFormat("en", opt);`);
+      expect(result).not.toMatch(`new Intl.DateTimeFormat("fi", opt);`);
+      expect(result).not.toMatch(`new Intl.DateTimeFormat("es", opt);`);
+    });
+  });
 });

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -65,17 +65,21 @@ export default class Compiler {
    * @param src - The source for which the JS code should be generated
    * @param plural - The default locale
    * @param plurals - A map of pluralization keys for all available locales
+   * @param isDescendentCall - Indicates whether or not this is the top level of the recursive call
    */
   compile(
     src: string | StringStructure,
     plural: PluralObject,
-    plurals?: { [key: string]: PluralObject }
+    plurals?: { [key: string]: PluralObject },
+    isDescendentCall?: boolean
   ) {
     if (typeof src === 'object') {
       const result: StringStructure = {};
       for (const key of Object.keys(src)) {
-        const pl = (plurals && plurals[key]) || plural;
-        result[key] = this.compile(src[key], pl, plurals);
+        const pl = isDescendentCall
+          ? plural
+          : (plurals && plurals[key]) || plural;
+        result[key] = this.compile(src[key], pl, plurals, true);
       }
       return result;
     }


### PR DESCRIPTION
Fixes: https://github.com/messageformat/messageformat/issues/361

This is a sketch to fix 361. I can see it being desirable to hide the inner recursive parameter by creating an "outer" and "inner" function, but I opted for the most simple approach. 