### PR TITLE
feat(number-skeleton): Add support for skeleton "precision-currency-standard/w"

### DIFF
--- a/packages/number-skeleton/src/numberformat/options.test.ts
+++ b/packages/number-skeleton/src/numberformat/options.test.ts
@@ -1,10 +1,10 @@
 import { UnsupportedError } from '../errors';
 import { Skeleton } from '../types/skeleton';
-import { getNumberFormatOptions } from './options';
+import { NumberFormatOptions, getNumberFormatOptions } from './options';
 
 interface TestCase {
   skeleton: Skeleton;
-  result?: Intl.NumberFormatOptions;
+  result?: NumberFormatOptions;
   unsupported?: string[][];
 }
 
@@ -154,6 +154,15 @@ const tests: { [K in keyof Skeleton]: { [name: string]: TestCase } } = {
     'precision-currency-standard': {
       skeleton: { precision: { style: 'precision-currency-standard' } },
       result: {}
+    },
+    'precision-currency-standard/w': {
+      skeleton: {
+        precision: {
+          style: 'precision-currency-standard',
+          trailingZero: 'stripIfInteger'
+        }
+      },
+      result: { trailingZeroDisplay: 'stripIfInteger' }
     },
     'precision-currency-cash': {
       skeleton: { precision: { style: 'precision-currency-cash' } },

--- a/packages/number-skeleton/src/numberformat/options.ts
+++ b/packages/number-skeleton/src/numberformat/options.ts
@@ -2,6 +2,17 @@ import { UnsupportedError } from '../errors.js';
 import { Skeleton } from '../types/skeleton.js';
 
 /**
+ * Extends `Intl.NumberFormat` options to include some features brought by the
+ * {@link https://github.com/tc39/proposal-intl-numberformat-v3 | ECMA-402
+ * Proposal: Intl.NumberFormat V3}
+ *
+ * @internal
+ */
+export interface NumberFormatOptions extends Intl.NumberFormatOptions {
+  trailingZeroDisplay?: 'auto' | 'stripIfInteger';
+}
+
+/**
  * Given an input ICU NumberFormatter skeleton, does its best to construct a
  * corresponding `Intl.NumberFormat` options structure.
  *
@@ -67,7 +78,7 @@ export function getNumberFormatOptions(
     if (onUnsupported) onUnsupported(new UnsupportedError(stem, source));
   };
 
-  const opt: Intl.NumberFormatOptions = {};
+  const opt: NumberFormatOptions = {};
 
   if (unit) {
     switch (unit.style) {
@@ -154,7 +165,9 @@ export function getNumberFormatOptions(
         opt.maximumFractionDigits = 20;
         break;
       case 'precision-increment':
+        break;
       case 'precision-currency-standard':
+        opt.trailingZeroDisplay = precision.trailingZero;
         break;
       case 'precision-currency-cash':
         fail(precision.style);

--- a/packages/number-skeleton/src/skeleton-parser/options.ts
+++ b/packages/number-skeleton/src/skeleton-parser/options.ts
@@ -24,7 +24,7 @@ const maxOptions = {
   'unit-width-hidden': 0,
   'precision-integer': 0,
   'precision-unlimited': 0,
-  'precision-currency-standard': 0,
+  'precision-currency-standard': 1,
   'precision-currency-cash': 0,
   'precision-increment': 1,
   'rounding-mode-ceiling': 0,

--- a/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
+++ b/packages/number-skeleton/src/skeleton-parser/skeleton-parser.test.ts
@@ -152,6 +152,12 @@ const tests: { [testSet: string]: { [src: string]: Skeleton } } = {
         maxSignificant: 3,
         source: '@@#'
       }
+    },
+    'precision-currency-standard/w': {
+      precision: {
+        style: 'precision-currency-standard',
+        trailingZero: 'stripIfInteger'
+      }
     }
   },
   'integer-width': {

--- a/packages/number-skeleton/src/skeleton-parser/token-parser.ts
+++ b/packages/number-skeleton/src/skeleton-parser/token-parser.ts
@@ -119,10 +119,17 @@ export class TokenParser {
       // precision
       case 'precision-integer':
       case 'precision-unlimited':
-      case 'precision-currency-standard':
       case 'precision-currency-cash':
         this.assertEmpty('precision');
         res.precision = { style: stem };
+        break;
+      case 'precision-currency-standard':
+        this.assertEmpty('precision');
+        if (option === 'w') {
+          res.precision = { style: stem, trailingZero: 'stripIfInteger' };
+        } else {
+          res.precision = { style: stem };
+        }
         break;
       case 'precision-increment': {
         const increment = Number(option);

--- a/packages/number-skeleton/src/types/skeleton.ts
+++ b/packages/number-skeleton/src/types/skeleton.ts
@@ -61,8 +61,11 @@ export interface Skeleton {
         style:
           | 'precision-integer'
           | 'precision-unlimited'
-          | 'precision-currency-standard'
           | 'precision-currency-cash';
+      }
+    | {
+        style: 'precision-currency-standard';
+        trailingZero?: 'auto' | 'stripIfInteger' | undefined;
       }
     | { style: 'precision-increment'; increment: number }
     | {


### PR DESCRIPTION
Add support for skeleton "precision-currency-standard/w"

Issue #391

Example using Node 19:
```bash
# npm run start

> start
> node -i -r ./scripts/start.js

Welcome to Node.js v19.9.0.
Type ".help" for more information.
> mf.compile('{test, number, ::currency/EUR precision-currency-standard/w}')({test: 3.00})
'€3'
> mf.compile('{test, number, ::currency/EUR precision-currency-standard/w}')({test: 3.10})
'€3.10'
> mf.compile('{test, number, ::currency/EUR precision-currency-standard/w}')({test: 3.14})
'€3.14'
> mf.compile('{test, number, ::currency/EUR precision-currency-standard}')({test: 3})
'€3.00'
```