### PR TITLE
fix(compiler): Generate backwards-compatible code to not crash on old browsers

### DIFF
--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -94,10 +94,10 @@ export default class Compiler {
     if (this.options.requireAllArguments && hasArgs) {
       this.setRuntimeFn('reqArgs');
       const reqArgs = JSON.stringify(this.arguments);
-      return `(d) => { reqArgs(${reqArgs}, d); return ${res}; }`;
+      return `function (d) { reqArgs(${reqArgs}, d); return ${res}; }`;
     }
 
-    return `(${hasArgs ? 'd' : ''}) => ${res}`;
+    return `function (${hasArgs ? 'd' : ''}) { return ${res}; }`;
   }
 
   cases(token: Select, pluralToken: Select | null) {

--- a/packages/rollup-plugin/src/__snapshots__/rollup.test.ts.snap
+++ b/packages/rollup-plugin/src/__snapshots__/rollup.test.ts.snap
@@ -5,11 +5,11 @@ exports[`.properties with Latin-1 encoding 1`] = `
 import { fi } from '@messageformat/runtime/lib/plurals';
 
 var messages = {
-  simple: () => "Yksinkertainen viesti.",
-  "var": (d) => "Viesti jossa " + d.X + ".",
-  plural: (d) => "Sinulla " + plural(d.N, 0, fi, { "0": "ei ole viestejä", one: "on 1 viesti", other: "on " + number("fi", d.N, 0) + " viestiä" }) + ".",
-  select: (d) => select(d.GENDER, { other: "Hän" }) + " lähetti sinulle viestin.",
-  ordinal: (d) => plural(d.N, 0, fi, { other: number("fi", d.N, 0) + "." }, 1) + " viesti."
+  simple: function () { return "Yksinkertainen viesti."; },
+  "var": function (d) { return "Viesti jossa " + d.X + "."; },
+  plural: function (d) { return "Sinulla " + plural(d.N, 0, fi, { "0": "ei ole viestejä", one: "on 1 viesti", other: "on " + number("fi", d.N, 0) + " viestiä" }) + "."; },
+  select: function (d) { return select(d.GENDER, { other: "Hän" }) + " lähetti sinulle viestin."; },
+  ordinal: function (d) { return plural(d.N, 0, fi, { other: number("fi", d.N, 0) + "." }, 1) + " viesti."; }
 };
 
 console.log(messages);
@@ -21,7 +21,7 @@ exports[`README sample 1`] = `
 import { fr as fr$1 } from '@messageformat/runtime/lib/cardinals';
 
 var fr = {
-  message_intro: (d) => plural(d.count, 0, fr$1, { one: "Votre message se trouve ici.", other: "Vos " + number("fr", d.count, 0) + " messages se trouvent ici." }) + "\\n"
+  message_intro: function (d) { return plural(d.count, 0, fr$1, { one: "Votre message se trouve ici.", other: "Vos " + number("fr", d.count, 0) + " messages se trouvent ici." }) + "\\n"; }
 };
 
 fr.message_intro({ count: 3 });
@@ -34,18 +34,18 @@ import { en, fi } from '@messageformat/runtime/lib/plurals';
 
 var messages = {
   en: {
-    simple: () => "A simple message.",
-    "var": (d) => "Message with " + d.X + ".",
-    plural: (d) => "You have " + plural(d.N, 0, en, { "0": "no messages", one: "1 message", other: number("en", d.N, 0) + " messages" }) + ".",
-    select: (d) => select(d.GENDER, { male: "He has", female: "She has", other: "They have" }) + " sent you a message.",
-    ordinal: (d) => "The " + plural(d.N, 0, en, { one: "1st", two: "2nd", few: "3rd", other: number("en", d.N, 0) + "th" }, 1) + " message."
+    simple: function () { return "A simple message."; },
+    "var": function (d) { return "Message with " + d.X + "."; },
+    plural: function (d) { return "You have " + plural(d.N, 0, en, { "0": "no messages", one: "1 message", other: number("en", d.N, 0) + " messages" }) + "."; },
+    select: function (d) { return select(d.GENDER, { male: "He has", female: "She has", other: "They have" }) + " sent you a message."; },
+    ordinal: function (d) { return "The " + plural(d.N, 0, en, { one: "1st", two: "2nd", few: "3rd", other: number("en", d.N, 0) + "th" }, 1) + " message."; }
   },
   fi: {
-    simple: () => "Yksinkertainen viesti.",
-    "var": (d) => "Viesti jossa " + d.X + ".",
-    plural: (d) => "Sinulla " + plural(d.N, 0, fi, { "0": "ei ole viestejä", one: "on 1 viesti", other: "on " + number("fi", d.N, 0) + " viestiä" }) + ".",
-    select: (d) => select(d.GENDER, { other: "Hän" }) + " lähetti sinulle viestin.",
-    ordinal: (d) => plural(d.N, 0, fi, { other: number("fi", d.N, 0) + "." }, 1) + " viesti."
+    simple: function () { return "Yksinkertainen viesti."; },
+    "var": function (d) { return "Viesti jossa " + d.X + "."; },
+    plural: function (d) { return "Sinulla " + plural(d.N, 0, fi, { "0": "ei ole viestejä", one: "on 1 viesti", other: "on " + number("fi", d.N, 0) + " viestiä" }) + "."; },
+    select: function (d) { return select(d.GENDER, { other: "Hän" }) + " lähetti sinulle viestin."; },
+    ordinal: function (d) { return plural(d.N, 0, fi, { other: number("fi", d.N, 0) + "." }, 1) + " viesti."; }
   }
 };
 
@@ -59,18 +59,18 @@ import { en, fi } from '@messageformat/runtime/lib/plurals';
 
 var messages = {
   en: {
-    simple: () => "A simple message.",
-    "var": (d) => "Message with " + d.X + ".",
-    plural: (d) => "You have " + plural(d.N, 0, en, { "0": "no messages", one: "1 message", other: number("en", d.N, 0) + " messages" }) + ".",
-    select: (d) => select(d.GENDER, { male: "He has", female: "She has", other: "They have" }) + " sent you a message.",
-    ordinal: (d) => "The " + plural(d.N, 0, en, { one: "1st", two: "2nd", few: "3rd", other: number("en", d.N, 0) + "th" }, 1) + " message."
+    simple: function () { return "A simple message."; },
+    "var": function (d) { return "Message with " + d.X + "."; },
+    plural: function (d) { return "You have " + plural(d.N, 0, en, { "0": "no messages", one: "1 message", other: number("en", d.N, 0) + " messages" }) + "."; },
+    select: function (d) { return select(d.GENDER, { male: "He has", female: "She has", other: "They have" }) + " sent you a message."; },
+    ordinal: function (d) { return "The " + plural(d.N, 0, en, { one: "1st", two: "2nd", few: "3rd", other: number("en", d.N, 0) + "th" }, 1) + " message."; }
   },
   fi: {
-    simple: () => "Yksinkertainen viesti.",
-    "var": (d) => "Viesti jossa " + d.X + ".",
-    plural: (d) => "Sinulla " + plural(d.N, 0, fi, { "0": "ei ole viestejä", one: "on 1 viesti", other: "on " + number("fi", d.N, 0) + " viestiä" }) + ".",
-    select: (d) => select(d.GENDER, { other: "Hän" }) + " lähetti sinulle viestin.",
-    ordinal: (d) => plural(d.N, 0, fi, { other: number("fi", d.N, 0) + "." }, 1) + " viesti."
+    simple: function () { return "Yksinkertainen viesti."; },
+    "var": function (d) { return "Viesti jossa " + d.X + "."; },
+    plural: function (d) { return "Sinulla " + plural(d.N, 0, fi, { "0": "ei ole viestejä", one: "on 1 viesti", other: "on " + number("fi", d.N, 0) + " viestiä" }) + "."; },
+    select: function (d) { return select(d.GENDER, { other: "Hän" }) + " lähetti sinulle viestin."; },
+    ordinal: function (d) { return plural(d.N, 0, fi, { other: number("fi", d.N, 0) + "." }, 1) + " viesti."; }
   }
 };
 

--- a/packages/rollup-plugin/src/index.test.ts
+++ b/packages/rollup-plugin/src/index.test.ts
@@ -9,7 +9,7 @@ const jsonSrc = '{"key":{"inner":"value {foo}"}}';
 const code = `
 export default {
   key: {
-    inner: (d) => "value " + d.foo
+    inner: function (d) { return "value " + d.foo; }
   }
 }`;
 
@@ -127,7 +127,7 @@ describe('transform', () => {
         import { number, plural } from "@messageformat/runtime";
         import { fi } from "@messageformat/runtime/lib/cardinals";
         export default {
-          key: (d) => "value " + plural(d.foo, 0, fi, { one: "1", other: number("fi", d.foo, 0) })
+          key: function (d) { return "value " + plural(d.foo, 0, fi, { one: "1", other: number("fi", d.foo, 0) }); }
         }`
     });
   });


### PR DESCRIPTION
Since adopting @messageformat/core we've been running into various issues for some users on old browsers.  For most of the issues the combination of Babel and polyfills handles it, but it appears this specific code is generating a string that contains an arrow function that's being passed to `eval()`, which of course Babel can't deal with.  Trivial change, tested on Chrome 38 on our game (https://worlds.frvr.com, still have the old version live), mostly just had to change a bunch of test case outputs to match.