### PR TITLE
feat(parser): Introduce new ParseOption to disable strict plural key check

### DIFF
--- a/packages/parser/src/parser.test.ts
+++ b/packages/parser/src/parser.test.ts
@@ -593,15 +593,29 @@ describe('Errors', () => {
     }).toThrow();
   });
 
-  it('should not allow invalid keys for plurals', function () {
-    expect(function () {
-      parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}');
-    }).toThrow();
-    expect(function () {
-      parse('{NUM, plural, one { 1 } some { error } other { 2 }}', {
-        cardinal: ['one', 'other']
-      });
-    }).toThrow();
+  describe('strictPluralKeys', () => {
+    it('should not allow invalid keys for plurals by default', function () {
+      expect(function () {
+        parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}');
+      }).toThrow();
+      expect(function () {
+        parse('{NUM, plural, one { 1 } some { error } other { 2 }}', {
+          cardinal: ['one', 'other']
+        });
+      }).toThrow();
+    });
+
+    it('should allow invalid keys for plurals if the `strictPluralKeys` option is set to false', function () {
+      expect(function () {
+        parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}', { strictPluralKeys: false });
+      }).not.toThrow();
+      expect(function () {
+        parse('{NUM, plural, one { 1 } some { error } other { 2 }}', {
+          cardinal: ['one', 'other'],
+          strictPluralKeys: false
+        });
+      }).not.toThrow();
+    });
   });
 
   it('should not allow invalid keys for selectordinals', function () {

--- a/packages/parser/src/parser.test.ts
+++ b/packages/parser/src/parser.test.ts
@@ -607,7 +607,9 @@ describe('Errors', () => {
 
     it('should allow invalid keys for plurals if the `strictPluralKeys` option is set to false', function () {
       expect(function () {
-        parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}', { strictPluralKeys: false });
+        parse('{NUM, plural, one { 1 } invalid { error } other { 2 }}', {
+          strictPluralKeys: false
+        });
       }).not.toThrow();
       expect(function () {
         parse('{NUM, plural, one { 1 } some { error } other { 2 }}', {

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -482,7 +482,7 @@ export interface ParseOptions {
   /**
    * By default, the parser will reject any plural keys that are not valid {@link http://cldr.unicode.org/index/cldr-spec/plural-rules | Unicode CLDR}
    * plural category keys.
-   * Setting `strictPluralKeys: true` will disable this check.
+   * Setting `strictPluralKeys: false` will disable this check.
    */
   strictPluralKeys?: boolean;
 }

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -480,7 +480,8 @@ export interface ParseOptions {
   strict?: boolean;
 
   /**
-   * By default, the parser will reject any plural keys that are not valid {@link http://cldr.unicode.org/index/cldr-spec/plural-rules | Unicode CLDR}
+   * By default, the parser will reject any plural keys that are not valid
+   * {@link http://cldr.unicode.org/index/cldr-spec/plural-rules | Unicode CLDR}
    * plural category keys.
    * Setting `strictPluralKeys: false` will disable this check.
    */

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -251,12 +251,14 @@ class Parser {
   strict: boolean;
   cardinalKeys: string[];
   ordinalKeys: string[];
+  strictPluralKeys: boolean;
 
   constructor(src: string, opt: ParseOptions) {
     this.lexer = lexer.reset(src);
     this.cardinalKeys = (opt && opt.cardinal) || defaultPluralKeys;
     this.ordinalKeys = (opt && opt.ordinal) || defaultPluralKeys;
     this.strict = (opt && opt.strict) || false;
+    this.strictPluralKeys = (opt && opt.strictPluralKeys) ?? true;
   }
 
   parse() {
@@ -269,7 +271,7 @@ class Parser {
         throw new ParseError(lt, `The case ${key} is not valid with select`);
     } else if (type !== 'select') {
       const keys = type === 'plural' ? this.cardinalKeys : this.ordinalKeys;
-      if (keys.length > 0 && !keys.includes(key)) {
+      if (this.strictPluralKeys && keys.length > 0 && !keys.includes(key)) {
         const msg = `The ${type} case ${key} is not valid in this locale`;
         throw new ParseError(lt, msg);
       }
@@ -476,6 +478,13 @@ export interface ParseOptions {
    *   Outside those, `#` and `'#'` will be parsed as literal text.
    */
   strict?: boolean;
+
+  /**
+   * By default, the parser will reject any plural keys that are not valid {@link http://cldr.unicode.org/index/cldr-spec/plural-rules | Unicode CLDR}
+   * plural category keys.
+   * Setting `strictPluralKeys: true` will disable this check.
+   */
+  strictPluralKeys?: boolean;
 }
 
 /**

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -255,10 +255,10 @@ class Parser {
 
   constructor(src: string, opt: ParseOptions) {
     this.lexer = lexer.reset(src);
-    this.cardinalKeys = (opt && opt.cardinal) || defaultPluralKeys;
-    this.ordinalKeys = (opt && opt.ordinal) || defaultPluralKeys;
-    this.strict = (opt && opt.strict) || false;
-    this.strictPluralKeys = (opt && opt.strictPluralKeys) ?? true;
+    this.cardinalKeys = opt?.cardinal ?? defaultPluralKeys;
+    this.ordinalKeys = opt?.ordinal ?? defaultPluralKeys;
+    this.strict = opt?.strict ?? false;
+    this.strictPluralKeys = opt?.strictPluralKeys ?? true;
   }
 
   parse() {


### PR DESCRIPTION
Issue #393 

As recommended in the issue referenced above, this change introduces a new option to the parser: `strictPluralKeys`, which is set to `true` by default. Relevant unit tests have also been added.

Once the PR is merged and a new version of `@messageformat/parser` released, I'll create a subsequent PR to add support for this option in `@messageformat/core`.