### PR TITLE
MF2 spec updates: BiDi isolation, u:options

### DIFF
--- a/mf2/fluent/src/fluent.test.ts
+++ b/mf2/fluent/src/fluent.test.ts
@@ -331,7 +331,7 @@ for (const [title, { locale = 'en', src, tests }] of Object.entries(
 )) {
   describe(title, () => {
     const data = fluentToResourceData(src).data;
-    const res = fluentToResource(data, locale);
+    const res = fluentToResource(data, locale, { bidiIsolation: 'none' });
 
     test('validate', () => {
       for (const [id, group] of res) {
@@ -444,6 +444,7 @@ describe('formatToParts', () => {
         {
           type: 'number',
           source: '$num',
+          dir: 'ltr',
           locale: 'en',
           parts: [{ type: 'integer', value: '42' }]
         }
@@ -455,7 +456,9 @@ describe('formatToParts', () => {
       const foo = res.get('foo')?.get('')?.formatToParts(undefined, onError);
       expect(foo).toEqual([
         { type: 'literal', value: 'Foo ' },
-        { type: 'fallback', source: '$num' }
+        { type: 'bidiIsolation', value: '\u2068' },
+        { type: 'fallback', source: '$num' },
+        { type: 'bidiIsolation', value: '\u2069' }
       ]);
       expect(onError).toHaveBeenCalledTimes(1);
     });
@@ -469,7 +472,9 @@ describe('formatToParts', () => {
           source: '|foo|',
           parts: [
             { type: 'literal', value: 'Foo ' },
-            { type: 'fallback', source: '$num' }
+            { type: 'bidiIsolation', value: '\u2068' },
+            { type: 'fallback', source: '$num' },
+            { type: 'bidiIsolation', value: '\u2069' }
           ]
         }
       ]);
@@ -572,6 +577,7 @@ describe('formatToParts', () => {
         {
           type: 'number',
           source: '$num',
+          dir: 'ltr',
           locale: 'en',
           parts: [{ type: 'integer', value: '42' }]
         }

--- a/mf2/icu-messageformat-1/src/mf1.test.ts
+++ b/mf2/icu-messageformat-1/src/mf1.test.ts
@@ -376,7 +376,7 @@ for (const [title, cases] of Object.entries(testCases)) {
 
           test(strParam.join(', '), () => {
             const data = mf1ToMessageData(parse(src));
-            const mf = mf1ToMessage(data, locale);
+            const mf = mf1ToMessage(data, locale, { bidiIsolation: 'none' });
             const req = validate(data, type => {
               throw new Error(`Validation failed: ${type}`);
             });

--- a/mf2/messageformat/src/cst/names.ts
+++ b/mf2/messageformat/src/cst/names.ts
@@ -54,9 +54,9 @@ export function parseNameValue(
   if (!isNameStartCode(cc)) return null;
   cc = src.charCodeAt(++pos);
   while (isNameCharCode(cc)) cc = src.charCodeAt(++pos);
-  const name = src.substring(nameStart, pos);
+  const value = src.substring(nameStart, pos).normalize();
   if (bidiChars.has(cc)) pos += 1;
-  return { value: name, end: pos };
+  return { value, end: pos };
 }
 
 export function isValidUnquotedLiteral(str: string): boolean {

--- a/mf2/messageformat/src/cst/parse-cst.ts
+++ b/mf2/messageformat/src/cst/parse-cst.ts
@@ -142,10 +142,13 @@ function parseVariant(ctx: ParseContext, start: number): CST.Variant {
 
     if (pos > start && !ws.hasWS) ctx.onError('missing-syntax', pos, "' '");
 
-    const key =
-      ch === '*'
-        ? ({ type: '*', start: pos, end: pos + 1 } satisfies CST.CatchallKey)
-        : parseLiteral(ctx, pos, true);
+    let key: CST.CatchallKey | CST.Literal;
+    if (ch === '*') {
+      key = { type: '*', start: pos, end: pos + 1 };
+    } else {
+      key = parseLiteral(ctx, pos, true);
+      key.value = key.value.normalize();
+    }
     if (key.end === pos) break; // error; reported in pattern.errors
     keys.push(key);
     pos = key.end;

--- a/mf2/messageformat/src/data-model/format-markup.ts
+++ b/mf2/messageformat/src/data-model/format-markup.ts
@@ -14,7 +14,7 @@ export function formatMarkup(
   if (options?.size) {
     part.options = {};
     for (const [name, value] of options) {
-      if (name === 'u:locale') {
+      if (name === 'u:dir' || name === 'u:locale') {
         const msg = `The option ${name} is not valid for markup`;
         const optSource = getValueSource(value);
         ctx.onError(new MessageResolutionError('bad-option', msg, optSource));

--- a/mf2/messageformat/src/data-model/format-markup.ts
+++ b/mf2/messageformat/src/data-model/format-markup.ts
@@ -23,7 +23,8 @@ export function formatMarkup(
         if (typeof rv === 'object' && typeof rv?.valueOf === 'function') {
           rv = rv.valueOf();
         }
-        part.options[name] = rv;
+        if (name === 'u:id') part.id = String(rv);
+        else part.options[name] = rv;
       }
     }
   }

--- a/mf2/messageformat/src/data-model/function-context.ts
+++ b/mf2/messageformat/src/data-model/function-context.ts
@@ -1,17 +1,30 @@
 import type { Context } from '../format-context.js';
+import { resolveValue } from './resolve-value.js';
+import { Options } from './types.js';
 
 export class MessageFunctionContext {
   #ctx: Context;
+  #locales: string[];
   readonly source: string;
-  constructor(ctx: Context, source: string) {
+  constructor(ctx: Context, source: string, options: Options | undefined) {
     this.#ctx = ctx;
+    const lc = options?.get('u:locale');
+    if (lc) {
+      let rl = resolveValue(ctx, lc);
+      if (typeof rl === 'object' && typeof rl?.valueOf === 'function') {
+        rl = rl.valueOf();
+      }
+      this.#locales = Array.isArray(rl) ? rl.map(String) : [String(rl)];
+    } else {
+      this.#locales = ctx.locales;
+    }
     this.source = source;
   }
   get localeMatcher() {
     return this.#ctx.localeMatcher;
   }
   get locales() {
-    return this.#ctx.locales.slice();
+    return this.#locales.slice();
   }
   get onError() {
     return this.#ctx.onError;

--- a/mf2/messageformat/src/data-model/function-context.ts
+++ b/mf2/messageformat/src/data-model/function-context.ts
@@ -7,6 +7,7 @@ export class MessageFunctionContext {
   #ctx: Context;
   #locales: Intl.Locale[];
   readonly dir: 'ltr' | 'rtl' | 'auto' | undefined;
+  readonly id: string | undefined;
   readonly source: string;
   constructor(ctx: Context, source: string, options?: Options) {
     this.#ctx = ctx;
@@ -41,6 +42,9 @@ export class MessageFunctionContext {
         ctx.onError(new MessageResolutionError('bad-option', msg, optSource));
       }
     }
+
+    const idOpt = options?.get('u:id');
+    this.id = idOpt ? String(resolveValue(ctx, idOpt)) : undefined;
 
     this.source = source;
   }

--- a/mf2/messageformat/src/data-model/function-ref.test.ts
+++ b/mf2/messageformat/src/data-model/function-ref.test.ts
@@ -30,7 +30,7 @@ describe('inputs with options', () => {
   test('local variable with :number expression', () => {
     const mf = new MessageFormat(
       'en',
-      `.local $val = {12345678 :number useGrouping=false}
+      `.local $val = {12345678 :number useGrouping=never}
       {{{$val :number minimumFractionDigits=2}}}`
     );
     //const val = new MessageNumber(null, BigInt(12345678), { options: { useGrouping: false } });
@@ -77,20 +77,28 @@ describe('inputs with options', () => {
 });
 
 describe('Type casts based on runtime', () => {
+  const date = '2000-01-01T15:00:00';
+
   test('boolean function option with literal value', () => {
-    const mfTrue = new MessageFormat('en', '{$var :number useGrouping=true}');
-    expect(mfTrue.format({ var: 1234 })).toBe('1,234');
-    const mfFalse = new MessageFormat('en', '{$var :number useGrouping=false}');
-    expect(mfFalse.format({ var: 1234 })).toBe('1234');
+    const mfTrue = new MessageFormat(
+      'en',
+      '{$date :datetime timeStyle=short hour12=true}'
+    );
+    expect(mfTrue.format({ date })).toMatch(/3:00/);
+    const mfFalse = new MessageFormat(
+      'en',
+      '{$date :datetime timeStyle=short hour12=false}'
+    );
+    expect(mfFalse.format({ date })).toMatch(/15:00/);
   });
 
   test('boolean function option with variable value', () => {
     const mf = new MessageFormat(
       'en',
-      '{$var :number useGrouping=$useGrouping}'
+      '{$date :datetime timeStyle=short hour12=$hour12}'
     );
-    expect(mf.format({ var: 1234, useGrouping: 'false' })).toBe('1234');
-    expect(mf.format({ var: 1234, useGrouping: false })).toBe('1234');
+    expect(mf.format({ date, hour12: 'false' })).toMatch(/15:00/);
+    expect(mf.format({ date, hour12: false })).toMatch(/15:00/);
   });
 });
 

--- a/mf2/messageformat/src/data-model/function-ref.test.ts
+++ b/mf2/messageformat/src/data-model/function-ref.test.ts
@@ -6,9 +6,10 @@ import {
 
 test('Custom function', () => {
   const functions = {
-    custom: ({ source, locales: [locale] }, _opt, input) => ({
+    custom: ({ dir, source, locales: [locale] }, _opt, input) => ({
       type: 'custom',
       source,
+      dir: dir ?? 'auto',
       locale,
       toParts: () => [
         { type: 'custom', source, locale, value: `part:${input}` }
@@ -17,9 +18,11 @@ test('Custom function', () => {
     })
   } satisfies MessageFunctions;
   const mf = new MessageFormat('en', '{$var :custom}', { functions });
-  expect(mf.format({ var: 42 })).toEqual('str:42');
+  expect(mf.format({ var: 42 })).toEqual('\u2068str:42\u2069');
   expect(mf.formatToParts({ var: 42 })).toEqual([
-    { type: 'custom', source: '$var', locale: 'en', value: 'part:42' }
+    { type: 'bidiIsolation', value: '\u2068' },
+    { type: 'custom', source: '$var', locale: 'en', value: 'part:42' },
+    { type: 'bidiIsolation', value: '\u2069' }
   ]);
 });
 
@@ -98,9 +101,11 @@ describe('Function return is not a MessageValue', () => {
     } satisfies MessageFunctions;
     const mf = new MessageFormat('en', '{:fail}', { functions });
     const onError = jest.fn();
-    expect(mf.format(undefined, onError)).toEqual('{:fail}');
+    expect(mf.format(undefined, onError)).toEqual('\u2068{:fail}\u2069');
     expect(mf.formatToParts(undefined, onError)).toEqual([
-      { type: 'fallback', source: ':fail' }
+      { type: 'bidiIsolation', value: '\u2068' },
+      { type: 'fallback', source: ':fail' },
+      { type: 'bidiIsolation', value: '\u2069' }
     ]);
     expect(onError).toHaveBeenCalledTimes(2);
   });
@@ -111,9 +116,11 @@ describe('Function return is not a MessageValue', () => {
     } satisfies MessageFunctions;
     const mf = new MessageFormat('en', '{42 :fail}', { functions });
     const onError = jest.fn();
-    expect(mf.format(undefined, onError)).toEqual('{|42|}');
+    expect(mf.format(undefined, onError)).toEqual('\u2068{|42|}\u2069');
     expect(mf.formatToParts(undefined, onError)).toEqual([
-      { type: 'fallback', source: '|42|' }
+      { type: 'bidiIsolation', value: '\u2068' },
+      { type: 'fallback', source: '|42|' },
+      { type: 'bidiIsolation', value: '\u2069' }
     ]);
     expect(onError).toHaveBeenCalledTimes(2);
   });

--- a/mf2/messageformat/src/data-model/literal.test.ts
+++ b/mf2/messageformat/src/data-model/literal.test.ts
@@ -15,13 +15,19 @@ function resolve(source: string, errors: any[] = []) {
 describe('quoted literals', () => {
   test('simple', () => {
     const res = resolve('{|quoted literal|}');
-    expect(res).toMatchObject([{ type: 'string', value: 'quoted literal' }]);
+    expect(res).toMatchObject([
+      { type: 'bidiIsolation', value: '\u2068' },
+      { type: 'string', value: 'quoted literal' },
+      { type: 'bidiIsolation', value: '\u2069' }
+    ]);
   });
 
   test('spaces, newlines and escapes', () => {
     const res = resolve('{| quoted \n \\\\\\|literal\\\\\\|\\{\\}|}');
     expect(res).toMatchObject([
-      { type: 'string', value: ' quoted \n \\|literal\\|{}' }
+      { type: 'bidiIsolation', value: '\u2068' },
+      { type: 'string', value: ' quoted \n \\|literal\\|{}' },
+      { type: 'bidiIsolation', value: '\u2069' }
     ]);
   });
 });
@@ -39,7 +45,11 @@ describe('unquoted numbers', () => {
   ]) {
     test(value, () => {
       const res = resolve(`{${value}}`);
-      expect(res).toMatchObject([{ type: 'string', value }]);
+      expect(res).toMatchObject([
+        { type: 'bidiIsolation', value: '\u2068' },
+        { type: 'string', value },
+        { type: 'bidiIsolation', value: '\u2069' }
+      ]);
     });
   }
 });

--- a/mf2/messageformat/src/data-model/markup.test.ts
+++ b/mf2/messageformat/src/data-model/markup.test.ts
@@ -26,7 +26,9 @@ describe('Simple open/close', () => {
         name: 'b'
       },
       { type: 'literal', value: 'foo' },
-      { type: 'string', locale: 'en', source: '$foo', value: 'foo bar' },
+      { type: 'bidiIsolation', value: '\u2068' },
+      { type: 'string', source: '$foo', locale: 'en', value: 'foo bar' },
+      { type: 'bidiIsolation', value: '\u2069' },
       {
         type: 'markup',
         kind: 'close',
@@ -35,7 +37,7 @@ describe('Simple open/close', () => {
         options: { foo: ' bar 13 ' }
       }
     ]);
-    expect(mf.format({ foo: 'foo bar' })).toBe('foofoo bar');
+    expect(mf.format({ foo: 'foo bar' })).toBe('foo\u2068foo bar\u2069');
   });
 
   test('do not allow operands', () => {

--- a/mf2/messageformat/src/data-model/parse.ts
+++ b/mf2/messageformat/src/data-model/parse.ts
@@ -91,7 +91,9 @@ function variant(): Model.Variant {
       keys.push({ type: '*' });
       pos += 1;
     } else {
-      keys.push(literal(true));
+      const key = literal(true);
+      key.value = key.value.normalize();
+      keys.push(key);
     }
   }
   return { keys, value: pattern(true) };

--- a/mf2/messageformat/src/data-model/resolve-function-ref.ts
+++ b/mf2/messageformat/src/data-model/resolve-function-ref.ts
@@ -39,6 +39,16 @@ export function resolveFunctionRef(
         `Function :${name} did not return a MessageValue`
       );
     }
+    if (msgCtx.id && typeof res.toParts === 'function') {
+      return {
+        ...res,
+        toParts() {
+          const parts = res.toParts!();
+          for (const part of parts) part.id = msgCtx.id;
+          return parts;
+        }
+      };
+    }
     return res;
   } catch (error) {
     ctx.onError(error);
@@ -51,7 +61,7 @@ function resolveOptions(ctx: Context, options: Options | undefined) {
   const opt: Record<string, unknown> = Object.create(null);
   if (options) {
     for (const [name, value] of options) {
-      if (name !== 'u:dir' && name !== 'u:locale') {
+      if (name !== 'u:dir' && name !== 'u:id' && name !== 'u:locale') {
         opt[name] = resolveValue(ctx, value);
       }
     }

--- a/mf2/messageformat/src/data-model/resolve-function-ref.ts
+++ b/mf2/messageformat/src/data-model/resolve-function-ref.ts
@@ -51,7 +51,7 @@ function resolveOptions(ctx: Context, options: Options | undefined) {
   const opt: Record<string, unknown> = Object.create(null);
   if (options) {
     for (const [name, value] of options) {
-      if (name !== 'u:locale') {
+      if (name !== 'u:dir' && name !== 'u:locale') {
         opt[name] = resolveValue(ctx, value);
       }
     }

--- a/mf2/messageformat/src/data-model/resolve-function-ref.ts
+++ b/mf2/messageformat/src/data-model/resolve-function-ref.ts
@@ -25,7 +25,7 @@ export function resolveFunctionRef(
     if (!rf) {
       throw new MessageError('unknown-function', `Unknown function :${name}`);
     }
-    const msgCtx = new MessageFunctionContext(ctx, source);
+    const msgCtx = new MessageFunctionContext(ctx, source, options);
     const opt = resolveOptions(ctx, options);
     const res = rf(msgCtx, opt, ...fnInput);
     if (
@@ -51,7 +51,9 @@ function resolveOptions(ctx: Context, options: Options | undefined) {
   const opt: Record<string, unknown> = Object.create(null);
   if (options) {
     for (const [name, value] of options) {
-      opt[name] = resolveValue(ctx, value);
+      if (name !== 'u:locale') {
+        opt[name] = resolveValue(ctx, value);
+      }
     }
   }
   return opt;

--- a/mf2/messageformat/src/data-model/resolve-value.ts
+++ b/mf2/messageformat/src/data-model/resolve-value.ts
@@ -19,6 +19,10 @@ export function resolveValue(
 }
 
 /** @internal */
+export function getValueSource(value: Literal | VariableRef): string;
+export function getValueSource(
+  value: Literal | VariableRef | undefined
+): string | undefined;
 export function getValueSource(value: Literal | VariableRef | undefined) {
   switch (value?.type) {
     case 'literal':

--- a/mf2/messageformat/src/data-model/resolve-variable.ts
+++ b/mf2/messageformat/src/data-model/resolve-variable.ts
@@ -42,6 +42,10 @@ function getValue(scope: unknown, name: string): unknown {
         return getValue(scope[head], tail);
       }
     }
+
+    for (const [key, value] of Object.entries(scope)) {
+      if (key.normalize() === name) return value;
+    }
   }
 
   return undefined;

--- a/mf2/messageformat/src/data-model/variable.test.ts
+++ b/mf2/messageformat/src/data-model/variable.test.ts
@@ -11,8 +11,9 @@ describe('variables', () => {
     expect(mf.formatToParts({ val: 42 })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$val',
+        dir: 'ltr',
+        locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
       }
     ]);
@@ -24,8 +25,9 @@ describe('variables', () => {
     expect(mf.formatToParts({ val })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$val',
+        dir: 'ltr',
+        locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
       }
     ]);
@@ -37,8 +39,9 @@ describe('variables', () => {
     expect(mf.formatToParts({ val })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$val',
+        dir: 'ltr',
+        locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
       }
     ]);
@@ -47,11 +50,9 @@ describe('variables', () => {
   test('wrapped number', () => {
     const val = { valueOf: () => BigInt(42) };
     expect(mf.formatToParts({ val })).toEqual([
-      {
-        type: 'unknown',
-        source: '$val',
-        value: val
-      }
+      { type: 'bidiIsolation', value: '\u2068' },
+      { type: 'unknown', source: '$val', value: val },
+      { type: 'bidiIsolation', value: '\u2069' }
     ]);
   });
 
@@ -63,8 +64,9 @@ describe('variables', () => {
     expect(mf.formatToParts({ val })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$val',
+        dir: 'ltr',
+        locale: 'en',
         parts: [
           { type: 'integer', value: '42' },
           { type: 'decimal', value: '.' },
@@ -85,8 +87,9 @@ describe('Variable paths', () => {
     expect(mf.formatToParts({ 'user.name': 42 })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$user.name',
+        dir: 'ltr',
+        locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
       }
     ]);
@@ -96,8 +99,9 @@ describe('Variable paths', () => {
     expect(mf.formatToParts({ user: { name: 42 } })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$user.name',
+        dir: 'ltr',
+        locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
       }
     ]);
@@ -107,8 +111,9 @@ describe('Variable paths', () => {
     expect(mf.formatToParts({ user: { name: 13 }, 'user.name': 42 })).toEqual([
       {
         type: 'number',
-        locale: 'en',
         source: '$user.name',
+        dir: 'ltr',
+        locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
       }
     ]);

--- a/mf2/messageformat/src/dir-utils.ts
+++ b/mf2/messageformat/src/dir-utils.ts
@@ -1,0 +1,26 @@
+export const LRI = '\u2066';
+export const RLI = '\u2067';
+export const FSI = '\u2068';
+export const PDI = '\u2069';
+
+// Data source: RECOMMENDED and LIMITED_USE scripts from
+// https://github.com/unicode-org/cldr/blob/1a914d1/common/properties/scriptMetadata.txt
+const RTL = 'Adlm,Arab,Hebr,Mand,Nkoo,Rohg,Syrc,Thaa';
+
+export function getLocaleDir(
+  locale: Intl.Locale | string | undefined
+): 'ltr' | 'rtl' | 'auto' {
+  if (locale) {
+    try {
+      if (typeof locale === 'string') locale = new Intl.Locale(locale);
+      // @ts-expect-error -- New feature, API changed during Stage 3
+      const info = locale.getTextInfo?.() ?? locale.textInfo;
+      if (info?.direction) return info.direction;
+      const script = locale.maximize().script;
+      if (script) return RTL.includes(script) ? 'rtl' : 'ltr';
+    } catch {
+      // Use 'auto' on error
+    }
+  }
+  return 'auto';
+}

--- a/mf2/messageformat/src/format-context.ts
+++ b/mf2/messageformat/src/format-context.ts
@@ -5,7 +5,7 @@ export interface Context {
   functions: MessageFunctions;
   onError(error: unknown): void;
   localeMatcher: 'best fit' | 'lookup';
-  locales: string[];
+  locales: Intl.Locale[];
   /** Cache for local variables */
   localVars: WeakSet<MessageValue>;
   /**

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -5,9 +5,16 @@ export type { MessageStringPart } from './functions/string.js';
 export type { MessageUnknownPart } from './functions/unknown.js';
 
 /** @beta */
+export interface MessageBiDiIsolationPart {
+  type: 'bidiIsolation';
+  value: '\u2066' | '\u2067' | '\u2068' | '\u2069'; // LRI | RLI | FSI | PDI
+}
+
+/** @beta */
 export interface MessageExpressionPart {
   type: string;
   source: string;
+  dir?: 'ltr' | 'rtl';
   locale?: string;
   parts?: Array<{ type: string; source?: string; value?: unknown }>;
   value?: unknown;
@@ -30,6 +37,7 @@ export interface MessageMarkupPart {
 
 /** @beta */
 export type MessagePart =
+  | MessageBiDiIsolationPart
   | MessageExpressionPart
   | MessageLiteralPart
   | MessageMarkupPart;

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -16,6 +16,7 @@ export interface MessageExpressionPart {
   source: string;
   dir?: 'ltr' | 'rtl';
   locale?: string;
+  id?: string;
   parts?: Array<{ type: string; source?: string; value?: unknown }>;
   value?: unknown;
 }
@@ -32,6 +33,7 @@ export interface MessageMarkupPart {
   kind: 'open' | 'standalone' | 'close';
   source: string;
   name: string;
+  id?: string;
   options?: { [key: string]: unknown };
 }
 

--- a/mf2/messageformat/src/functions/index.ts
+++ b/mf2/messageformat/src/functions/index.ts
@@ -9,8 +9,9 @@ export { type MessageUnknownValue, unknown } from './unknown.js';
 
 export interface MessageValue {
   readonly type: string;
-  readonly locale: string;
   readonly source: string;
+  readonly locale: string;
+  readonly dir?: 'ltr' | 'rtl' | 'auto';
   readonly options?: Readonly<object>;
   selectKey?: (keys: Set<string>) => string | null;
   toParts?: () => MessageExpressionPart[];

--- a/mf2/messageformat/src/functions/number.ts
+++ b/mf2/messageformat/src/functions/number.ts
@@ -2,12 +2,7 @@ import { MessageResolutionError } from '../errors.js';
 import type { MessageExpressionPart } from '../formatted-parts.js';
 import { getLocaleDir } from '../dir-utils.js';
 import type { MessageFunctionContext, MessageValue } from './index.js';
-import {
-  asBoolean,
-  asPositiveInteger,
-  asString,
-  mergeLocales
-} from './utils.js';
+import { asPositiveInteger, asString, mergeLocales } from './utils.js';
 
 /** @beta */
 export interface MessageNumber extends MessageValue {
@@ -98,9 +93,12 @@ export function number(
           // @ts-expect-error TS types don't know about roundingIncrement
           opt[name] = asPositiveInteger(optval);
           break;
-        case 'useGrouping':
-          opt[name] = asBoolean(optval);
+        case 'useGrouping': {
+          const strval = asString(optval);
+          // @ts-expect-error TS type is wrong
+          opt[name] = strval === 'never' ? false : strval;
           break;
+        }
         default:
           // @ts-expect-error Unknown options will be ignored
           opt[name] = asString(optval);

--- a/mf2/messageformat/src/functions/string.ts
+++ b/mf2/messageformat/src/functions/string.ts
@@ -33,12 +33,13 @@ export function string(
   input?: unknown
 ): MessageString {
   const str = input === undefined ? '' : String(input);
+  const selStr = str.normalize();
   const [locale] = mergeLocales(locales, input, options);
   return {
     type: 'string',
     source,
     locale,
-    selectKey: keys => (keys.has(str) ? str : null),
+    selectKey: keys => (keys.has(selStr) ? selStr : null),
     toParts: () => [{ type: 'string', source, locale, value: str }],
     toString: () => str,
     valueOf: () => str

--- a/mf2/messageformat/src/functions/unknown.ts
+++ b/mf2/messageformat/src/functions/unknown.ts
@@ -5,6 +5,7 @@ import type { MessageValue } from './index.js';
 export interface MessageUnknownValue extends MessageValue {
   readonly type: 'unknown';
   readonly source: string;
+  readonly dir: 'auto';
   readonly locale: 'und';
   toParts(): [MessageUnknownPart];
   toString(): string;
@@ -25,6 +26,7 @@ export const unknown = (
 ): MessageUnknownValue => ({
   type: 'unknown',
   source,
+  dir: 'auto',
   locale: 'und',
   toParts: () => [{ type: 'unknown', source, value: input }],
   toString: () => String(input),

--- a/mf2/messageformat/src/functions/utils.ts
+++ b/mf2/messageformat/src/functions/utils.ts
@@ -1,3 +1,5 @@
+export { getLocaleDir } from '../dir-utils.js';
+
 /**
  * Utility function for custom functions.
  * Cast a value as a Boolean,

--- a/mf2/messageformat/src/spec.test.ts
+++ b/mf2/messageformat/src/spec.test.ts
@@ -23,8 +23,6 @@ import {
 
 import { testFunctions } from './functions/test-functions.js';
 
-const mfOpt: MessageFormatOptions = { functions: testFunctions };
-
 const tests = (tc: Test) => () => {
   switch (testType(tc)) {
     case 'syntax-error':
@@ -67,6 +65,8 @@ const tests = (tc: Test) => () => {
     default:
       test('format', () => {
         let errors: any[] = [];
+        const mfOpt: MessageFormatOptions = { functions: testFunctions };
+        if (tc.bidiIsolation) mfOpt.bidiIsolation = tc.bidiIsolation;
         const mf = new MessageFormat(tc.locale, tc.src, mfOpt);
         const msg = mf.format(tc.params, err => errors.push(err));
         if (typeof tc.exp === 'string') expect(msg).toBe(tc.exp);

--- a/test/utils/mfwg-test-utils.ts
+++ b/test/utils/mfwg-test-utils.ts
@@ -84,6 +84,9 @@ type DefaultTestProperties = {
   /** The MF2 syntax source. */
   src?: string;
 
+  /** The bidi isolation strategy. */
+  bidiIsolation?: 'default' | 'none';
+
   /** Parameters to pass in to the formatter for resolving external variables. */
   params?: Array<
     | { name: string; value: unknown }


### PR DESCRIPTION
Fixes #431 

Filing initially as a draft, pending on unicode-org/message-format-wg#917 getting merged and the test submodule here updated.

This PR (finally!) adds support for spec-mandated [bidi isolation](https://github.com/unicode-org/message-format-wg/blob/main/spec/formatting.md#handling-bidirectional-text), and uses the _Default Bidi Strategy_ by, well, default. This means that many placeholders will be wrapped with `\u2068...\u2069` FSI/PDI control characters. To disable that, set `bidiIsolation: 'none'` in the formatter options.

No introspection of placeholder contents is included, as doing that right would require implementing the [UAX#9 P2 algorithm](https://www.unicode.org/reports/tr9/#P2) in JavaScript which doesn't really make sense -- when rendering the message contents, the same work can be done by the browser's built-in implementation, at the cost of including the FSI/PDI controls in the output.

The message directionality is detected from the locale, or can be explicitly set by a new `dir: 'ltr' | 'rtl' | 'auto'` formatter option.

The three [`u:` options](https://github.com/unicode-org/message-format-wg/blob/main/spec/u-namespace.md) are added: `u:dir`, `u:id`, and `u:locale`.

At some point, these changes will need to be reflected in the TC39 proposal as well (CC @ryzokuken).