### PR TITLE
Drop locales & message from MF2 resolvedOptions()

### DIFF
--- a/packages/mf2-messageformat/src/data-model/stringify.ts
+++ b/packages/mf2-messageformat/src/data-model/stringify.ts
@@ -1,4 +1,3 @@
-import { MessageFormat } from '../messageformat.js';
 import { isValidUnquotedLiteral } from '../cst/names.js';
 import {
   isLiteral,
@@ -24,8 +23,7 @@ import type {
  *
  * @beta
  */
-export function stringifyMessage(msg: Message | MessageFormat) {
-  if (msg instanceof MessageFormat) msg = msg.resolvedOptions().message;
+export function stringifyMessage(msg: Message) {
   let res = '';
   for (const decl of msg.declarations) res += stringifyDeclaration(decl);
   if (isPatternMessage(msg)) {

--- a/packages/mf2-messageformat/src/messageformat.ts
+++ b/packages/mf2-messageformat/src/messageformat.ts
@@ -156,9 +156,7 @@ export class MessageFormat {
   resolvedOptions() {
     return {
       functions: Object.freeze(this.#functions),
-      localeMatcher: this.#localeMatcher,
-      locales: this.#locales.slice(),
-      message: Object.freeze(this.#message)
+      localeMatcher: this.#localeMatcher
     };
   }
 


### PR DESCRIPTION
This is a breaking change, following the spec change in tc39/proposal-intl-messageformat#63.