### PR TITLE
fix(cli): Support Windows paths as directory path inputs

### DIFF
--- a/packages/cli/lib/read-input.js
+++ b/packages/cli/lib/read-input.js
@@ -12,7 +12,10 @@ function listFiles(include, extensions) {
     if (!fs.existsSync(fn)) throw new Error(`Input file not found: ${fn}`);
     if (fs.statSync(fn).isDirectory()) {
       extensions.forEach(ext => {
-        ls.push.apply(ls, glob.sync(path.join(fn, '**/*' + ext)));
+        ls.push.apply(
+          ls,
+          glob.sync(path.join(fn, '**/*' + ext), { windowsPathsNoEscape: true })
+        );
       });
     } else if (extensions.includes(path.extname(fn))) {
       ls.push(fn);


### PR DESCRIPTION
Fixes #387

Backward-slashes are replaced with forward-slashes in glob pattern when using `windowsPathsNoEscape: true` option in `glob.sync`. This does mean that symbols cant be escaped in glob patterns but I think it isn't a problem in this use-case.

Did manual testing with windows and mac and both seemed to still work.