### PR TITLE
feat(number-skeleton): Add rounding-modes Half Ceiling and Half Floor

### DIFF
--- a/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
+++ b/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
@@ -177,6 +177,8 @@ const tests: { [testSet: string]: { [src: string]: Skeleton } } = {
     'rounding-mode-down': { roundingMode: 'rounding-mode-down' },
     'rounding-mode-floor': { roundingMode: 'rounding-mode-floor' },
     'rounding-mode-up': { roundingMode: 'rounding-mode-up' },
+    'rounding-mode-half-even': { roundingMode: 'rounding-mode-half-even' },
+    'rounding-mode-half-odd': { roundingMode: 'rounding-mode-half-odd' },
     'rounding-mode-half-ceiling': {
       roundingMode: 'rounding-mode-half-ceiling'
     },

--- a/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
+++ b/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
@@ -176,7 +176,11 @@ const tests: { [testSet: string]: { [src: string]: Skeleton } } = {
     'rounding-mode-ceiling': { roundingMode: 'rounding-mode-ceiling' },
     'rounding-mode-down': { roundingMode: 'rounding-mode-down' },
     'rounding-mode-floor': { roundingMode: 'rounding-mode-floor' },
-    'rounding-mode-up': { roundingMode: 'rounding-mode-up' }
+    'rounding-mode-up': { roundingMode: 'rounding-mode-up' },
+    'rounding-mode-half-ceiling': {
+      roundingMode: 'rounding-mode-half-ceiling'
+    },
+    'rounding-mode-half-floor': { roundingMode: 'rounding-mode-half-floor' }
   }
 };
 

--- a/packages/number-skeleton/src/skeleton-parser/token-parser.ts
+++ b/packages/number-skeleton/src/skeleton-parser/token-parser.ts
@@ -139,6 +139,8 @@ export class TokenParser {
       case 'rounding-mode-down':
       case 'rounding-mode-up':
       case 'rounding-mode-half-even':
+      case 'rounding-mode-half-ceiling':
+      case 'rounding-mode-half-floor':
       case 'rounding-mode-half-down':
       case 'rounding-mode-half-up':
       case 'rounding-mode-unnecessary':

--- a/packages/number-skeleton/src/skeleton-parser/token-parser.ts
+++ b/packages/number-skeleton/src/skeleton-parser/token-parser.ts
@@ -139,6 +139,7 @@ export class TokenParser {
       case 'rounding-mode-down':
       case 'rounding-mode-up':
       case 'rounding-mode-half-even':
+      case 'rounding-mode-half-odd':
       case 'rounding-mode-half-ceiling':
       case 'rounding-mode-half-floor':
       case 'rounding-mode-half-down':

--- a/packages/number-skeleton/src/types/skeleton.ts
+++ b/packages/number-skeleton/src/types/skeleton.ts
@@ -79,6 +79,7 @@ export interface Skeleton {
     | 'rounding-mode-down'
     | 'rounding-mode-up'
     | 'rounding-mode-half-even'
+    | 'rounding-mode-half-odd'
     | 'rounding-mode-half-ceiling'
     | 'rounding-mode-half-floor'
     | 'rounding-mode-half-down'

--- a/packages/number-skeleton/src/types/skeleton.ts
+++ b/packages/number-skeleton/src/types/skeleton.ts
@@ -79,6 +79,8 @@ export interface Skeleton {
     | 'rounding-mode-down'
     | 'rounding-mode-up'
     | 'rounding-mode-half-even'
+    | 'rounding-mode-half-ceiling'
+    | 'rounding-mode-half-floor'
     | 'rounding-mode-half-down'
     | 'rounding-mode-half-up'
     | 'rounding-mode-unnecessary';


### PR DESCRIPTION
Added the rounding modes `Half Ceiling` and `Half Floor` and `Half Odd`. See [ICU Rounding Modes](https://unicode-org.github.io/icu/userguide/format_parse/numbers/rounding-modes.html)