### PR TITLE
Flip MF2 constructor args from (source, locales, options) to (locales, source, options)

### DIFF
--- a/packages/mf2-fluent/src/fluent-to-resource.ts
+++ b/packages/mf2-fluent/src/fluent-to-resource.ts
@@ -46,7 +46,7 @@ export function fluentToResource(
       res.set(id, rg);
     }
     for (const [attr, msg] of group) {
-      rg.set(attr, new MessageFormat(msg, locales, opt));
+      rg.set(attr, new MessageFormat(locales, msg, opt));
     }
   }
 

--- a/packages/mf2-icu-mf1/src/mf1-to-message.ts
+++ b/packages/mf2-icu-mf1/src/mf1-to-message.ts
@@ -36,5 +36,5 @@ export function mf1ToMessage(
     msg = source;
   }
   opt.functions = Object.assign(getMF1Functions(), opt.functions);
-  return new MessageFormat(msg, locales, opt);
+  return new MessageFormat(locales, msg, opt);
 }

--- a/packages/mf2-messageformat/src/data-model/function-annotation.test.ts
+++ b/packages/mf2-messageformat/src/data-model/function-annotation.test.ts
@@ -16,7 +16,7 @@ test('Custom function', () => {
       toString: () => `str:${input}`
     })
   } satisfies MessageFunctions;
-  const mf = new MessageFormat('{$var :custom}', 'en', { functions });
+  const mf = new MessageFormat('en', '{$var :custom}', { functions });
   expect(mf.format({ var: 42 })).toEqual('str:42');
   expect(mf.formatToParts({ var: 42 })).toEqual([
     { type: 'custom', source: '$var', locale: 'en', value: 'part:42' }
@@ -26,9 +26,9 @@ test('Custom function', () => {
 describe('inputs with options', () => {
   test('local variable with :number expression', () => {
     const mf = new MessageFormat(
+      'en',
       `.local $val = {12345678 :number useGrouping=false}
-      {{{$val :number minimumFractionDigits=2}}}`,
-      'en'
+      {{{$val :number minimumFractionDigits=2}}}`
     );
     //const val = new MessageNumber(null, BigInt(12345678), { options: { useGrouping: false } });
     const msg = mf.formatToParts();
@@ -43,8 +43,8 @@ describe('inputs with options', () => {
 
   test('value with options', () => {
     const mf = new MessageFormat(
-      '{$val :number minimumFractionDigits=2}',
-      'en'
+      'en',
+      '{$val :number minimumFractionDigits=2}'
     );
     const val = Object.assign(new Number(12345678), {
       options: { minimumFractionDigits: 4, useGrouping: false }
@@ -61,8 +61,8 @@ describe('inputs with options', () => {
 
   test('MessageValue locales take precedence', () => {
     const mf = new MessageFormat(
-      '{$val :number minimumFractionDigits=2}',
-      'en'
+      'en',
+      '{$val :number minimumFractionDigits=2}'
     );
     const val = Object.assign(new Number(12345), { locale: 'fi' });
     const msg = mf.formatToParts({ val });
@@ -75,16 +75,16 @@ describe('inputs with options', () => {
 
 describe('Type casts based on runtime', () => {
   test('boolean function option with literal value', () => {
-    const mfTrue = new MessageFormat('{$var :number useGrouping=true}', 'en');
+    const mfTrue = new MessageFormat('en', '{$var :number useGrouping=true}');
     expect(mfTrue.format({ var: 1234 })).toBe('1,234');
-    const mfFalse = new MessageFormat('{$var :number useGrouping=false}', 'en');
+    const mfFalse = new MessageFormat('en', '{$var :number useGrouping=false}');
     expect(mfFalse.format({ var: 1234 })).toBe('1234');
   });
 
   test('boolean function option with variable value', () => {
     const mf = new MessageFormat(
-      '{$var :number useGrouping=$useGrouping}',
-      'en'
+      'en',
+      '{$var :number useGrouping=$useGrouping}'
     );
     expect(mf.format({ var: 1234, useGrouping: 'false' })).toBe('1234');
     expect(mf.format({ var: 1234, useGrouping: false })).toBe('1234');
@@ -96,7 +96,7 @@ describe('Function return is not a MessageValue', () => {
     const functions = {
       fail: () => ({ type: 'fail' }) as any
     } satisfies MessageFunctions;
-    const mf = new MessageFormat('{:fail}', 'en', { functions });
+    const mf = new MessageFormat('en', '{:fail}', { functions });
     const onError = jest.fn();
     expect(mf.format(undefined, onError)).toEqual('{:fail}');
     expect(mf.formatToParts(undefined, onError)).toEqual([
@@ -109,7 +109,7 @@ describe('Function return is not a MessageValue', () => {
     const functions = {
       fail: () => null as any
     } satisfies MessageFunctions;
-    const mf = new MessageFormat('{42 :fail}', 'en', { functions });
+    const mf = new MessageFormat('en', '{42 :fail}', { functions });
     const onError = jest.fn();
     expect(mf.format(undefined, onError)).toEqual('{|42|}');
     expect(mf.formatToParts(undefined, onError)).toEqual([

--- a/packages/mf2-messageformat/src/data-model/literal.test.ts
+++ b/packages/mf2-messageformat/src/data-model/literal.test.ts
@@ -1,7 +1,7 @@
 import { MessageFormat } from '../index.js';
 
 function resolve(source: string, errors: any[] = []) {
-  const mf = new MessageFormat(source);
+  const mf = new MessageFormat(undefined, source);
   const onError = jest.fn();
   const res = mf.formatToParts(undefined, onError);
   expect(onError).toHaveBeenCalledTimes(errors.length);
@@ -26,8 +26,12 @@ describe('quoted literals', () => {
   });
 
   test('invalid escapes', () => {
-    expect(() => new MessageFormat('{|quoted \\}iteral|}')).toThrow();
-    expect(() => new MessageFormat('{|quoted \\{iteral|}')).toThrow();
+    expect(
+      () => new MessageFormat(undefined, '{|quoted \\}iteral|}')
+    ).toThrow();
+    expect(
+      () => new MessageFormat(undefined, '{|quoted \\{iteral|}')
+    ).toThrow();
   });
 });
 

--- a/packages/mf2-messageformat/src/data-model/markup.test.ts
+++ b/packages/mf2-messageformat/src/data-model/markup.test.ts
@@ -2,7 +2,7 @@ import { MessageFormat, parseCST } from '../index.js';
 
 describe('Simple open/close', () => {
   test('no options, literal body', () => {
-    const mf = new MessageFormat('{#b}foo{/b}');
+    const mf = new MessageFormat(undefined, '{#b}foo{/b}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
       { type: 'literal', value: 'foo' },
@@ -13,8 +13,8 @@ describe('Simple open/close', () => {
 
   test('options', () => {
     const mf = new MessageFormat(
-      '{#b foo=42 bar=$foo}foo{$foo}{/b foo=| bar 13 |}',
-      'en'
+      'en',
+      '{#b foo=42 bar=$foo}foo{$foo}{/b foo=| bar 13 |}'
     );
     const msg = mf.formatToParts({ foo: 'foo bar' });
     expect(msg).toEqual([
@@ -40,7 +40,7 @@ describe('Simple open/close', () => {
 
   test('do not allow operands', () => {
     const src = '{x #b}';
-    expect(() => new MessageFormat(src, 'en')).toThrow();
+    expect(() => new MessageFormat('en', src)).toThrow();
     const cst = parseCST(src);
     expect(cst).toMatchObject({
       type: 'simple',
@@ -59,7 +59,7 @@ describe('Simple open/close', () => {
 
 describe('Multiple open/close', () => {
   test('adjacent', () => {
-    const mf = new MessageFormat('{#b}foo{/b}{#a}bar{/a}');
+    const mf = new MessageFormat(undefined, '{#b}foo{/b}{#a}bar{/a}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
       { type: 'literal', value: 'foo' },
@@ -72,7 +72,7 @@ describe('Multiple open/close', () => {
   });
 
   test('nested', () => {
-    const mf = new MessageFormat('{#b}foo{#a}bar{/a}{/b}');
+    const mf = new MessageFormat(undefined, '{#b}foo{#a}bar{/a}{/b}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
       { type: 'literal', value: 'foo' },
@@ -85,7 +85,7 @@ describe('Multiple open/close', () => {
   });
 
   test('overlapping', () => {
-    const mf = new MessageFormat('{#b}foo{#a}bar{/b}baz{/a}');
+    const mf = new MessageFormat(undefined, '{#b}foo{#a}bar{/b}baz{/a}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
       { type: 'literal', value: 'foo' },

--- a/packages/mf2-messageformat/src/data-model/unsupported-annotation.test.ts
+++ b/packages/mf2-messageformat/src/data-model/unsupported-annotation.test.ts
@@ -5,7 +5,7 @@ function resolve(
   params: Record<string, unknown>,
   errors: any[] = []
 ) {
-  const mf = new MessageFormat(source);
+  const mf = new MessageFormat(undefined, source);
   const onError = jest.fn();
   const res = mf.formatToParts(params, onError);
   expect(onError).toHaveBeenCalledTimes(errors.length);
@@ -49,6 +49,8 @@ describe('Reserved syntax', () => {
   });
 
   test('surrogates', () => {
-    expect(() => new MessageFormat('{ %invalid \ud900 surrogate }')).toThrow();
+    expect(
+      () => new MessageFormat(undefined, '{ %invalid \ud900 surrogate }')
+    ).toThrow();
   });
 });

--- a/packages/mf2-messageformat/src/data-model/variable.test.ts
+++ b/packages/mf2-messageformat/src/data-model/variable.test.ts
@@ -3,7 +3,7 @@ import { MessageFormat } from '../index.js';
 describe('variables', () => {
   let mf: MessageFormat;
   beforeEach(() => {
-    mf = new MessageFormat('{$val}', 'en');
+    mf = new MessageFormat('en', '{$val}');
   });
 
   test('number', () => {
@@ -78,7 +78,7 @@ describe('variables', () => {
 describe('Variable paths', () => {
   let mf: MessageFormat;
   beforeEach(() => {
-    mf = new MessageFormat('{$user.name}', 'en');
+    mf = new MessageFormat('en', '{$user.name}');
   });
 
   test('top-level match', () => {

--- a/packages/mf2-messageformat/src/messageformat.ts
+++ b/packages/mf2-messageformat/src/messageformat.ts
@@ -76,8 +76,8 @@ export class MessageFormat {
   readonly #functions: Readonly<MessageFunctions>;
 
   constructor(
+    locales: string | string[] | undefined,
     source: string | Message,
-    locales?: string | string[],
     options?: MessageFormatOptions
   ) {
     this.#localeMatcher = options?.localeMatcher ?? 'best fit';

--- a/packages/mf2-messageformat/src/mf2-features.test.ts
+++ b/packages/mf2-messageformat/src/mf2-features.test.ts
@@ -42,13 +42,13 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
 
   test('input as { start, end } object', () => {
     const mf = new MessageFormat(
+      'nl',
       source`
         .input {$range :range}
         .match {$range}
         one {{{$range} dag}}
         * {{{$range} dagen}}
       `,
-      'nl',
       { functions: { range } }
     );
 
@@ -134,7 +134,7 @@ describe('Multi-selector messages (unicode-org/message-format-wg#119)', () => {
     expect(msg.selectors).toHaveLength(6);
     expect(msg.variants).toHaveLength(64);
 
-    const mf = new MessageFormat(msg, 'en');
+    const mf = new MessageFormat('en', msg);
 
     const one = mf.format({
       N: 1,
@@ -236,19 +236,19 @@ maybe('List formatting', () => {
     const list = ['Motorcycle', 'Bus', 'Car'];
     const opt = { functions: { list: listFn() } };
 
-    const mf1 = new MessageFormat('{$list :list}', 'en', opt);
+    const mf1 = new MessageFormat('en', '{$list :list}', opt);
     expect(mf1.format({ list })).toBe('Motorcycle, Bus, and Car');
 
     const mf2 = new MessageFormat(
-      '{$list :list style=short type=conjunction}',
       'en',
+      '{$list :list style=short type=conjunction}',
       opt
     );
     expect(mf2.format({ list })).toBe('Motorcycle, Bus, & Car');
 
     const mf3 = new MessageFormat(
-      '{$list :list style=long type=disjunction}',
       'en',
+      '{$list :list style=long type=disjunction}',
       opt
     );
     expect(mf3.format({ list })).toBe('Motorcycle, Bus, or Car');
@@ -266,12 +266,12 @@ maybe('List formatting', () => {
     }
 
     const mf = new MessageFormat(
+      'ro',
       source`
         .match {$count :number}
         one {{I-am dat cadouri {$list :list each=dative}.}}
         * {{Le-am dat cadouri {$list :list each=dative}.}}
       `,
-      'ro',
       { functions: { list: listFn({ dative }) } }
     );
 
@@ -315,7 +315,7 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
   }
 
   test('Match, no change', () => {
-    const mf = new MessageFormat('A {$foo} and an {$other}', 'en');
+    const mf = new MessageFormat('en', 'A {$foo} and an {$other}');
     const parts = mf.formatToParts({ foo: 'foo', other: 'other' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
@@ -327,7 +327,7 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
   });
 
   test('Match, changed', () => {
-    const mf = new MessageFormat('A {$foo} and an {$other}', 'en');
+    const mf = new MessageFormat('en', 'A {$foo} and an {$other}');
     const parts = mf.formatToParts({ foo: 'other', other: 'foo' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
@@ -339,7 +339,7 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
   });
 
   test('No match, no change', () => {
-    const mf = new MessageFormat('The {$foo} and lotsa {$other}', 'en');
+    const mf = new MessageFormat('en', 'The {$foo} and lotsa {$other}');
     const parts = mf.formatToParts({ foo: 'foo', other: 'other' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
@@ -351,7 +351,7 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
   });
 
   test('Articles across non-wordy content', () => {
-    const mf = new MessageFormat('{$foo} foo and a {|...|} {$other}', 'en');
+    const mf = new MessageFormat('en', '{$foo} foo and a {|...|} {$other}');
     const parts = mf.formatToParts({ foo: 'An', other: 'other' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([

--- a/packages/mf2-messageformat/src/spec.test.ts
+++ b/packages/mf2-messageformat/src/spec.test.ts
@@ -25,7 +25,9 @@ const tests = (tc: Test) => () => {
     case 'syntax-error':
       describe('syntax error', () => {
         test('MessageFormat(string)', () => {
-          expect(() => new MessageFormat(tc.src)).toThrow(MessageSyntaxError);
+          expect(() => new MessageFormat(undefined, tc.src)).toThrow(
+            MessageSyntaxError
+          );
         });
         test('parseCST(string)', () => {
           const cst = parseCST(tc.src);
@@ -39,7 +41,7 @@ const tests = (tc: Test) => () => {
     case 'data-model-error':
       describe('data model error', () => {
         test('MessageFormat(string)', () => {
-          expect(() => new MessageFormat(tc.src)).toThrow(
+          expect(() => new MessageFormat(undefined, tc.src)).toThrow(
             MessageDataModelError
           );
         });
@@ -56,7 +58,7 @@ const tests = (tc: Test) => () => {
     default:
       test('format', () => {
         let errors: any[] = [];
-        const mf = new MessageFormat(tc.src, tc.locale);
+        const mf = new MessageFormat(tc.locale, tc.src);
         const msg = mf.format(tc.params, err => errors.push(err));
         if (typeof tc.exp === 'string') expect(msg).toBe(tc.exp);
         if (Array.isArray(tc.expErrors)) {


### PR DESCRIPTION
This is a breaking change, following the spec change in tc39/proposal-intl-messageformat#62.

Note that as both arguments accept a string value, tooling such as TypeScript may not catch all the places where you'll need to change your code.

This also means that the constructor now has two required arguments, albeit the first one can be `undefined`.