### PR TITLE
feat(core): Add `strictPluralKeys` option for supporting the corresponding option in parser

### DIFF
--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -71,7 +71,8 @@ export default class Compiler {
     plural: PluralObject,
     plurals?: { [key: string]: PluralObject }
   ) {
-    const { localeCodeFromKey, requireAllArguments, strict } = this.options;
+    const { localeCodeFromKey, requireAllArguments, strict, strictPluralKeys } =
+      this.options;
 
     if (typeof src === 'object') {
       const result: StringStructure = {};
@@ -87,7 +88,8 @@ export default class Compiler {
     const parserOptions = {
       cardinal: plural.cardinals,
       ordinal: plural.ordinals,
-      strict
+      strict,
+      strictPluralKeys
     };
     this.arguments = [];
     const r = parse(src, parserOptions).map(token => this.token(token, null));

--- a/packages/core/src/messageformat.test.ts
+++ b/packages/core/src/messageformat.test.ts
@@ -122,6 +122,14 @@ describe('compile() errors', () => {
     );
   });
 
+  test('Invalid plural key when strictPluralKeys option is set to `false`', () => {
+    const mf = new MessageFormat('en', { strictPluralKeys: false });
+    const src = '{X, plural, foo{a}}';
+    expect(() => mf.compile(src)).not.toThrow(
+      'The plural case foo is not valid in this locale'
+    );
+  });
+
   test('Invalid selectordinal key', () => {
     const mf = new MessageFormat('en');
     const src = '{X, selectordinal, foo{a}}';

--- a/packages/core/src/messageformat.test.ts
+++ b/packages/core/src/messageformat.test.ts
@@ -124,10 +124,8 @@ describe('compile() errors', () => {
 
   test('Invalid plural key when strictPluralKeys option is set to `false`', () => {
     const mf = new MessageFormat('en', { strictPluralKeys: false });
-    const src = '{X, plural, foo{a}}';
-    expect(() => mf.compile(src)).not.toThrow(
-      'The plural case foo is not valid in this locale'
-    );
+    const src = '{X, plural, foo{a} other{b}}';
+    expect(() => mf.compile(src)).not.toThrow();
   });
 
   test('Invalid selectordinal key', () => {

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -121,8 +121,8 @@ export interface MessageFormatOptions<
   /**
    * Enable strict checks for plural keys according to
    * {@link http://cldr.unicode.org/index/cldr-spec/plural-rules | Unicode CLDR}.
-   * When set to `false`, the compiler will also accept any invalid plural keys. Also see the
-   * {@link http://messageformat.github.io/messageformat/api/parser.parseoptions.strictPluralKeys/ | parser option}.
+   * When set to `false`, the compiler will also accept any invalid plural keys.
+   * Also see the corresponding {@link @messageformat/parser#ParseOptions | parser option}.
    *
    * Default: `true`
    */

--- a/packages/core/src/messageformat.ts
+++ b/packages/core/src/messageformat.ts
@@ -117,6 +117,16 @@ export interface MessageFormatOptions<
    * Default: `false`
    */
   strict?: boolean;
+
+  /**
+   * Enable strict checks for plural keys according to
+   * {@link http://cldr.unicode.org/index/cldr-spec/plural-rules | Unicode CLDR}.
+   * When set to `false`, the compiler will also accept any invalid plural keys. Also see the
+   * {@link http://messageformat.github.io/messageformat/api/parser.parseoptions.strictPluralKeys/ | parser option}.
+   *
+   * Default: `true`
+   */
+  strictPluralKeys?: boolean;
 }
 
 /**
@@ -226,7 +236,8 @@ export default class MessageFormat<
         requireAllArguments: false,
         returnType: 'string',
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        strict: (options && (options as any).strictNumberSign) || false
+        strict: (options && (options as any).strictNumberSign) || false,
+        strictPluralKeys: true
       },
       options
     );


### PR DESCRIPTION
Issue #393 

As a part of the above mentioned issue, this change adds the `strictPluralKeys` option to the `@messageformat/core` package.

The corresponding option has already been added to `@messageformat/parser` in #397.