### PR TITLE
Rounding modes

### DIFF
--- a/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
+++ b/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
@@ -177,7 +177,9 @@ const tests: { [testSet: string]: { [src: string]: Skeleton } } = {
     'rounding-mode-down': { roundingMode: 'rounding-mode-down' },
     'rounding-mode-floor': { roundingMode: 'rounding-mode-floor' },
     'rounding-mode-up': { roundingMode: 'rounding-mode-up' },
-    'rounding-mode-half-ceiling': { roundingMode: 'rounding-mode-half-ceiling' },
+    'rounding-mode-half-ceiling': {
+      roundingMode: 'rounding-mode-half-ceiling'
+    },
     'rounding-mode-half-floor': { roundingMode: 'rounding-mode-half-floor' }
   }
 };

--- a/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
+++ b/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
@@ -176,7 +176,9 @@ const tests: { [testSet: string]: { [src: string]: Skeleton } } = {
     'rounding-mode-ceiling': { roundingMode: 'rounding-mode-ceiling' },
     'rounding-mode-down': { roundingMode: 'rounding-mode-down' },
     'rounding-mode-floor': { roundingMode: 'rounding-mode-floor' },
-    'rounding-mode-up': { roundingMode: 'rounding-mode-up' }
+    'rounding-mode-up': { roundingMode: 'rounding-mode-up' },
+    'rounding-mode-half-ceiling': { roundingMode: 'rounding-mode-half-ceiling' },
+    'rounding-mode-half-floor': { roundingMode: 'rounding-mode-half-floor' }
   }
 };
 

--- a/packages/number-skeleton/src/skeleton-parser/token-parser.ts
+++ b/packages/number-skeleton/src/skeleton-parser/token-parser.ts
@@ -138,6 +138,8 @@ export class TokenParser {
       case 'rounding-mode-floor':
       case 'rounding-mode-down':
       case 'rounding-mode-up':
+      case 'rounding-mode-half-ceiling':
+      case 'rounding-mode-half-floor':
       case 'rounding-mode-half-even':
       case 'rounding-mode-half-down':
       case 'rounding-mode-half-up':

--- a/packages/number-skeleton/src/types/skeleton.ts
+++ b/packages/number-skeleton/src/types/skeleton.ts
@@ -78,6 +78,8 @@ export interface Skeleton {
     | 'rounding-mode-floor'
     | 'rounding-mode-down'
     | 'rounding-mode-up'
+    | 'rounding-mode-half-ceiling'
+    | 'rounding-mode-half-floor'
     | 'rounding-mode-half-even'
     | 'rounding-mode-half-down'
     | 'rounding-mode-half-up'


### PR DESCRIPTION
…de-half-floor

Added the rounding modes `Half Ceiling` and `Half Floor`. See [ICU Rounding Modes](https://unicode-org.github.io/icu/userguide/format_parse/numbers/rounding-modes.html)

Did not add rounding mode `Half Odd` because there is no equivalence in `Intl.NumberFormat` and according to their discussion this mode is very unusual and was not included in their specification.