### PR TITLE
MF2 spec updates

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with: { node-version: 18 }
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: '2.7'
+          ruby-version: '3.3'
           working-directory: ./docs
       - run: npm ci
       - run: npm run build

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
-
-# https://github.com/jekyll/jekyll/issues/8523
-gem "webrick", "~> 1.7"

--- a/packages/mf2-fluent/src/fluent-to-message.ts
+++ b/packages/mf2-fluent/src/fluent-to-message.ts
@@ -119,13 +119,13 @@ function asExpression(exp: Fluent.Expression): Expression {
         throw new Error(`More than one positional argument is not supported.`);
       }
       if (named.length > 0) {
-        annotation.options = [];
+        annotation.options = new Map();
         for (const { name, value } of named) {
           const quoted = value.type !== 'NumberLiteral';
           const litValue = quoted ? value.parse().value : value.value;
-          annotation.options.push({
-            name: name.name,
-            value: { type: 'literal', value: litValue }
+          annotation.options.set(name.name, {
+            type: 'literal',
+            value: litValue
           });
         }
       }
@@ -152,13 +152,13 @@ function asExpression(exp: Fluent.Expression): Expression {
         ? `-${exp.id.name}.${exp.attribute.name}`
         : `-${exp.id.name}`;
       if (exp.arguments?.named.length) {
-        annotation.options = [];
+        annotation.options = new Map();
         for (const { name, value } of exp.arguments.named) {
           const quoted = value.type !== 'NumberLiteral';
           const litValue = quoted ? value.parse().value : value.value;
-          annotation.options.push({
-            name: name.name,
-            value: { type: 'literal', value: litValue }
+          annotation.options.set(name.name, {
+            type: 'literal',
+            value: litValue
           });
         }
       }

--- a/packages/mf2-fluent/src/fluent.test.ts
+++ b/packages/mf2-fluent/src/fluent.test.ts
@@ -272,7 +272,7 @@ const testCases: Record<string, TestCase> = {
         msg: 'plural',
         scope: {},
         exp: 'B',
-        errors: ['$selector', 'bad-operand', 'not-selectable']
+        errors: ['$selector', 'bad-operand', 'bad-selector']
       },
       { msg: 'plural', scope: { selector: 1 }, exp: 'A' },
       { msg: 'plural', scope: { selector: 2 }, exp: 'B' },
@@ -280,7 +280,7 @@ const testCases: Record<string, TestCase> = {
         msg: 'plural',
         scope: { selector: 'one' },
         exp: 'B',
-        errors: ['bad-operand', 'not-selectable']
+        errors: ['bad-operand', 'bad-selector']
       },
       {
         msg: 'default',
@@ -667,7 +667,7 @@ describe('formatToParts', () => {
       expect(msg).toEqual([{ type: 'literal', value: 'Other' }]);
       expect(onError.mock.calls.map(args => args[0].type)).toEqual([
         'bad-operand',
-        'not-selectable'
+        'bad-selector'
       ]);
     });
   });

--- a/packages/mf2-fluent/src/message-to-fluent.ts
+++ b/packages/mf2-fluent/src/message-to-fluent.ts
@@ -165,17 +165,19 @@ function functionRefToFluent(
 ): Fluent.InlineExpression {
   const args = new Fluent.CallArguments();
   if (arg) args.positional[0] = arg;
-  if (options) {
-    args.named = options.map(opt => {
-      const va = valueToFluent(ctx, opt.value);
+  if (options?.size) {
+    args.named = [];
+    for (const [name, value] of options) {
+      const va = valueToFluent(ctx, value);
       if (va instanceof Fluent.BaseLiteral) {
-        const id = new Fluent.Identifier(opt.name);
-        return new Fluent.NamedArgument(id, va);
+        const id = new Fluent.Identifier(name);
+        args.named.push(new Fluent.NamedArgument(id, va));
+      } else {
+        throw new Error(
+          `Fluent options must have literal values (got ${va.type} for ${name})`
+        );
       }
-      throw new Error(
-        `Fluent options must have literal values (got ${va.type} for ${opt.name})`
-      );
-    });
+    }
   }
 
   const id = ctx.functionMap[name];

--- a/packages/mf2-icu-mf1/src/mf1-to-message-data.ts
+++ b/packages/mf2-icu-mf1/src/mf1-to-message-data.ts
@@ -3,7 +3,7 @@ import type {
   Expression,
   FunctionAnnotation,
   Message,
-  Option,
+  Options,
   VariableRef,
   Variant
 } from 'messageformat';
@@ -76,9 +76,7 @@ function tokenToPart(
           if (pt.type === 'content') value += pt.value;
           else throw new Error(`Unsupported param type: ${pt.type}`);
         }
-        annotation.options = [
-          { name: 'param', value: { type: 'literal', value } }
-        ];
+        annotation.options = new Map([['param', { type: 'literal', value }]]);
       }
       return {
         type: 'expression',
@@ -93,12 +91,9 @@ function tokenToPart(
         name: 'number'
       };
       if (pluralOffset) {
-        annotation.options = [
-          {
-            name: 'pluralOffset',
-            value: { type: 'literal', value: String(pluralOffset) }
-          }
-        ];
+        annotation.options = new Map([
+          ['pluralOffset', { type: 'literal', value: String(pluralOffset) }]
+        ]);
       }
       return {
         type: 'expression',
@@ -126,22 +121,19 @@ function argToExpression({
     };
   }
 
-  const options: Option[] = [];
+  const options: Options = new Map();
   if (pluralOffset) {
-    options.push({
-      name: 'pluralOffset',
-      value: { type: 'literal', value: String(pluralOffset) }
+    options.set('pluralOffset', {
+      type: 'literal',
+      value: String(pluralOffset)
     });
   }
   if (type === 'selectordinal') {
-    options.push({
-      name: 'type',
-      value: { type: 'literal', value: 'ordinal' }
-    });
+    options.set('type', { type: 'literal', value: 'ordinal' });
   }
 
   const annotation: FunctionAnnotation = { type: 'function', name: 'number' };
-  if (options.length) annotation.options = options;
+  if (options.size) annotation.options = options;
 
   return { type: 'expression', arg, annotation };
 }

--- a/packages/mf2-messageformat/src/cst/declarations.ts
+++ b/packages/mf2-messageformat/src/cst/declarations.ts
@@ -5,12 +5,15 @@ import type * as CST from './types.js';
 import { whitespaces } from './util.js';
 import { parseVariable } from './values.js';
 
-export function parseDeclarations(ctx: ParseContext): {
+export function parseDeclarations(
+  ctx: ParseContext,
+  start: number
+): {
   declarations: CST.Declaration[];
   end: number;
 } {
   const { source } = ctx;
-  let pos = whitespaces(source, 0);
+  let pos = start;
   const declarations: CST.Declaration[] = [];
   loop: while (source[pos] === '.') {
     const keyword = parseNameValue(source, pos + 1);

--- a/packages/mf2-messageformat/src/cst/expression.ts
+++ b/packages/mf2-messageformat/src/cst/expression.ts
@@ -277,15 +277,12 @@ function parseAttribute(ctx: ParseContext, start: number): CST.Attribute {
   let pos = id.end;
   const ws = whitespaces(source, pos);
   let equals: CST.Syntax<'='> | undefined;
-  let value: CST.Literal | CST.VariableRef | undefined;
+  let value: CST.Literal | undefined;
   if (source[pos + ws] === '=') {
     pos += ws + 1;
     equals = { start: pos - 1, end: pos, value: '=' };
     pos += whitespaces(source, pos);
-    value =
-      source[pos] === '$'
-        ? parseVariable(ctx, pos)
-        : parseLiteral(ctx, pos, true);
+    value = parseLiteral(ctx, pos, true);
     pos = value.end;
   }
   return {

--- a/packages/mf2-messageformat/src/cst/parse-cst.ts
+++ b/packages/mf2-messageformat/src/cst/parse-cst.ts
@@ -95,7 +95,7 @@ function parseSelectMessage(
     const sel = parseExpression(ctx, pos);
     const body = sel.markup ?? sel.annotation;
     if (body && body.type !== 'function') {
-      ctx.onError('bad-selector', body.start, body.end);
+      ctx.onError('parse-error', body.start, body.end);
     }
     selectors.push(sel);
     pos = sel.end;

--- a/packages/mf2-messageformat/src/cst/parse-cst.ts
+++ b/packages/mf2-messageformat/src/cst/parse-cst.ts
@@ -52,13 +52,16 @@ export function parseCST(
 ): CST.Message {
   const ctx = new ParseContext(source, opt);
 
-  if (source.startsWith('.')) {
-    const { declarations, end: pos } = parseDeclarations(ctx);
-    return source.startsWith('.match', pos)
-      ? parseSelectMessage(ctx, pos, declarations)
-      : parsePatternMessage(ctx, pos, declarations, true);
+  const pos = whitespaces(source, 0);
+  if (source.startsWith('.', pos)) {
+    const { declarations, end } = parseDeclarations(ctx, pos);
+    return source.startsWith('.match', end)
+      ? parseSelectMessage(ctx, end, declarations)
+      : parsePatternMessage(ctx, end, declarations, true);
   } else {
-    return parsePatternMessage(ctx, 0, [], source.startsWith('{{'));
+    return source.startsWith('{{', pos)
+      ? parsePatternMessage(ctx, pos, [], true)
+      : parsePatternMessage(ctx, 0, [], false);
   }
 }
 

--- a/packages/mf2-messageformat/src/cst/types.ts
+++ b/packages/mf2-messageformat/src/cst/types.ts
@@ -186,7 +186,7 @@ export interface Attribute {
   open: Syntax<'@'>;
   name: Identifier;
   equals?: Syntax<'='>;
-  value?: Literal | VariableRef;
+  value?: Literal;
 }
 
 /** @beta */

--- a/packages/mf2-messageformat/src/data-model/format-markup.ts
+++ b/packages/mf2-messageformat/src/data-model/format-markup.ts
@@ -10,9 +10,9 @@ export function formatMarkup(
   const source =
     kind === 'close' ? `/${name}` : kind === 'open' ? `#${name}` : `#${name}/`;
   const part: MessageMarkupPart = { type: 'markup', kind, source, name };
-  if (options?.length) {
+  if (options?.size) {
     part.options = {};
-    for (const { name, value } of options) {
+    for (const [name, value] of options) {
       let rv = resolveValue(ctx, value);
       if (typeof rv === 'object' && typeof rv?.valueOf === 'function') {
         const vv = rv.valueOf();

--- a/packages/mf2-messageformat/src/data-model/literal.test.ts
+++ b/packages/mf2-messageformat/src/data-model/literal.test.ts
@@ -19,19 +19,10 @@ describe('quoted literals', () => {
   });
 
   test('spaces, newlines and escapes', () => {
-    const res = resolve('{| quoted \n \\\\\\|literal\\\\\\||}');
+    const res = resolve('{| quoted \n \\\\\\|literal\\\\\\|\\{\\}|}');
     expect(res).toMatchObject([
-      { type: 'string', value: ' quoted \n \\|literal\\|' }
+      { type: 'string', value: ' quoted \n \\|literal\\|{}' }
     ]);
-  });
-
-  test('invalid escapes', () => {
-    expect(
-      () => new MessageFormat(undefined, '{|quoted \\}iteral|}')
-    ).toThrow();
-    expect(
-      () => new MessageFormat(undefined, '{|quoted \\{iteral|}')
-    ).toThrow();
   });
 });
 

--- a/packages/mf2-messageformat/src/data-model/parse.test.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.test.ts
@@ -35,7 +35,11 @@ describe('private annotations', () => {
       declarations: [],
       pattern: [
         'foo ',
-        { type: 'expression', annotation: { type: 'priv-bar' } }
+        {
+          type: 'expression',
+          annotation: { type: 'priv-bar' },
+          attributes: new Map([['baz', true]])
+        }
       ]
     });
   });

--- a/packages/mf2-messageformat/src/data-model/parse.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.ts
@@ -377,9 +377,7 @@ function text(): string {
     switch (source[i]) {
       case '\\': {
         const esc = source[i + 1];
-        if (esc !== '\\' && esc !== '{' && esc !== '}') {
-          throw SyntaxError('bad-escape', i, i + 2);
-        }
+        if (!'\\{|}'.includes(esc)) throw SyntaxError('bad-escape', i, i + 2);
         value += source.substring(pos, i) + esc;
         i += 1;
         pos = i + 1;
@@ -430,9 +428,7 @@ function quotedLiteral(): Model.Literal {
     switch (source[i]) {
       case '\\': {
         const esc = source[i + 1];
-        if (esc !== '\\' && esc !== '|') {
-          throw SyntaxError('bad-escape', i, i + 2);
-        }
+        if (!'\\{|}'.includes(esc)) throw SyntaxError('bad-escape', i, i + 2);
         value += source.substring(pos, i) + esc;
         i += 1;
         pos = i + 1;

--- a/packages/mf2-messageformat/src/data-model/parse.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.ts
@@ -236,7 +236,7 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
       pos += 1; // ':'
       annotation = { type: 'function', name: identifier() };
       const options_ = options();
-      if (options_.length) annotation.options = options_;
+      if (options_) annotation.options = options_;
       break;
     }
     case '#':
@@ -246,7 +246,7 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
       const kind = sigil === '#' ? 'open' : 'close';
       markup = { type: 'markup', kind, name: identifier() };
       const options_ = options();
-      if (options_.length) markup.options = options_;
+      if (options_) markup.options = options_;
       break;
     }
     case '^':
@@ -267,7 +267,7 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
       throw SyntaxError('parse-error', pos);
   }
 
-  while (source[pos] === '@') attribute();
+  const attributes_ = attributes();
   if (markup?.kind === 'open' && source[pos] === '/') {
     markup.kind = 'standalone';
     pos += 1; // '/'
@@ -275,42 +275,67 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
   expect('}', true);
 
   if (annotation) {
-    return arg
+    const exp: Model.Expression = arg
       ? { type: 'expression', arg, annotation }
       : { type: 'expression', annotation };
+    if (attributes_) exp.attributes = attributes_;
+    return exp;
   }
-  if (markup) return markup;
+  if (markup) {
+    if (attributes_) markup.attributes = attributes_;
+    return markup;
+  }
   if (!arg) throw SyntaxError('empty-token', start, pos);
-  return { type: 'expression', arg };
+  return attributes_
+    ? { type: 'expression', arg, attributes: attributes_ }
+    : { type: 'expression', arg };
 }
 
 /** Requires and consumes leading and trailing whitespace. */
 function options() {
   ws('/}');
-  const options: Model.Option[] = [];
+  const options: Model.Options = new Map();
+  let isEmpty = true;
   while (pos < source.length) {
     const next = source[pos];
     if (next === '@' || next === '/' || next === '}') break;
+    const start = pos;
     const name_ = identifier();
+    if (options.has(name_)) {
+      throw SyntaxError('duplicate-option-name', start, pos);
+    }
     ws();
     expect('=', true);
     ws();
-    options.push({ name: name_, value: value(true) });
+    options.set(name_, value(true));
+    isEmpty = false;
     ws('/}');
   }
-  return options;
+  return isEmpty ? null : options;
 }
 
-function attribute() {
-  pos += 1; // '@'
-  identifier(); // name
-  ws('=/}');
-  if (source[pos] === '=') {
-    pos += 1; // '='
-    ws();
-    value(true); // value
-    ws('/}');
+function attributes() {
+  const attributes: Model.Attributes = new Map();
+  let isEmpty = true;
+  while (source[pos] === '@') {
+    const start = pos;
+    pos += 1; // '@'
+    const name_ = identifier();
+    if (attributes.has(name_)) {
+      throw SyntaxError('duplicate-attribute', start, pos);
+    }
+    ws('=/}');
+    if (source[pos] === '=') {
+      pos += 1; // '='
+      ws();
+      attributes.set(name_, literal(true));
+      ws('/}');
+    } else {
+      attributes.set(name_, true);
+    }
+    isEmpty = false;
   }
+  return isEmpty ? null : attributes;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/mf2-messageformat/src/data-model/parse.ts
+++ b/packages/mf2-messageformat/src/data-model/parse.ts
@@ -72,6 +72,7 @@ export function parseMessage(
   if (source.startsWith('.match', pos)) return selectMessage(decl);
 
   const quoted = decl.length > 0 || source.startsWith('{{', pos);
+  if (!quoted && pos > 0) pos = 0;
   const pattern_ = pattern(quoted);
   if (quoted) {
     ws();
@@ -149,6 +150,7 @@ function pattern(quoted: boolean): Model.Pattern {
 
 function declarations(): Model.Declaration[] {
   const declarations: Model.Declaration[] = [];
+  ws();
   loop: while (source[pos] === '.') {
     const keyword = parseNameValue(source, pos + 1);
     switch (keyword) {

--- a/packages/mf2-messageformat/src/data-model/resolve-function-annotation.ts
+++ b/packages/mf2-messageformat/src/data-model/resolve-function-annotation.ts
@@ -6,7 +6,7 @@ import { getValueSource, resolveValue } from './resolve-value.js';
 import type {
   FunctionAnnotation,
   Literal,
-  Option,
+  Options,
   VariableRef
 } from './types.js';
 
@@ -51,10 +51,10 @@ export function resolveFunctionAnnotation(
   }
 }
 
-function resolveOptions(ctx: Context, options: Option[] | undefined) {
+function resolveOptions(ctx: Context, options: Options | undefined) {
   const opt: Record<string, unknown> = Object.create(null);
   if (options) {
-    for (const { name, value } of options) {
+    for (const [name, value] of options) {
       opt[name] = resolveValue(ctx, value);
     }
   }

--- a/packages/mf2-messageformat/src/data-model/resolve-function-annotation.ts
+++ b/packages/mf2-messageformat/src/data-model/resolve-function-annotation.ts
@@ -28,7 +28,7 @@ export function resolveFunctionAnnotation(
 
     const rf = ctx.functions[name];
     if (!rf) {
-      throw new MessageError('missing-func', `Unknown function :${name}`);
+      throw new MessageError('unknown-function', `Unknown function :${name}`);
     }
     const msgCtx = new MessageFunctionContext(ctx, source);
     const opt = resolveOptions(ctx, options);

--- a/packages/mf2-messageformat/src/data-model/stringify.ts
+++ b/packages/mf2-messageformat/src/data-model/stringify.ts
@@ -109,11 +109,16 @@ function stringifyPattern(pattern: Pattern, quoted: boolean) {
     quoted = true;
   }
   for (const el of pattern) {
-    if (typeof el === 'string') res += el;
+    if (typeof el === 'string') res += stringifyString(el, quoted);
     else if (el.type === 'markup') res += stringifyMarkup(el);
     else res += stringifyExpression(el);
   }
   return quoted ? `{{${res}}}` : res;
+}
+
+function stringifyString(str: string, quoted: boolean) {
+  const esc = quoted ? /[\\|]/g : /[\\{}]/g;
+  return str.replace(esc, '\\$&');
 }
 
 function stringifyExpression({ arg, annotation, attributes }: Expression) {

--- a/packages/mf2-messageformat/src/data-model/stringify.ts
+++ b/packages/mf2-messageformat/src/data-model/stringify.ts
@@ -105,7 +105,7 @@ function stringifyAttribute({ name, value }: Attribute) {
 
 function stringifyPattern(pattern: Pattern, quoted: boolean) {
   let res = '';
-  if (!quoted && typeof pattern[0] === 'string' && pattern[0][0] === '.') {
+  if (!quoted && typeof pattern[0] === 'string' && /^\s*\./.test(pattern[0])) {
     quoted = true;
   }
   for (const el of pattern) {

--- a/packages/mf2-messageformat/src/data-model/stringify.ts
+++ b/packages/mf2-messageformat/src/data-model/stringify.ts
@@ -6,14 +6,12 @@ import {
   isVariableRef
 } from './type-guards.js';
 import type {
-  Attribute,
   Declaration,
   Expression,
   FunctionAnnotation,
   Literal,
   Markup,
   Message,
-  Option,
   Pattern,
   VariableRef
 } from './types.js';
@@ -67,16 +65,26 @@ function stringifyDeclaration(decl: Declaration) {
 
 function stringifyFunctionAnnotation({ name, options }: FunctionAnnotation) {
   let res = `:${name}`;
-  if (options) for (const opt of options) res += ' ' + stringifyOption(opt);
+  if (options) {
+    for (const [key, value] of options) {
+      res += ' ' + stringifyOption(key, value);
+    }
+  }
   return res;
 }
 
 function stringifyMarkup({ kind, name, options, attributes }: Markup) {
   let res = kind === 'close' ? '{/' : '{#';
   res += name;
-  if (options) for (const opt of options) res += ' ' + stringifyOption(opt);
+  if (options) {
+    for (const [name, value] of options) {
+      res += ' ' + stringifyOption(name, value);
+    }
+  }
   if (attributes) {
-    for (const attr of attributes) res += ' ' + stringifyAttribute(attr);
+    for (const [name, value] of attributes) {
+      res += ' ' + stringifyAttribute(name, value);
+    }
   }
   res += kind === 'standalone' ? ' /}' : '}';
   return res;
@@ -88,19 +96,15 @@ function stringifyLiteral({ value }: Literal) {
   return `|${esc}|`;
 }
 
-function stringifyOption({ name, value }: Option) {
+function stringifyOption(name: string, value: Literal | VariableRef) {
   const valueStr = isVariableRef(value)
     ? stringifyVariableRef(value)
     : stringifyLiteral(value);
   return `${name}=${valueStr}`;
 }
 
-function stringifyAttribute({ name, value }: Attribute) {
-  if (!value) return `@${name}`;
-  const valueStr = isVariableRef(value)
-    ? stringifyVariableRef(value)
-    : stringifyLiteral(value);
-  return `@${name}=${valueStr}`;
+function stringifyAttribute(name: string, value: true | Literal) {
+  return value === true ? `@${name}` : `@${name}=${stringifyLiteral(value)}`;
 }
 
 function stringifyPattern(pattern: Pattern, quoted: boolean) {
@@ -141,7 +145,9 @@ function stringifyExpression({ arg, annotation, attributes }: Expression) {
         : annotation.source ?? '�';
   }
   if (attributes) {
-    for (const attr of attributes) res += ' ' + stringifyAttribute(attr);
+    for (const [name, value] of attributes) {
+      res += ' ' + stringifyAttribute(name, value);
+    }
   }
   return `{${res}}`;
 }

--- a/packages/mf2-messageformat/src/data-model/types.ts
+++ b/packages/mf2-messageformat/src/data-model/types.ts
@@ -15,9 +15,7 @@ export type MessageNode =
   | VariableRef
   | FunctionAnnotation
   | UnsupportedAnnotation
-  | Markup
-  | Option
-  | Attribute;
+  | Markup;
 
 /**
  * The representation of a single message.
@@ -140,21 +138,13 @@ export type Expression<
     | Literal
     | VariableRef
     | undefined
-> = A extends Literal | VariableRef
-  ? {
-      type: 'expression';
-      arg: A;
-      annotation?: FunctionAnnotation | UnsupportedAnnotation;
-      attributes?: Attribute[];
-      [cst]?: CST.Expression;
-    }
-  : {
-      type: 'expression';
-      arg?: never;
-      annotation: FunctionAnnotation | UnsupportedAnnotation;
-      attributes?: Attribute[];
-      [cst]?: CST.Expression;
-    };
+> = {
+  type: 'expression';
+  attributes?: Attributes;
+  [cst]?: CST.Expression;
+} & (A extends Literal | VariableRef
+  ? { arg: A; annotation?: FunctionAnnotation | UnsupportedAnnotation }
+  : { arg?: never; annotation: FunctionAnnotation | UnsupportedAnnotation });
 
 /**
  * An immediately defined value.
@@ -206,7 +196,7 @@ export interface VariableRef {
 export interface FunctionAnnotation {
   type: 'function';
   name: string;
-  options?: Option[];
+  options?: Options;
   [cst]?: CST.FunctionRef;
 }
 
@@ -245,33 +235,21 @@ export interface Markup {
   type: 'markup';
   kind: 'open' | 'standalone' | 'close';
   name: string;
-  options?: Option[];
-  attributes?: Attribute[];
+  options?: Options;
+  attributes?: Attributes;
   [cst]?: CST.Expression;
 }
 
 /**
- * The options of {@link FunctionAnnotation} and {@link Markup}
- * are expressed as `key`/`value` pairs to allow their order to be maintained.
+ * The options of {@link FunctionAnnotation} and {@link Markup}.
  *
  * @beta
  */
-export interface Option {
-  type?: never;
-  name: string;
-  value: Literal | VariableRef;
-  [cst]?: CST.Option;
-}
+export type Options = Map<string, Literal | VariableRef>;
 
 /**
- * The attributes of {@link Expression} and {@link Markup}
- * are expressed as `key`/`value` pairs to allow their order to be maintained.
+ * The attributes of {@link Expression} and {@link Markup}.
  *
  * @beta
  */
-export interface Attribute {
-  type?: never;
-  name: string;
-  value?: Literal | VariableRef;
-  [cst]?: CST.Attribute;
-}
+export type Attributes = Map<string, true | Literal>;

--- a/packages/mf2-messageformat/src/data-model/validate.ts
+++ b/packages/mf2-messageformat/src/data-model/validate.ts
@@ -25,9 +25,6 @@ import { visit } from './visit.js';
  * - **Invalid Forward Reference**:
  *   A _declaration_ _expression_ refers to a _variable_ defined by a later _declaration_.
  *
- * - **Duplicate Option Name**:
- *   The same _identifier_ appears as the name of more than one _option_ in the same _expression_.
- *
  * - **Duplicate Variant**:
  *   The same list of _keys_ is used for more than one _variant_.
  *
@@ -92,15 +89,6 @@ export function validate(
           (arg?.type !== 'variable' || !annotated.has(arg.name))
         ) {
           onError('missing-selector-annotation', expression);
-        }
-      }
-    },
-
-    option({ name }, index, options) {
-      for (let j = index + 1; j < options.length; ++j) {
-        if (options[j].name === name) {
-          onError('duplicate-option', options[j]);
-          break;
         }
       }
     },

--- a/packages/mf2-messageformat/src/data-model/validate.ts
+++ b/packages/mf2-messageformat/src/data-model/validate.ts
@@ -28,6 +28,9 @@ import { visit } from './visit.js';
  * - **Duplicate Option Name**:
  *   The same _identifier_ appears as the name of more than one _option_ in the same _expression_.
  *
+ * - **Duplicate Variant**:
+ *   The same list of _keys_ is used for more than one _variant_.
+ *
  * @returns The sets of runtime `functions` and `variables` used by the message.
  * @beta
  */
@@ -52,6 +55,7 @@ export function validate(
   const functions = new Set<string>();
   const localVars = new Set<string>();
   const variables = new Set<string>();
+  const variants = new Set<string>();
 
   let setArgAsDeclared = true;
   visit(msg, {
@@ -116,6 +120,11 @@ export function validate(
     variant(variant) {
       const { keys } = variant;
       if (keys.length !== selectorCount) onError('key-mismatch', variant);
+      const strKeys = JSON.stringify(
+        keys.map(key => (key.type === 'literal' ? key.value : 0))
+      );
+      if (variants.has(strKeys)) onError('duplicate-variant', variant);
+      else variants.add(strKeys);
       missingFallback &&= keys.every(key => key.type === '*') ? null : variant;
     }
   });

--- a/packages/mf2-messageformat/src/data-model/visit.ts
+++ b/packages/mf2-messageformat/src/data-model/visit.ts
@@ -1,5 +1,5 @@
 import type {
-  Attribute,
+  Attributes,
   CatchallKey,
   Declaration,
   Expression,
@@ -8,7 +8,7 @@ import type {
   Markup,
   Message,
   MessageNode,
-  Option,
+  Options,
   Pattern,
   UnsupportedAnnotation,
   VariableRef,
@@ -39,10 +39,8 @@ export function visit(
       context: 'declaration' | 'selector' | 'placeholder',
       argument: Literal | VariableRef | undefined
     ) => (() => void) | void;
-    attribute?: (
-      attr: Attribute,
-      index: number,
-      attributes: Attribute[],
+    attributes?: (
+      attributes: Attributes,
       context: 'declaration' | 'selector' | 'placeholder'
     ) => (() => void) | void;
     declaration?: (declaration: Declaration) => (() => void) | void;
@@ -60,10 +58,8 @@ export function visit(
       context: 'declaration' | 'placeholder'
     ) => (() => void) | void;
     node?: (node: MessageNode, ...rest: unknown[]) => void;
-    option?: (
-      option: Option,
-      index: number,
-      options: Option[],
+    options?: (
+      options: Options,
       context: 'declaration' | 'selector' | 'placeholder'
     ) => (() => void) | void;
     pattern?: (pattern: Pattern) => (() => void) | void;
@@ -78,41 +74,43 @@ export function visit(
   const { node, pattern } = visitors;
   const {
     annotation = node,
-    attribute = node,
+    attributes = null,
     declaration = node,
     expression = node,
     key = node,
     markup = node,
-    option = node,
+    options = null,
     value = node,
     variant = node
   } = visitors;
 
   const handleOptions = (
-    options: Option[] | undefined,
+    options_: Options | undefined,
     context: 'declaration' | 'selector' | 'placeholder'
   ) => {
-    if (options) {
-      for (let i = 0; i < options.length; ++i) {
-        const opt = options[i];
-        const end = option?.(opt, i, options, context);
-        value?.(opt.value, context, 'option');
-        end?.();
+    if (options_) {
+      const end = options?.(options_, context);
+      if (value) {
+        for (const value_ of options_.values()) {
+          value(value_, context, 'option');
+        }
       }
+      end?.();
     }
   };
 
   const handleAttributes = (
-    attributes: Attribute[] | undefined,
+    attributes_: Attributes | undefined,
     context: 'declaration' | 'selector' | 'placeholder'
   ) => {
-    if (attributes) {
-      for (let i = 0; i < attributes.length; ++i) {
-        const attr = attributes[i];
-        const end = attribute?.(attr, i, attributes, context);
-        if (attr.value) value?.(attr.value, context, 'attribute');
-        end?.();
+    if (attributes_) {
+      const end = attributes?.(attributes_, context);
+      if (value) {
+        for (const value_ of attributes_.values()) {
+          if (value_ !== true) value(value_, context, 'attribute');
+        }
       }
+      end?.();
     }
   };
 

--- a/packages/mf2-messageformat/src/errors.ts
+++ b/packages/mf2-messageformat/src/errors.ts
@@ -8,8 +8,8 @@ import { cst } from './data-model/from-cst.js';
  */
 export class MessageError extends Error {
   type:
-    | 'missing-func'
     | 'not-formattable'
+    | 'unknown-function'
     | typeof MessageResolutionError.prototype.type
     | typeof MessageSelectionError.prototype.type
     | typeof MessageSyntaxError.prototype.type;
@@ -30,7 +30,6 @@ export class MessageSyntaxError extends MessageError {
     | 'empty-token'
     | 'bad-escape'
     | 'bad-input-expression'
-    | 'bad-selector'
     | 'duplicate-declaration'
     | 'duplicate-option'
     | 'extra-content'
@@ -107,7 +106,7 @@ export class MessageResolutionError extends MessageError {
  * @beta
  */
 export class MessageSelectionError extends MessageError {
-  declare type: 'no-match' | 'not-selectable';
+  declare type: 'bad-selector' | 'no-match';
   constructor(type: typeof MessageSelectionError.prototype.type) {
     super(type, `Selection error: ${type}`);
   }

--- a/packages/mf2-messageformat/src/errors.ts
+++ b/packages/mf2-messageformat/src/errors.ts
@@ -30,8 +30,9 @@ export class MessageSyntaxError extends MessageError {
     | 'empty-token'
     | 'bad-escape'
     | 'bad-input-expression'
+    | 'duplicate-attribute'
     | 'duplicate-declaration'
-    | 'duplicate-option'
+    | 'duplicate-option-name'
     | 'duplicate-variant'
     | 'extra-content'
     | 'key-mismatch'
@@ -64,7 +65,6 @@ export class MessageSyntaxError extends MessageError {
 export class MessageDataModelError extends MessageSyntaxError {
   declare type:
     | 'duplicate-declaration'
-    | 'duplicate-option'
     | 'duplicate-variant'
     | 'key-mismatch'
     | 'missing-fallback'

--- a/packages/mf2-messageformat/src/errors.ts
+++ b/packages/mf2-messageformat/src/errors.ts
@@ -109,7 +109,12 @@ export class MessageResolutionError extends MessageError {
  */
 export class MessageSelectionError extends MessageError {
   declare type: 'bad-selector' | 'no-match';
-  constructor(type: typeof MessageSelectionError.prototype.type) {
+  cause?: unknown;
+  constructor(
+    type: typeof MessageSelectionError.prototype.type,
+    cause?: unknown
+  ) {
     super(type, `Selection error: ${type}`);
+    if (cause !== undefined) this.cause = cause;
   }
 }

--- a/packages/mf2-messageformat/src/errors.ts
+++ b/packages/mf2-messageformat/src/errors.ts
@@ -32,6 +32,7 @@ export class MessageSyntaxError extends MessageError {
     | 'bad-input-expression'
     | 'duplicate-declaration'
     | 'duplicate-option'
+    | 'duplicate-variant'
     | 'extra-content'
     | 'key-mismatch'
     | 'parse-error'
@@ -64,6 +65,7 @@ export class MessageDataModelError extends MessageSyntaxError {
   declare type:
     | 'duplicate-declaration'
     | 'duplicate-option'
+    | 'duplicate-variant'
     | 'key-mismatch'
     | 'missing-fallback'
     | 'missing-selector-annotation';

--- a/packages/mf2-messageformat/src/functions/datetime.ts
+++ b/packages/mf2-messageformat/src/functions/datetime.ts
@@ -72,7 +72,7 @@ export const datetime = (
 
     // Set defaults if localeMatcher is the only option
     if (Object.keys(res).length <= 1) {
-      res.dateStyle = 'short';
+      res.dateStyle = 'medium';
       res.timeStyle = 'short';
     }
   });
@@ -89,7 +89,7 @@ export const date = (
   input?: unknown
 ): MessageDateTime =>
   dateTimeImplementation(ctx, options, input, res => {
-    const ds = options.style ?? res.dateStyle ?? 'short';
+    const ds = options.style ?? res.dateStyle ?? 'medium';
     for (const name of Object.keys(res)) {
       if (!localeOptions.includes(name)) delete res[name];
     }

--- a/packages/mf2-messageformat/src/functions/number.ts
+++ b/packages/mf2-messageformat/src/functions/number.ts
@@ -40,8 +40,6 @@ export interface MessageNumberPart extends MessageExpressionPart {
   parts: Intl.NumberFormatPart[];
 }
 
-const NotFormattable = Symbol('not-formattable');
-
 /**
  * `number` accepts a number, BigInt or string representing a JSON number as input
  * and formats it with the same options as
@@ -110,7 +108,6 @@ export function number(
     }
   }
 
-  const formattable = !options[NotFormattable];
   const lc = mergeLocales(locales, input, options);
   const num = value;
   let locale: string | undefined;
@@ -137,21 +134,17 @@ export function number(
       cat ??= new Intl.PluralRules(lc, pluralOpt).select(Number(num));
       return keys.has(cat) ? cat : null;
     },
-    toParts: formattable
-      ? () => {
-          nf ??= new Intl.NumberFormat(lc, opt);
-          const parts = nf.formatToParts(num);
-          locale ??= nf.resolvedOptions().locale;
-          return [{ type: 'number', source, locale, parts }];
-        }
-      : undefined,
-    toString: formattable
-      ? () => {
-          nf ??= new Intl.NumberFormat(lc, opt);
-          str ??= nf.format(num);
-          return str;
-        }
-      : undefined,
+    toParts() {
+      nf ??= new Intl.NumberFormat(lc, opt);
+      const parts = nf.formatToParts(num);
+      locale ??= nf.resolvedOptions().locale;
+      return [{ type: 'number', source, locale, parts }];
+    },
+    toString() {
+      nf ??= new Intl.NumberFormat(lc, opt);
+      str ??= nf.format(num);
+      return str;
+    },
     valueOf: () => num
   };
 }

--- a/packages/mf2-messageformat/src/functions/test-functions.ts
+++ b/packages/mf2-messageformat/src/functions/test-functions.ts
@@ -1,0 +1,144 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * These functions are used only in the MF2 test suite,
+ * and are not a part of the library's public API.
+ */
+
+import { MessageResolutionError } from '../errors.js';
+import type { MessageFunctionContext, MessageValue } from './index.js';
+import { asPositiveInteger, asString } from './utils.js';
+
+interface TestValue extends MessageValue {
+  readonly type: 'test';
+  readonly options: {
+    canFormat: boolean;
+    canSelect: boolean;
+    decimalPlaces: 0 | 1;
+    failsFormat: boolean;
+    failsSelect: boolean;
+  };
+}
+
+export const testFunctions: Record<string, typeof testFunction> = {
+  'test:format': (ctx, options, input) =>
+    testFunction(ctx, { ...options, canFormat: true, canSelect: false }, input),
+  'test:function': (ctx, options, input) =>
+    testFunction(ctx, { ...options, canFormat: true, canSelect: true }, input),
+  'test:select': (ctx, options, input) =>
+    testFunction(ctx, { ...options, canFormat: false, canSelect: true }, input)
+};
+
+function testFunction(
+  { onError, source }: MessageFunctionContext,
+  options: Record<string, unknown>,
+  input: unknown
+): TestValue {
+  const opt: TestValue['options'] = {
+    canFormat: Boolean(options.canFormat),
+    canSelect: Boolean(options.canSelect),
+    decimalPlaces: 0,
+    failsFormat: false,
+    failsSelect: false
+  };
+  if (typeof input === 'object') {
+    const valueOf = input?.valueOf;
+    if (typeof valueOf === 'function') {
+      if ((input as any).type === 'test') {
+        Object.assign(opt, (input as any).options);
+      }
+      input = valueOf.call(input);
+    }
+  }
+  if (typeof input === 'string') {
+    try {
+      input = JSON.parse(input);
+    } catch {
+      // handled below
+    }
+  }
+  if (typeof input !== 'number') {
+    const msg = 'Input is not numeric';
+    throw new MessageResolutionError('bad-operand', msg, source);
+  }
+  const value: number = input; // Otherwise TS complains in callbacks
+
+  if ('decimalPlaces' in options) {
+    try {
+      const dp = asPositiveInteger(options.decimalPlaces);
+      if (dp === 0 || dp === 1) opt.decimalPlaces = dp;
+      else throw 1;
+    } catch {
+      const msg = `Invalid option decimalPlaces=${options.decimalPlaces}`;
+      throw new MessageResolutionError('bad-option', msg, source);
+    }
+  }
+  if ('fails' in options) {
+    try {
+      switch (asString(options.fails)) {
+        case 'never':
+          break;
+        case 'select':
+          opt.failsSelect = true;
+          break;
+        case 'format':
+          opt.failsFormat = true;
+          break;
+        case 'always':
+          opt.failsSelect = true;
+          opt.failsFormat = true;
+          break;
+        default:
+          throw 1;
+      }
+    } catch {
+      const msg = `Invalid option fails=${options.fails}`;
+      onError(new MessageResolutionError('bad-option', msg, source));
+    }
+  }
+
+  return {
+    type: 'test',
+    source,
+    locale: 'und',
+    get options() {
+      return { ...opt };
+    },
+    selectKey: opt.canSelect
+      ? keys => {
+          if (opt.failsSelect) throw new Error('Selection failed');
+          if (value === 1) {
+            if (opt.decimalPlaces === 1 && keys.has('1.0')) return '1.0';
+            if (keys.has('1')) return '1';
+          }
+          return null;
+        }
+      : undefined,
+    toParts: opt.canFormat
+      ? () => {
+          if (opt.failsFormat) throw new Error('Formatting failed');
+          const parts = Array.from(testParts(value, opt.decimalPlaces));
+          return [{ type: 'test', source, locale: 'und', parts }];
+        }
+      : undefined,
+    toString: opt.canFormat
+      ? () => {
+          if (opt.failsFormat) throw new Error('Formatting failed');
+          const parts = Array.from(testParts(value, opt.decimalPlaces));
+          return parts.map(part => part.value).join('');
+        }
+      : undefined,
+    valueOf: () => value
+  };
+}
+
+function* testParts(num: number, decimalPlaces: 0 | 1) {
+  if (num < 0) yield { type: 'neg', value: '-' };
+  const abs = Math.abs(num);
+  yield { type: 'int', value: String(Math.floor(abs)) };
+  if (decimalPlaces) {
+    yield { type: 'dot', value: '.' };
+    const frac = Math.floor((abs - Math.floor(abs)) * 10);
+    yield { type: 'frac', value: String(frac) };
+  }
+}

--- a/packages/mf2-messageformat/src/select-pattern.ts
+++ b/packages/mf2-messageformat/src/select-pattern.ts
@@ -15,7 +15,7 @@ export function selectPattern(context: Context, message: Message): Pattern {
         if (typeof selector.selectKey === 'function') {
           selectKey = selector.selectKey.bind(selector);
         } else {
-          context.onError(new MessageSelectionError('not-selectable'));
+          context.onError(new MessageSelectionError('bad-selector'));
           selectKey = () => null;
         }
         return {
@@ -70,7 +70,7 @@ export function selectPattern(context: Context, message: Message): Pattern {
     }
 
     default:
-      context.onError(new MessageSelectionError('not-selectable'));
+      context.onError(new MessageSelectionError('bad-selector'));
       return [];
   }
 }

--- a/packages/mf2-messageformat/src/select-pattern.ts
+++ b/packages/mf2-messageformat/src/select-pattern.ts
@@ -36,7 +36,13 @@ export function selectPattern(context: Context, message: Message): Pattern {
             if (key.type !== '*') sc.keys.add(key.value);
           }
         }
-        sc.best = sc.keys.size ? sc.selectKey(sc.keys) : null;
+        try {
+          sc.best = sc.keys.size ? sc.selectKey(sc.keys) : null;
+        } catch (error) {
+          context.onError(new MessageSelectionError('bad-selector', error));
+          sc.selectKey = () => null;
+          sc.best = null;
+        }
 
         // Leave out all candidate variants that aren't the best,
         // or only the catchall ones, if nothing else matches.

--- a/packages/mf2-messageformat/src/spec.test.ts
+++ b/packages/mf2-messageformat/src/spec.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   MessageDataModelError,
   MessageFormat,
+  MessageFormatOptions,
   MessageSyntaxError,
   cst,
   messageFromCST,
@@ -19,6 +20,10 @@ import {
   validate,
   visit
 } from './index.js';
+
+import { testFunctions } from './functions/test-functions.js';
+
+const mfOpt: MessageFormatOptions = { functions: testFunctions };
 
 const tests = (tc: Test) => () => {
   switch (testType(tc)) {
@@ -58,7 +63,7 @@ const tests = (tc: Test) => () => {
     default:
       test('format', () => {
         let errors: any[] = [];
-        const mf = new MessageFormat(tc.locale, tc.src);
+        const mf = new MessageFormat(tc.locale, tc.src, mfOpt);
         const msg = mf.format(tc.params, err => errors.push(err));
         if (typeof tc.exp === 'string') expect(msg).toBe(tc.exp);
         if (Array.isArray(tc.expErrors)) {

--- a/packages/mf2-messageformat/src/spec.test.ts
+++ b/packages/mf2-messageformat/src/spec.test.ts
@@ -47,14 +47,18 @@ const tests = (tc: Test) => () => {
       describe('data model error', () => {
         test('MessageFormat(string)', () => {
           expect(() => new MessageFormat(undefined, tc.src)).toThrow(
-            MessageDataModelError
+            MessageSyntaxError
           );
         });
         test('parseCST(string)', () => {
           const cst = parseCST(tc.src);
-          const msg = messageFromCST(cst);
           const onError = jest.fn();
-          validate(msg, onError);
+          try {
+            const msg = messageFromCST(cst);
+            validate(msg, onError);
+          } catch (error) {
+            onError(error);
+          }
           expect(onError).toHaveBeenCalledTimes(1);
         });
       });
@@ -95,7 +99,6 @@ const tests = (tc: Test) => () => {
         visit(msg2, {
           node(node) {
             delete node[cst];
-            if ('attributes' in node) delete node.attributes;
           }
         });
 
@@ -123,6 +126,7 @@ for (const scenario of testScenarios('test/messageformat-wg/test/tests')) {
   describe(scenario.scenario, () => {
     for (const tc of testCases(scenario)) {
       (tc.only ? describe.only : describe)(testName(tc), tests(tc));
+      //if (tc.only) describe(testName(tc), tests(tc));
     }
   });
 }

--- a/packages/mf2-xliff/src/mf2xliff.ts
+++ b/packages/mf2-xliff/src/mf2xliff.ts
@@ -382,7 +382,7 @@ function resolveExpression({
     if (isFunctionAnnotation(annotation)) {
       const elements: X.MessageFunction['elements'] = [];
       if (annotation.options) {
-        for (const { name, value } of annotation.options) {
+        for (const [name, value] of annotation.options) {
           elements.push({
             type: 'element',
             name: 'mf:option',
@@ -411,12 +411,12 @@ function resolveExpression({
     else throw new Error('Invalid empty expression');
   }
   if (attributes) {
-    for (const { name, value } of attributes) {
+    for (const [name, value] of attributes) {
       elements.push({
         type: 'element',
         name: 'mf:attribute',
         attributes: { name },
-        elements: value ? [resolveArgument(value)] : undefined
+        elements: value === true ? undefined : [resolveArgument(value)]
       });
     }
   }
@@ -426,7 +426,7 @@ function resolveExpression({
 function resolveMarkup({ name, options, attributes }: MF.Markup) {
   const elements: X.MessageOption[] = [];
   if (options) {
-    for (const { name, value } of options) {
+    for (const [name, value] of options) {
       elements.push({
         type: 'element',
         name: 'mf:option',
@@ -439,18 +439,22 @@ function resolveMarkup({ name, options, attributes }: MF.Markup) {
     { type: 'element', name: 'mf:markup', attributes: { name }, elements }
   ];
   if (attributes) {
-    for (const { name, value } of attributes) {
+    for (const [name, value] of attributes) {
       mfElements.push({
         type: 'element',
         name: 'mf:attribute',
         attributes: { name },
-        elements: value ? [resolveArgument(value)] : undefined
+        elements: value === true ? undefined : [resolveArgument(value)]
       });
     }
   }
   return mfElements;
 }
 
+function resolveArgument(part: MF.Literal): X.MessageLiteral;
+function resolveArgument(
+  part: MF.Literal | MF.VariableRef
+): X.MessageLiteral | X.MessageVariable;
 function resolveArgument(
   part: MF.Literal | MF.VariableRef
 ): X.MessageLiteral | X.MessageVariable {

--- a/packages/mf2-xliff/src/xliff-spec.ts
+++ b/packages/mf2-xliff/src/xliff-spec.ts
@@ -1248,5 +1248,5 @@ export interface MessageAttribute extends Element {
   attributes: {
     name: string;
   };
-  elements?: [] | [MessageLiteral | MessageVariable];
+  elements?: [] | [MessageLiteral];
 }

--- a/test/mfwg-test-utils.ts
+++ b/test/mfwg-test-utils.ts
@@ -47,6 +47,7 @@ export function testName({ src, locale, params }: Test) {
 const dataModelErrors = [
   'duplicate-declaration',
   'duplicate-option-name',
+  'duplicate-variant',
   'missing-fallback-variant',
   'missing-selector-annotation',
   'variant-key-mismatch'

--- a/test/mfwg-test-utils.ts
+++ b/test/mfwg-test-utils.ts
@@ -45,6 +45,7 @@ export function testName({ src, locale, params }: Test) {
 }
 
 const dataModelErrors = [
+  'duplicate-attribute',
   'duplicate-declaration',
   'duplicate-option-name',
   'duplicate-variant',


### PR DESCRIPTION
These changes bring the implementation in line with the upstream spec as of today. The tests won't initially pass, as unicode-org/message-format-wg#862 and unicode-org/message-format-wg#863 will need to be merged first and the git submodule here updated to match.

Because of the data model changes, I've opted to consider duplicate options and attributes as syntax errors rather than data model errors. They're not detected in `parseCST()`, but are thrown for in `messageFromCST()`.