### PR TITLE
Add a separate MF2 parser optimised for formatting

### DIFF
--- a/packages/mf2-messageformat/src/cst/declarations.ts
+++ b/packages/mf2-messageformat/src/cst/declarations.ts
@@ -1,5 +1,5 @@
-import { parseExpression, parseReservedBody } from './expression.js';
 import { parseNameValue } from './names.js';
+import { parseExpression, parseReservedBody } from './expression.js';
 import type { ParseContext } from './parse-cst.js';
 import type * as CST from './types.js';
 import { whitespaces } from './util.js';
@@ -123,7 +123,7 @@ function parseReservedStatement(
   while (ctx.source[pos] === '{') {
     if (ctx.source.startsWith('{{', pos)) break;
     const value = parseExpression(ctx, pos);
-    values.push(value)
+    values.push(value);
     end = value.end;
     pos = end + whitespaces(ctx.source, end);
   }

--- a/packages/mf2-messageformat/src/cst/expression.ts
+++ b/packages/mf2-messageformat/src/cst/expression.ts
@@ -1,6 +1,6 @@
 import { MessageSyntaxError } from '../errors.js';
-import type { ParseContext } from './parse-cst.js';
 import { parseNameValue } from './names.js';
+import type { ParseContext } from './parse-cst.js';
 import type * as CST from './types.js';
 import { whitespaceChars, whitespaces } from './util.js';
 import { parseLiteral, parseQuotedLiteral, parseVariable } from './values.js';

--- a/packages/mf2-messageformat/src/cst/names.ts
+++ b/packages/mf2-messageformat/src/cst/names.ts
@@ -1,10 +1,3 @@
-import type { ParseContext } from './parse-cst.js';
-
-// name-start = ALPHA / "_"
-//            / %xC0-D6 / %xD8-F6 / %xF8-2FF
-//            / %x370-37D / %x37F-1FFF / %x200C-200D
-//            / %x2070-218F / %x2C00-2FEF / %x3001-D7FF
-//            / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
 const isNameStartCode = (cc: number) =>
   (cc >= 0x41 && cc <= 0x5a) || // A-Z
   cc === 0x5f || // _
@@ -22,8 +15,6 @@ const isNameStartCode = (cc: number) =>
   (cc >= 0xfdf0 && cc <= 0xfffd) ||
   (cc >= 0x10000 && cc <= 0xeffff);
 
-// name-char = name-start / DIGIT / "-" / "."
-//           / %xB7 / %x300-36F / %x203F-2040
 const isNameCharCode = (cc: number) =>
   isNameStartCode(cc) ||
   cc === 0x2d || // -
@@ -58,7 +49,7 @@ export function isValidUnquotedLiteral(str: string): boolean {
 }
 
 export function parseUnquotedLiteralValue(
-  { source }: ParseContext,
+  source: string,
   start: number
 ): string {
   numberLiteral.lastIndex = start;

--- a/packages/mf2-messageformat/src/cst/values.ts
+++ b/packages/mf2-messageformat/src/cst/values.ts
@@ -61,7 +61,7 @@ export function parseLiteral(
   required: boolean
 ): CST.Literal | undefined {
   if (ctx.source[start] === '|') return parseQuotedLiteral(ctx, start);
-  const value = parseUnquotedLiteralValue(ctx, start);
+  const value = parseUnquotedLiteralValue(ctx.source, start);
   if (!value) {
     if (required) ctx.onError('empty-token', start, start);
     else return undefined;

--- a/packages/mf2-messageformat/src/data-model/parse.test.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.test.ts
@@ -1,0 +1,61 @@
+import testCore from '../__fixtures/test-core.json';
+import testFunctions from '../__fixtures/test-functions.json';
+import { testName } from '../__fixtures/util-test-name.js';
+import { parseMessage, validate } from '../index.js';
+
+for (const [title, messages] of [
+  ['Parse data model of core messages', testCore] as const,
+  ...Object.entries(testFunctions).map(
+    x => [`Parse data model of :${x[0]} messages`, x[1]] as const
+  )
+]) {
+  describe(title, () => {
+    for (const testMsg of messages) {
+      const tx = testMsg.only ? test.only : test;
+      tx(testName(testMsg), () => {
+        validate(parseMessage(testMsg.src));
+      });
+    }
+  });
+}
+
+describe('private annotations', () => {
+  for (const source of ['{^foo}', '{&bar}']) {
+    test(source, () => {
+      const data = parseMessage(source, {
+        privateAnnotation(src, pos) {
+          const end = src.indexOf('}', pos);
+          return {
+            annotation: { type: 'private' },
+            pos: end
+          };
+        }
+      });
+      expect(data).toEqual({
+        type: 'message',
+        declarations: [],
+        pattern: [{ type: 'expression', annotation: { type: 'private' } }]
+      });
+    });
+  }
+
+  test('foo {&bar @baz}', () => {
+    const data = parseMessage('foo {&bar @baz}', {
+      privateAnnotation(src, pos) {
+        const end = src.indexOf(' ', pos);
+        return {
+          annotation: { type: 'priv-bar' },
+          pos: end
+        };
+      }
+    });
+    expect(data).toEqual({
+      type: 'message',
+      declarations: [],
+      pattern: [
+        'foo ',
+        { type: 'expression', annotation: { type: 'priv-bar' } }
+      ]
+    });
+  });
+});

--- a/packages/mf2-messageformat/src/data-model/parse.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.ts
@@ -241,14 +241,10 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
     case '/': {
       if (arg || !allowMarkup) throw SyntaxError('parse-error', pos);
       pos += 1; // '#' or '/'
-      if (sigil === '#') {
-        markup = { type: 'markup', kind: 'open', name: identifier() };
-        const options_ = options();
-        if (options_.length) markup.options = options_;
-      } else {
-        markup = { type: 'markup', kind: 'close', name: identifier() };
-        ws('}');
-      }
+      const kind = sigil === '#' ? 'open' : 'close';
+      markup = { type: 'markup', kind, name: identifier() };
+      const options_ = options();
+      if (options_.length) markup.options = options_;
       break;
     }
     case '^':
@@ -271,7 +267,6 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
 
   while (source[pos] === '@') attribute();
   if (markup?.kind === 'open' && source[pos] === '/') {
-    // @ts-expect-error Yes, TS, this does become MarkupStandalone.
     markup.kind = 'standalone';
     pos += 1; // '/'
   }
@@ -327,12 +322,9 @@ function privateAnnotation(sigil: '^' | '&'): any {
   return unsupportedAnnotation(sigil);
 }
 
-function unsupportedAnnotation(
-  sigil: Model.UnsupportedAnnotation['sigil']
-): Model.UnsupportedAnnotation {
+function unsupportedAnnotation(sigil: string): Model.UnsupportedAnnotation {
   pos += 1; // sigil
-  const src = reservedBody();
-  return { type: 'unsupported-annotation', sigil, source: src };
+  return { type: 'unsupported-annotation', source: sigil + reservedBody() };
 }
 
 function reservedBody(): string {

--- a/packages/mf2-messageformat/src/data-model/parse.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.ts
@@ -1,0 +1,486 @@
+import { parseNameValue, parseUnquotedLiteralValue } from '../cst/names.js';
+import { MessageSyntaxError } from '../errors.js';
+import type * as Model from './types.js';
+
+const whitespaceChars = ['\t', '\n', '\r', ' ', '\u3000'];
+
+export type MessageParserOptions = {
+  /**
+   * Parse a private annotation starting with `^` or `&`.
+   * By default, private annotations are parsed as unsupported annotations.
+   *
+   * @returns `pos` as the position at the end of the `annotation`,
+   *   not including any trailing whitespace.
+   */
+  privateAnnotation?: (
+    source: string,
+    pos: number
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) => { pos: number; annotation: any };
+};
+
+//// Parser State ////
+
+let pos: number;
+let source: string;
+let opt: MessageParserOptions;
+
+//// Utilities & Error Wrappers ////
+
+// These indirections allow for the function names to be mangled,
+// while keeping the error class name intact.
+
+const MissingSyntax = (pos: number, expected: string) =>
+  new MessageSyntaxError(
+    'missing-syntax',
+    pos,
+    pos + expected.length,
+    expected
+  );
+const SyntaxError = (
+  ...args: ConstructorParameters<typeof MessageSyntaxError>
+) => new MessageSyntaxError(...args);
+
+function expect(searchString: string, consume: boolean) {
+  if (source.startsWith(searchString, pos)) {
+    if (consume) pos += searchString.length;
+  } else {
+    throw MissingSyntax(pos, searchString);
+  }
+}
+
+/**
+ * A MessageFormat 2 parser for message formatting.
+ *
+ * Parses the `source` syntax representation of a message into
+ * its corresponding data model representation.
+ * Throws on syntax errors, but does not check for data model errors.
+ */
+export function parseMessage(
+  source: string,
+  opt?: MessageParserOptions
+): Model.Message;
+export function parseMessage(
+  source_: string,
+  opt_: MessageParserOptions = {}
+): Model.Message {
+  pos = 0;
+  source = source_;
+  opt = opt_;
+
+  const decl = declarations();
+  if (source.startsWith('.match', pos)) return selectMessage(decl);
+
+  const quoted = decl.length > 0 || source.startsWith('{{', pos);
+  const pattern_ = pattern(quoted);
+  if (quoted) {
+    ws();
+    if (pos < source.length) {
+      throw SyntaxError('extra-content', pos, source.length);
+    }
+  }
+  return { type: 'message', declarations: decl, pattern: pattern_ };
+}
+
+function selectMessage(declarations: Model.Declaration[]): Model.SelectMessage {
+  pos += 6; // '.match'
+  ws();
+
+  const selectors: Model.Expression[] = [];
+  while (source[pos] === '{') {
+    selectors.push(expression(false));
+    ws();
+  }
+  if (selectors.length === 0) throw SyntaxError('empty-token', pos);
+
+  const variants: Model.Variant[] = [];
+  while (pos < source.length) {
+    variants.push(variant());
+    ws();
+  }
+
+  return { type: 'select', declarations, selectors, variants };
+}
+
+function variant(): Model.Variant {
+  const keys: Array<Model.Literal | Model.CatchallKey> = [];
+  while (pos < source.length) {
+    ws(keys.length ? '{' : false);
+    const next = source[pos];
+    if (next === '{') break;
+    if (next === '*') {
+      keys.push({ type: '*' });
+      pos += 1;
+    } else {
+      keys.push(literal(true));
+    }
+  }
+  return { keys, value: pattern(true) };
+}
+
+function pattern(quoted: boolean): Model.Pattern {
+  if (quoted) {
+    if (source.startsWith('{{', pos)) pos += 2;
+    else throw MissingSyntax(pos, '{{');
+  }
+
+  const pattern: Model.Pattern = [];
+  loop: while (pos < source.length) {
+    switch (source[pos]) {
+      case '{': {
+        pattern.push(expression(true));
+        break;
+      }
+      case '}':
+        if (!quoted) throw SyntaxError('parse-error', pos);
+        break loop;
+      default: {
+        pattern.push(text());
+      }
+    }
+  }
+
+  if (quoted) {
+    if (source.startsWith('}}', pos)) pos += 2;
+    else throw MissingSyntax(pos, '}}');
+  }
+  return pattern;
+}
+
+function declarations(): Model.Declaration[] {
+  const declarations: Model.Declaration[] = [];
+  loop: while (source[pos] === '.') {
+    const keyword = parseNameValue(source, pos + 1);
+    switch (keyword) {
+      case 'input':
+        declarations.push(inputDeclaration());
+        break;
+      case 'local':
+        declarations.push(localDeclaration());
+        break;
+      case 'match':
+        break loop;
+      case '':
+        throw SyntaxError('parse-error', pos);
+      default:
+        declarations.push(unsupportedStatement(keyword));
+    }
+    ws();
+  }
+  return declarations;
+}
+
+function inputDeclaration(): Model.InputDeclaration {
+  pos += 6; // '.input'
+  ws();
+  expect('{', false);
+  const valueStart = pos;
+  const value = expression(false);
+  if (value.type === 'expression' && value.arg?.type === 'variable') {
+    // @ts-expect-error TS isn't catching that value is Expression<VariableRef>
+    return { type: 'input', name: value.arg.name, value };
+  }
+  throw SyntaxError('bad-input-expression', valueStart, pos);
+}
+
+function localDeclaration(): Model.LocalDeclaration {
+  pos += 6; // '.local'
+  ws(true);
+  expect('$', true);
+  const name_ = name();
+  ws();
+  expect('=', true);
+  ws();
+  expect('{', false);
+  const value = expression(false);
+  return { type: 'local', name: name_, value };
+}
+
+function unsupportedStatement(keyword: string): Model.UnsupportedStatement {
+  pos += 1 + keyword.length; // '.' + keyword
+  ws('{');
+  const body = reservedBody();
+  const expressions: (Model.Expression | Model.Markup)[] = [];
+  while (source[pos] === '{') {
+    if (source.startsWith('{{', pos)) break;
+    expressions.push(expression(false));
+    ws();
+  }
+  if (expressions.length === 0) throw SyntaxError('empty-token', pos);
+  return { type: 'unsupported-statement', keyword, body, expressions };
+}
+
+function expression(allowMarkup: false): Model.Expression;
+function expression(allowMarkup: boolean): Model.Expression | Model.Markup;
+function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
+  const start = pos;
+  pos += 1; // '{'
+  ws();
+
+  const arg = value(false);
+  if (arg) ws('}');
+
+  const sigil = source[pos];
+  let annotation:
+    | Model.FunctionAnnotation
+    | Model.UnsupportedAnnotation
+    | undefined;
+  let markup: Model.Markup | undefined;
+  switch (sigil) {
+    case '@':
+    case '}':
+      break;
+    case ':': {
+      pos += 1; // ':'
+      annotation = { type: 'function', name: identifier() };
+      const options_ = options();
+      if (options_.length) annotation.options = options_;
+      break;
+    }
+    case '#':
+    case '/': {
+      if (arg || !allowMarkup) throw SyntaxError('parse-error', pos);
+      pos += 1; // '#' or '/'
+      if (sigil === '#') {
+        markup = { type: 'markup', kind: 'open', name: identifier() };
+        const options_ = options();
+        if (options_.length) markup.options = options_;
+      } else {
+        markup = { type: 'markup', kind: 'close', name: identifier() };
+        ws('}');
+      }
+      break;
+    }
+    case '^':
+    case '&':
+      annotation = privateAnnotation(sigil);
+      break;
+    case '!':
+    case '%':
+    case '*':
+    case '+':
+    case '<':
+    case '>':
+    case '?':
+    case '~':
+      annotation = unsupportedAnnotation(sigil);
+      break;
+    default:
+      throw SyntaxError('parse-error', pos);
+  }
+
+  while (source[pos] === '@') attribute();
+  if (markup?.kind === 'open' && source[pos] === '/') {
+    // @ts-expect-error Yes, TS, this does become MarkupStandalone.
+    markup.kind = 'standalone';
+    pos += 1; // '/'
+  }
+  expect('}', true);
+
+  if (annotation) {
+    return arg
+      ? { type: 'expression', arg, annotation }
+      : { type: 'expression', annotation };
+  }
+  if (markup) return markup;
+  if (!arg) throw SyntaxError('empty-token', start, pos);
+  return { type: 'expression', arg };
+}
+
+/** Requires and consumes leading and trailing whitespace. */
+function options() {
+  ws('/}');
+  const options: Model.Option[] = [];
+  while (pos < source.length) {
+    const next = source[pos];
+    if (next === '@' || next === '/' || next === '}') break;
+    const name_ = identifier();
+    ws();
+    expect('=', true);
+    ws();
+    options.push({ name: name_, value: value(true) });
+    ws('/}');
+  }
+  return options;
+}
+
+function attribute() {
+  pos += 1; // '@'
+  identifier(); // name
+  ws('=/}');
+  if (source[pos] === '=') {
+    pos += 1; // '='
+    ws();
+    value(true); // value
+    ws('/}');
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function privateAnnotation(sigil: '^' | '&'): any {
+  if (opt.privateAnnotation) {
+    const res = opt.privateAnnotation(source, pos);
+    pos = res.pos;
+    ws('}');
+    return res.annotation;
+  }
+  return unsupportedAnnotation(sigil);
+}
+
+function unsupportedAnnotation(
+  sigil: Model.UnsupportedAnnotation['sigil']
+): Model.UnsupportedAnnotation {
+  pos += 1; // sigil
+  const src = reservedBody();
+  return { type: 'unsupported-annotation', sigil, source: src };
+}
+
+function reservedBody(): string {
+  const start = pos;
+  loop: while (pos < source.length) {
+    const next = source[pos];
+    switch (next) {
+      case '\\': {
+        switch (source[pos + 1]) {
+          case '\\':
+          case '{':
+          case '|':
+          case '}':
+            break;
+          default:
+            throw SyntaxError('bad-escape', pos, pos + 2);
+        }
+        pos += 2;
+        break;
+      }
+      case '|':
+        quotedLiteral();
+        break;
+      case '@':
+        pos -= 1;
+        ws(true);
+        break loop;
+      case '{':
+      case '}':
+        break loop;
+      default: {
+        const cc = next.charCodeAt(0);
+        if (cc >= 0xd800 && cc < 0xe000) {
+          // surrogates are invalid here
+          throw SyntaxError('parse-error', pos);
+        }
+        pos += 1;
+      }
+    }
+  }
+  return source.substring(start, pos).trimEnd();
+}
+
+function text(): string {
+  let value = '';
+  let i = pos;
+  loop: for (; i < source.length; ++i) {
+    switch (source[i]) {
+      case '\\': {
+        const esc = source[i + 1];
+        if (esc !== '\\' && esc !== '{' && esc !== '}') {
+          throw SyntaxError('bad-escape', i, i + 2);
+        }
+        value += source.substring(pos, i) + esc;
+        i += 1;
+        pos = i + 1;
+        break;
+      }
+      case '{':
+      case '}':
+        break loop;
+    }
+  }
+  value += source.substring(pos, i);
+  pos = i;
+  return value;
+}
+
+function value(required: true): Model.Literal | Model.VariableRef;
+function value(
+  required: boolean
+): Model.Literal | Model.VariableRef | undefined;
+function value(
+  required: boolean
+): Model.Literal | Model.VariableRef | undefined {
+  if (source[pos] === '$') {
+    pos += 1; // '$'
+    return { type: 'variable', name: name() };
+  } else {
+    return literal(required);
+  }
+}
+
+function literal(required: true): Model.Literal;
+function literal(required: boolean): Model.Literal | undefined;
+function literal(required: boolean): Model.Literal | undefined {
+  if (source[pos] === '|') return quotedLiteral();
+  const value = parseUnquotedLiteralValue(source, pos);
+  if (!value) {
+    if (required) throw SyntaxError('empty-token', pos);
+    else return undefined;
+  }
+  pos += value.length;
+  return { type: 'literal', value };
+}
+
+function quotedLiteral(): Model.Literal {
+  pos += 1; // '|'
+  let value = '';
+  for (let i = pos; i < source.length; ++i) {
+    switch (source[i]) {
+      case '\\': {
+        const esc = source[i + 1];
+        if (esc !== '\\' && esc !== '|') {
+          throw SyntaxError('bad-escape', i, i + 2);
+        }
+        value += source.substring(pos, i) + esc;
+        i += 1;
+        pos = i + 1;
+        break;
+      }
+      case '|':
+        value += source.substring(pos, i);
+        pos = i + 1;
+        return { type: 'literal', value };
+    }
+  }
+  throw MissingSyntax(source.length, '|');
+}
+
+function identifier(): string {
+  const name_ = name();
+  if (source[pos] === ':') {
+    pos += 1;
+    return name_ + ':' + name();
+  }
+  return name_;
+}
+
+function name(): string {
+  const name = parseNameValue(source, pos);
+  if (!name) throw SyntaxError('empty-token', pos);
+  pos += name.length;
+  return name;
+}
+
+function ws(required?: boolean): void;
+function ws(requiredIfNotFollowedBy: string): void;
+function ws(req: string | boolean): void;
+function ws(req: string | boolean = false): void {
+  let length = 0;
+  let next = source[pos];
+  while (whitespaceChars.includes(next)) {
+    length += 1;
+    next = source[pos + length];
+  }
+  pos += length;
+  if (req && !length && (req === true || !req.includes(source[pos]))) {
+    throw MissingSyntax(pos, "' '");
+  }
+}

--- a/packages/mf2-messageformat/src/data-model/stringify.ts
+++ b/packages/mf2-messageformat/src/data-model/stringify.ts
@@ -1,5 +1,5 @@
-import { isValidUnquotedLiteral } from '../cst/names.js';
 import { MessageFormat } from '../messageformat.js';
+import { isValidUnquotedLiteral } from '../cst/names.js';
 import {
   isLiteral,
   isPatternMessage,

--- a/packages/mf2-messageformat/src/index.ts
+++ b/packages/mf2-messageformat/src/index.ts
@@ -6,6 +6,7 @@ export type * from './formatted-parts.js';
 export { parseCST } from './cst/parse-cst.js';
 export { stringifyCST } from './cst/stringify-cst.js';
 export { messageFromCST, cst } from './data-model/from-cst.js';
+export { type MessageParserOptions, parseMessage } from './data-model/parse.js';
 export { stringifyMessage } from './data-model/stringify.js';
 export {
   isCatchallKey,

--- a/packages/mf2-messageformat/src/messageformat.test.ts
+++ b/packages/mf2-messageformat/src/messageformat.test.ts
@@ -6,8 +6,8 @@ import {
   MessageFormat,
   MessageSyntaxError,
   messageFromCST,
-  parseMessage,
-  parseCST
+  parseCST,
+  parseMessage
 } from './index.js';
 
 describe('Syntax errors', () => {

--- a/packages/mf2-messageformat/src/messageformat.test.ts
+++ b/packages/mf2-messageformat/src/messageformat.test.ts
@@ -2,8 +2,13 @@ import syntaxErrors from './__fixtures/syntax-errors.json';
 import testCore from './__fixtures/test-core.json';
 import testFunctions from './__fixtures/test-functions.json';
 import { testName } from './__fixtures/util-test-name.js';
-import { MessageSyntaxError } from './errors.js';
-import { MessageFormat } from './messageformat.js';
+import {
+  MessageFormat,
+  MessageSyntaxError,
+  messageFromCST,
+  parseMessage,
+  parseCST
+} from './index.js';
 
 describe('Syntax errors', () => {
   for (const src of syntaxErrors) {
@@ -13,34 +18,42 @@ describe('Syntax errors', () => {
   }
 });
 
-for (const [title, messages] of [
-  ['Core message syntax', testCore] as const,
-  ...Object.entries(testFunctions).map(
-    x => [`Messages using :${x[0]}`, x[1]] as const
-  )
-]) {
-  describe(title, () => {
-    for (const testMsg of messages) {
-      const {
-        src,
-        exp,
-        parts,
-        locale,
-        params,
-        errors: expErrors,
-        only
-      } = testMsg;
-      (only ? test.only : test)(testName(testMsg), () => {
-        let errors: any[] = [];
-        const mf = new MessageFormat(src, locale ?? 'en');
-        const msg = mf.format(params, err => errors.push(err));
-        expect(msg).toBe(exp);
-        expect(errors).toMatchObject(expErrors ?? []);
-        if (parts) {
-          errors = [];
-          const mp = mf.formatToParts(params, err => errors.push(err));
-          expect(mp).toMatchObject(parts);
-          expect(errors).toMatchObject(expErrors ?? []);
+for (const [parserName, parse] of [
+  ['Built-in parser', src => src],
+  ['CST parser', src => messageFromCST(parseCST(src))],
+  ['Data model parser', parseMessage]
+] as Array<[string, (src: string) => any]>) {
+  describe(parserName, () => {
+    for (const [title, messages] of [
+      ['Core message syntax', testCore] as const,
+      ...Object.entries(testFunctions).map(
+        x => [`Messages using :${x[0]}`, x[1]] as const
+      )
+    ]) {
+      describe(title, () => {
+        for (const testMsg of messages) {
+          const {
+            src,
+            exp,
+            parts,
+            locale,
+            params,
+            errors: expErrors,
+            only
+          } = testMsg;
+          (only ? test.only : test)(testName(testMsg), () => {
+            let errors: any[] = [];
+            const mf = new MessageFormat(parse(src), locale ?? 'en');
+            const msg = mf.format(params, err => errors.push(err));
+            expect(msg).toBe(exp);
+            expect(errors).toMatchObject(expErrors ?? []);
+            if (parts) {
+              errors = [];
+              const mp = mf.formatToParts(params, err => errors.push(err));
+              expect(mp).toMatchObject(parts);
+              expect(errors).toMatchObject(expErrors ?? []);
+            }
+          });
         }
       });
     }

--- a/packages/mf2-messageformat/src/messageformat.ts
+++ b/packages/mf2-messageformat/src/messageformat.ts
@@ -1,5 +1,3 @@
-import { parseCST } from './cst/parse-cst.js';
-import { messageFromCST } from './data-model/from-cst.js';
 import type { MessageFunctionContext } from './data-model/function-context.js';
 import { formatMarkup } from './data-model/format-markup.js';
 import { resolveExpression } from './data-model/resolve-expression.js';
@@ -22,6 +20,7 @@ import {
   plural,
   string
 } from './functions/index.js';
+import { parseMessage } from './data-model/parse.js';
 import { selectPattern } from './select-pattern.js';
 
 const defaultFunctions = Object.freeze({
@@ -87,8 +86,7 @@ export class MessageFormat {
       : locales
         ? [locales]
         : [];
-    this.#message =
-      typeof source === 'string' ? messageFromCST(parseCST(source)) : source;
+    this.#message = typeof source === 'string' ? parseMessage(source) : source;
     validate(this.#message, (type, node) => {
       throw new MessageDataModelError(type, node);
     });


### PR DESCRIPTION
The spec discussion and probable change in tc39/proposal-intl-messageformat#47 of requiring messages to be input as data models has highlighted the need for a performant parser. That's added here as `parseMessage(source, options)`. Its only supported option is `privateAnnotation`, a function that can be defined to parse private `^` and `&` annotations.

Unlike the CSV parser, this one does not create any intermediate structure on its way to the data model. It's also smaller, minifying & compressing to 2.3kB compared to the CSV's 4.4kB (The MessageFormat runtime is about 4.2kB).