### PR TITLE
MF2 updates

### DIFF
--- a/mf2/fluent/README.md
+++ b/mf2/fluent/README.md
@@ -52,7 +52,7 @@ import {
   fluentToMessage,
   fluentToResource,
   fluentToResourceData,
-  getFluentFunctions,
+  getMessageFunction,
   messageToFluent,
   resourceToFluent
 } from '@messageformat/fluent';

--- a/mf2/fluent/src/fluent-to-message.ts
+++ b/mf2/fluent/src/fluent-to-message.ts
@@ -227,19 +227,16 @@ function asFluentSelect(
   }
 }
 
-export type FluentToMessageOptions = {
-  /** Set `false` to disable number selector detection based on keys. */
-  detectNumberSelection?: boolean;
-};
-
 /**
  * Compile a {@link https://projectfluent.org/fluent.js/syntax/classes/pattern.html | Fluent.Pattern}
  * (i.e. the value of a Fluent message or an attribute) into a
- * {@link MF.Message} data object.
+ * {@link MF.Message | Model.Message} data object.
+ *
+ * @param options.detectNumberSelection - Set `false` to disable number selector detection based on keys.
  */
 export function fluentToMessage(
   ast: Fluent.Pattern,
-  { detectNumberSelection }: FluentToMessageOptions = {}
+  options?: { detectNumberSelection?: boolean }
 ): MF.PatternMessage | MF.SelectMessage {
   const args = findSelectArgs(ast);
   if (args.length === 0) {
@@ -325,7 +322,7 @@ export function fluentToMessage(
   addParts(ast, []);
 
   const declarations = args.map((arg, index) =>
-    asSelectorDeclaration(arg, index, detectNumberSelection)
+    asSelectorDeclaration(arg, index, options?.detectNumberSelection)
   );
   return {
     type: 'select',

--- a/mf2/fluent/src/fluent.test.ts
+++ b/mf2/fluent/src/fluent.test.ts
@@ -446,7 +446,7 @@ describe('formatToParts', () => {
     test('defined formatted variable', () => {
       const foo = res.get('foo')?.get('')?.formatToParts({ num: 42 });
       expect(foo).toEqual([
-        { type: 'literal', value: 'Foo ' },
+        { type: 'text', value: 'Foo ' },
         {
           type: 'number',
           source: '$num',
@@ -461,7 +461,7 @@ describe('formatToParts', () => {
       const onError = jest.fn();
       const foo = res.get('foo')?.get('')?.formatToParts(undefined, onError);
       expect(foo).toEqual([
-        { type: 'literal', value: 'Foo ' },
+        { type: 'text', value: 'Foo ' },
         { type: 'bidiIsolation', value: '\u2068' },
         { type: 'fallback', source: '$num' },
         { type: 'bidiIsolation', value: '\u2069' }
@@ -477,7 +477,7 @@ describe('formatToParts', () => {
           type: 'fluent-message',
           source: '|foo|',
           parts: [
-            { type: 'literal', value: 'Foo ' },
+            { type: 'text', value: 'Foo ' },
             { type: 'bidiIsolation', value: '\u2068' },
             { type: 'fallback', source: '$num' },
             { type: 'bidiIsolation', value: '\u2069' }
@@ -489,13 +489,13 @@ describe('formatToParts', () => {
 
     test('defined selector', () => {
       const sel = res.get('sel')?.get('')?.formatToParts({ selector: 'a' });
-      expect(sel).toEqual([{ type: 'literal', value: 'A' }]);
+      expect(sel).toEqual([{ type: 'text', value: 'A' }]);
     });
 
     test('undefined selector', () => {
       const onError = jest.fn();
       const sel = res.get('sel')?.get('')?.formatToParts(undefined, onError);
-      expect(sel).toEqual([{ type: 'literal', value: 'B' }]);
+      expect(sel).toEqual([{ type: 'text', value: 'B' }]);
       expect(onError).toHaveBeenCalledTimes(1);
     });
   });
@@ -579,7 +579,7 @@ describe('formatToParts', () => {
     test('foo', () => {
       const foo = res.get('foo')?.get('')?.formatToParts({ num: 42 });
       expect(foo).toEqual([
-        { type: 'literal', value: 'Foo ' },
+        { type: 'text', value: 'Foo ' },
         {
           type: 'number',
           source: '$num',
@@ -592,12 +592,12 @@ describe('formatToParts', () => {
 
     test('bar', () => {
       const bar = res.get('bar')?.get('')?.formatToParts();
-      expect(bar).toEqual([{ type: 'literal', value: 'Bar' }]);
+      expect(bar).toEqual([{ type: 'text', value: 'Bar' }]);
     });
 
     test('qux', () => {
       const qux = res.get('qux')?.get('')?.formatToParts();
-      expect(qux).toEqual([{ type: 'literal', value: 'Qux' }]);
+      expect(qux).toEqual([{ type: 'text', value: 'Qux' }]);
     });
   });
 
@@ -623,7 +623,7 @@ describe('formatToParts', () => {
 
     test('case with match', () => {
       const msg = res.get('case')?.get('')?.formatToParts({ case: 'genitive' });
-      expect(msg).toEqual([{ type: 'literal', value: 'GEN' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'GEN' }]);
     });
 
     test('case with fallback', () => {
@@ -632,7 +632,7 @@ describe('formatToParts', () => {
         .get('case')
         ?.get('')
         ?.formatToParts({ case: 'oblique' }, onError);
-      expect(msg).toEqual([{ type: 'literal', value: 'NOM' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'NOM' }]);
       expect(onError).not.toHaveBeenCalled();
     });
 
@@ -641,13 +641,13 @@ describe('formatToParts', () => {
         .get('gender')
         ?.get('')
         ?.formatToParts({ gender: 'feminine' });
-      expect(msg).toEqual([{ type: 'literal', value: 'F' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'F' }]);
     });
 
     test('gender with fallback', () => {
       const onError = jest.fn();
       const msg = res.get('gender')?.get('')?.formatToParts(undefined, onError);
-      expect(msg).toEqual([{ type: 'literal', value: 'N' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'N' }]);
       expect(onError.mock.calls.map(args => args[0].type)).toEqual([
         'unresolved-variable'
       ]);
@@ -655,7 +655,7 @@ describe('formatToParts', () => {
 
     test('plural with match', () => {
       const msg = res.get('plural')?.get('')?.formatToParts({ num: 2 });
-      expect(msg).toEqual([{ type: 'literal', value: 'Other' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'Other' }]);
     });
 
     test('plural with fallback', () => {
@@ -664,7 +664,7 @@ describe('formatToParts', () => {
         .get('plural')
         ?.get('')
         ?.formatToParts({ num: 1 }, onError);
-      expect(msg).toEqual([{ type: 'literal', value: 'Other' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'Other' }]);
       expect(onError).not.toHaveBeenCalled();
     });
 
@@ -674,7 +674,7 @@ describe('formatToParts', () => {
         .get('plural')
         ?.get('')
         ?.formatToParts({ num: 'NaN' }, onError);
-      expect(msg).toEqual([{ type: 'literal', value: 'Other' }]);
+      expect(msg).toEqual([{ type: 'text', value: 'Other' }]);
       expect(onError.mock.calls.map(args => args[0].type)).toEqual([
         'bad-operand',
         'bad-selector'

--- a/mf2/fluent/src/fluent.test.ts
+++ b/mf2/fluent/src/fluent.test.ts
@@ -393,7 +393,7 @@ for (const [title, { locale = 'en', src, tests }] of Object.entries(
 
     test('resourceToFluent', () => {
       const template = Fluent.parse(src, { withSpans: false });
-      const res = resourceToFluent(data, template);
+      const res = resourceToFluent(data, { template });
 
       class FixResult extends Fluent.Transformer {
         // When converting to MF2, number wrappers are added

--- a/mf2/fluent/src/functions.ts
+++ b/mf2/fluent/src/functions.ts
@@ -1,15 +1,22 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { MessageFormat, MessagePart } from 'messageformat';
+import type { MessagePart } from 'messageformat';
 import type {
-  MessageFunction,
   MessageFunctionContext,
   MessageValue
 } from 'messageformat/functions';
-import { DraftFunctions, getLocaleDir } from 'messageformat/functions';
+import { getLocaleDir } from 'messageformat/functions';
 import type { FluentMessageResource } from './index.ts';
 import { valueToMessageRef } from './message-to-fluent.ts';
 
-const getMessageFunction = (res: FluentMessageResource) =>
+/**
+ * Build a custom function for Fluent message and term references.
+ *
+ * By default, {@link fluentToResource} uses this with the id `fluent:message`.
+ *
+ * @param res - A Map of {@link MessageFormat} instances,
+ *   one for each referrable message and term.
+ *   This Map may be passed in as initially empty, and later filled out by the caller.
+ */
+export const getMessageFunction = (res: FluentMessageResource) =>
   function message(
     ctx: MessageFunctionContext,
     options: Record<string, unknown>,
@@ -50,22 +57,3 @@ const getMessageFunction = (res: FluentMessageResource) =>
       valueOf: () => (str ??= mf.format(options, onError))
     } satisfies MessageValue;
   };
-
-/**
- * Build a {@link MessageFormat} runtime to use with Fluent messages.
- *
- * This builds on top of the default runtime, but uses all-caps names for the
- * `DATETIME` and `NUMBER` message formatters.
- * A custom function `MESSAGE` is also included to support
- * Fluent term and message references.
- *
- * @param res - A Map of MessageFormat instances, for use by `MESSAGE`.
- *   This Map may be passed in as initially empty, and later filled out by the caller.
- */
-export const getFluentFunctions = (
-  res: FluentMessageResource
-): Record<string, MessageFunction> => ({
-  currency: DraftFunctions.currency,
-  unit: DraftFunctions.unit,
-  'fluent:message': getMessageFunction(res)
-});

--- a/mf2/fluent/src/index.ts
+++ b/mf2/fluent/src/index.ts
@@ -21,6 +21,6 @@ export {
   fluentToResource,
   fluentToResourceData
 } from './fluent-to-resource.ts';
-export { getMessageFunction } from './functions.ts';
+export { getMessageFunction, type MessageReferenceValue } from './functions.ts';
 export { messageToFluent } from './message-to-fluent.ts';
 export { resourceToFluent } from './resource-to-fluent.ts';

--- a/mf2/fluent/src/index.ts
+++ b/mf2/fluent/src/index.ts
@@ -1,4 +1,4 @@
-import type { Model as MF, MessageFormat } from 'messageformat';
+import type { MessageFormat, Model } from 'messageformat';
 
 /**
  * A Map of {@link MessageFormat} instances.
@@ -9,26 +9,18 @@ import type { Model as MF, MessageFormat } from 'messageformat';
 export type FluentMessageResource = Map<string, Map<string, MessageFormat>>;
 
 /**
- * A Map of {@link MF.Message} data structures.
+ * A Map of {@link Model.Message} data structures.
  *
  * As each Fluent message and term may consist of a value and attributes,
  * the inner Map of this structure uses `''` as the key for the value.
  */
-export type FluentMessageResourceData = Map<string, Map<string, MF.Message>>;
+export type FluentMessageResourceData = Map<string, Map<string, Model.Message>>;
 
-export {
-  fluentToMessage,
-  type FluentToMessageOptions
-} from './fluent-to-message.ts';
+export { fluentToMessage } from './fluent-to-message.ts';
 export {
   fluentToResource,
   fluentToResourceData
 } from './fluent-to-resource.ts';
-export { getFluentFunctions } from './functions.ts';
-export {
-  defaultFunctionMap,
-  FluentMessageRef,
-  messageToFluent,
-  type FunctionMap
-} from './message-to-fluent.ts';
+export { getMessageFunction } from './functions.ts';
+export { messageToFluent } from './message-to-fluent.ts';
 export { resourceToFluent } from './resource-to-fluent.ts';

--- a/mf2/icu-messageformat-1/src/functions.ts
+++ b/mf2/icu-messageformat-1/src/functions.ts
@@ -97,15 +97,12 @@ function duration(
   }
 
   return {
-    type: 'mf1-duration' as const,
+    type: 'mf1-duration',
     source,
-    toParts() {
-      const res = { type: 'mf1-duration' as const, source, value: str };
-      return [res] as [typeof res];
-    },
+    toParts: () => [{ type: 'mf1-duration', source, value: str }],
     toString: () => str,
     valueOf: () => value
-  } satisfies MessageValue;
+  } satisfies MessageValue<'mf1-duration'>;
 }
 
 function number(

--- a/mf2/icu-messageformat-1/src/mf1.test.ts
+++ b/mf2/icu-messageformat-1/src/mf1.test.ts
@@ -1,5 +1,6 @@
 import { parse } from '@messageformat/parser';
 import { validate } from 'messageformat';
+import { DefaultFunctions } from 'messageformat/functions';
 import { mf1ToMessage, mf1ToMessageData } from './index.ts';
 
 export type TestCase = {
@@ -350,6 +351,14 @@ export const testCases: Record<string, TestCase[]> = {
   ]
 };
 
+const mf1FunctionNames = new Set([
+  ...Object.keys(DefaultFunctions),
+  'mf1:date',
+  'mf1:duration',
+  'mf1:number',
+  'mf1:time'
+]);
+
 for (const [title, cases] of Object.entries(testCases)) {
   describe(title, () => {
     for (const { locale = 'en', options, src, exp, only } of cases) {
@@ -380,9 +389,8 @@ for (const [title, cases] of Object.entries(testCases)) {
             const req = validate(data, type => {
               throw new Error(`Validation failed: ${type}`);
             });
-            const { functions } = mf.resolvedOptions();
             for (const fn of req.functions) {
-              if (typeof functions[fn] !== 'function') {
+              if (!mf1FunctionNames.has(fn)) {
                 throw new Error(`Unknown message function: ${fn}`);
               }
             }

--- a/mf2/messageformat/src/data-model/stringify.ts
+++ b/mf2/messageformat/src/data-model/stringify.ts
@@ -17,7 +17,9 @@ import type {
 } from './types.ts';
 
 /**
- * Stringify a message using its syntax representation.
+ * Stringify a {@link Message} using its syntax representation.
+ * Parsing and stringifying a message will not necessarily produce
+ * exactly the same syntax representation.
  *
  * @category Message Data Model
  */

--- a/mf2/messageformat/src/data-model/types.ts
+++ b/mf2/messageformat/src/data-model/types.ts
@@ -29,6 +29,7 @@ export type Node =
 
 /**
  * The representation of a single message.
+ * See {@link parseMessage}.
  */
 export type Message = PatternMessage | SelectMessage;
 

--- a/mf2/messageformat/src/data-model/validate.ts
+++ b/mf2/messageformat/src/data-model/validate.ts
@@ -4,26 +4,24 @@ import { visit } from './visit.ts';
 
 /**
  * Ensure that the `msg` data model is _valid_, calling `onError` on errors.
+ * If `onError` is not defined, a {@link MessageDataModelError} will be thrown on error.
  *
  * Detects the following errors:
  *
- * - **Variant Key Mismatch**:
+ * - `'key-mismatch'`: **Variant Key Mismatch**<br>
  *   The number of keys on a _variant_ does not equal the number of _selectors_.
  *
- * - **Missing Fallback Variant**:
+ * - `'missing-fallback'`: **Missing Fallback Variant**<br>
  *   The message does not include a _variant_ with only catch-all keys.
  *
- * - **Missing Selector Annotation**:
+ * - `'missing-selector-annotation'`: **Missing Selector Annotation**<br>
  *   A _selector_ does not contains a _variable_ that directly or indirectly
  *   reference a _declaration_ with a _function_.
  *
- * - **Duplicate Declaration**:
+ * - `'duplicate-declaration'`: **Duplicate Declaration**<br>
  *   A _variable_ appears in two _declarations_.
  *
- * - **Invalid Forward Reference**:
- *   A _declaration_ _expression_ refers to a _variable_ defined by a later _declaration_.
- *
- * - **Duplicate Variant**:
+ * - `'duplicate-variant'`: **Duplicate Variant**<br>
  *   The same list of _keys_ is used for more than one _variant_.
  *
  * @category Message Data Model

--- a/mf2/messageformat/src/format-context.ts
+++ b/mf2/messageformat/src/format-context.ts
@@ -1,13 +1,13 @@
 import type { MessageValue } from './message-value.ts';
 import type { MessageFunction } from './messageformat.ts';
 
-export interface Context {
-  functions: Record<string, MessageFunction>;
+export interface Context<T extends string = string, P extends string = T> {
+  functions: Record<string, MessageFunction<T, P>>;
   onError(error: unknown): void;
   localeMatcher: 'best fit' | 'lookup';
   locales: Intl.Locale[];
   /** Cache for local variables */
-  localVars: WeakSet<MessageValue>;
+  localVars: WeakSet<MessageValue<T, P>>;
   /**
    * A representation of the parameters/arguments passed to a message formatter,
    * and extended by declarations.

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -18,7 +18,11 @@ export interface MessageBiDiIsolationPart {
   value: '\u2066' | '\u2067' | '\u2068' | '\u2069';
 }
 
-/** @category Formatted Parts */
+/**
+ * The base formatted part for all expressions.
+ *
+ * @category Formatted Parts
+ */
 export interface MessageExpressionPart {
   type: string;
   source: string;
@@ -35,7 +39,11 @@ export interface MessageLiteralPart {
   value: string;
 }
 
-/** @category Formatted Parts */
+/**
+ * The formatted part for a markup placeholder.
+ *
+ * @category Formatted Parts
+ */
 export interface MessageMarkupPart {
   type: 'markup';
   kind: 'open' | 'standalone' | 'close';

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -1,13 +1,25 @@
-export type { MessageDateTimePart } from './functions/datetime.ts';
-export type { MessageFallbackPart } from './functions/fallback.ts';
-export type { MessageNumberPart } from './functions/number.ts';
-export type { MessageStringPart } from './functions/string.ts';
-export type { MessageUnknownPart } from './functions/unknown.ts';
+import type { MessageDateTimePart } from './functions/datetime.ts';
+import type { MessageFallbackPart } from './functions/fallback.ts';
+import type { MessageNumberPart } from './functions/number.ts';
+import type { MessageStringPart } from './functions/string.ts';
+import type { MessageUnknownPart } from './functions/unknown.ts';
+
+export type {
+  MessageDateTimePart,
+  MessageFallbackPart,
+  MessageNumberPart,
+  MessageStringPart,
+  MessageUnknownPart
+};
 
 /**
  * These are always paired in the output.
- * The first part has U+2066 LEFT-TO-RIGHT ISOLATE, U+2067 RIGHT-TO-LEFT ISOLATE,
- * or U+2068 FIRST STRONG ISOLATE as its `value`,
+ * The first part has
+ * - U+2066 LEFT-TO-RIGHT ISOLATE,
+ * - U+2067 RIGHT-TO-LEFT ISOLATE, or
+ * - U+2068 FIRST STRONG ISOLATE
+ *
+ * as its `value`,
  * and an ending isolation part has U+2069 POP DIRECTIONAL ISOLATE as its `value`.
  *
  * @category Formatted Parts
@@ -23,8 +35,8 @@ export interface MessageBiDiIsolationPart {
  *
  * @category Formatted Parts
  */
-export interface MessageExpressionPart {
-  type: string;
+export interface MessageExpressionPart<P extends string> {
+  type: P;
   source: string;
   dir?: 'ltr' | 'rtl';
   locale?: string;
@@ -58,8 +70,25 @@ export interface MessageMarkupPart {
  *
  * @category Formatted Parts
  */
-export type MessagePart =
+export type MessagePart<P extends string> =
   | MessageBiDiIsolationPart
-  | MessageExpressionPart
+  | MessageFallbackPart
   | MessageLiteralPart
-  | MessageMarkupPart;
+  | MessageMarkupPart
+  | MessageNumberPart
+  | MessageStringPart
+  | MessageUnknownPart
+  | MessageExpressionPart<
+      Exclude<
+        P,
+        (
+          | MessageBiDiIsolationPart
+          | MessageFallbackPart
+          | MessageLiteralPart
+          | MessageMarkupPart
+          | MessageNumberPart
+          | MessageStringPart
+          | MessageUnknownPart
+        )['type']
+      >
+    >;

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -46,8 +46,8 @@ export interface MessageExpressionPart<P extends string> {
 }
 
 /** @category Formatted Parts */
-export interface MessageLiteralPart {
-  type: 'literal';
+export interface MessageTextPart {
+  type: 'text';
   value: string;
 }
 
@@ -73,10 +73,10 @@ export interface MessageMarkupPart {
 export type MessagePart<P extends string> =
   | MessageBiDiIsolationPart
   | MessageFallbackPart
-  | MessageLiteralPart
   | MessageMarkupPart
   | MessageNumberPart
   | MessageStringPart
+  | MessageTextPart
   | MessageUnknownPart
   | MessageExpressionPart<
       Exclude<
@@ -84,10 +84,10 @@ export type MessagePart<P extends string> =
         (
           | MessageBiDiIsolationPart
           | MessageFallbackPart
-          | MessageLiteralPart
           | MessageMarkupPart
           | MessageNumberPart
           | MessageStringPart
+          | MessageTextPart
           | MessageUnknownPart
         )['type']
       >

--- a/mf2/messageformat/src/functions/datetime.ts
+++ b/mf2/messageformat/src/functions/datetime.ts
@@ -13,7 +13,7 @@ import { asBoolean, asPositiveInteger, asString } from './utils.ts';
  *
  * @beta
  */
-export interface MessageDateTime extends MessageValue {
+export interface MessageDateTime extends MessageValue<'datetime'> {
   readonly type: 'datetime';
   readonly source: string;
   readonly dir: 'ltr' | 'rtl' | 'auto';
@@ -29,7 +29,7 @@ export interface MessageDateTime extends MessageValue {
  * @beta
  * @category Formatted Parts
  */
-export interface MessageDateTimePart extends MessageExpressionPart {
+export interface MessageDateTimePart extends MessageExpressionPart<'datetime'> {
   type: 'datetime';
   source: string;
   locale: string;

--- a/mf2/messageformat/src/functions/datetime.ts
+++ b/mf2/messageformat/src/functions/datetime.ts
@@ -3,9 +3,16 @@ import { MessageResolutionError } from '../errors.ts';
 import type { MessageExpressionPart } from '../formatted-parts.ts';
 import type { MessageValue } from '../message-value.ts';
 import type { MessageFunctionContext } from '../resolve/function-context.ts';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { DraftFunctions } from './index.ts';
 import { asBoolean, asPositiveInteger, asString } from './utils.ts';
 
-/** @beta */
+/**
+ * The resolved value of a {@link DraftFunctions.date | :date},
+ * {@link DraftFunctions.datetime | :datetime}, or {@link DraftFunctions.time | :time} expression.
+ *
+ * @beta
+ */
 export interface MessageDateTime extends MessageValue {
   readonly type: 'datetime';
   readonly source: string;
@@ -17,6 +24,8 @@ export interface MessageDateTime extends MessageValue {
 }
 
 /**
+ * The formatted part for a {@link MessageDateTime} value.
+ *
  * @beta
  * @category Formatted Parts
  */
@@ -51,9 +60,9 @@ const fieldOptions = new Set([
 export const datetime = (
   ctx: MessageFunctionContext,
   options: Record<string, unknown>,
-  input?: unknown
+  operand?: unknown
 ): MessageDateTime =>
-  dateTimeImplementation(ctx, input, res => {
+  dateTimeImplementation(ctx, operand, res => {
     let hasStyle = false;
     let hasFields = false;
     for (const [name, value] of Object.entries(options)) {
@@ -97,9 +106,9 @@ export const datetime = (
 export const date = (
   ctx: MessageFunctionContext,
   options: Record<string, unknown>,
-  input?: unknown
+  operand?: unknown
 ): MessageDateTime =>
-  dateTimeImplementation(ctx, input, res => {
+  dateTimeImplementation(ctx, operand, res => {
     for (const name of Object.keys(res)) {
       if (styleOptions.has(name) || fieldOptions.has(name)) delete res[name];
     }
@@ -134,9 +143,9 @@ export const date = (
 export const time = (
   ctx: MessageFunctionContext,
   options: Record<string, unknown>,
-  input?: unknown
+  operand?: unknown
 ): MessageDateTime =>
-  dateTimeImplementation(ctx, input, res => {
+  dateTimeImplementation(ctx, operand, res => {
     for (const name of Object.keys(res)) {
       if (styleOptions.has(name) || fieldOptions.has(name)) delete res[name];
     }

--- a/mf2/messageformat/src/functions/fallback.ts
+++ b/mf2/messageformat/src/functions/fallback.ts
@@ -4,7 +4,7 @@ import type { MessageValue } from '../message-value.ts';
 /**
  * Used to represent runtime/formatting errors.
  */
-export interface MessageFallback extends MessageValue {
+export interface MessageFallback extends MessageValue<'fallback'> {
   readonly type: 'fallback';
   readonly source: string;
   toParts(): [MessageFallbackPart];
@@ -12,7 +12,7 @@ export interface MessageFallback extends MessageValue {
 }
 
 /** @category Formatted Parts */
-export interface MessageFallbackPart extends MessageExpressionPart {
+export interface MessageFallbackPart extends MessageExpressionPart<'fallback'> {
   type: 'fallback';
   source: string;
 }

--- a/mf2/messageformat/src/functions/index.ts
+++ b/mf2/messageformat/src/functions/index.ts
@@ -34,7 +34,7 @@ import { unit } from './unit.ts';
  * Functions classified as REQUIRED by the
  * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 47 MessageFormat specification}.
  */
-export const DefaultFunctions = Object.freeze({
+export let DefaultFunctions = {
   /**
    * Supports formatting and selection as defined in LDML 47 for the
    * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-integer-function | :integer function}.
@@ -61,7 +61,10 @@ export const DefaultFunctions = Object.freeze({
    * An `undefined` value is resolved as an empty string.
    */
   string
-});
+};
+DefaultFunctions = Object.freeze(
+  Object.assign(Object.create(null), DefaultFunctions)
+);
 
 /**
  * Functions classified as DRAFT by the
@@ -78,7 +81,7 @@ export const DefaultFunctions = Object.freeze({
  *
  * @beta
  */
-export const DraftFunctions = Object.freeze({
+export let DraftFunctions = {
   /**
    * Supports formatting as defined in LDML 47 for the
    * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-currency-function | :currency function}.
@@ -136,4 +139,7 @@ export const DraftFunctions = Object.freeze({
    * The `unit` option must be provided by either the operand's `options` or the `exprOpt` expression options.
    */
   unit
-});
+};
+DraftFunctions = Object.freeze(
+  Object.assign(Object.create(null), DraftFunctions)
+);

--- a/mf2/messageformat/src/functions/index.ts
+++ b/mf2/messageformat/src/functions/index.ts
@@ -31,18 +31,43 @@ import { string } from './string.ts';
 import { unit } from './unit.ts';
 
 /**
- * Functions classified as REQUIRED by the MessageFormat 2 specification.
+ * Functions classified as REQUIRED by the
+ * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 47 MessageFormat specification}.
  */
 export const DefaultFunctions = Object.freeze({
+  /**
+   * Supports formatting and selection as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-integer-function | :integer function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
   integer,
+
+  /**
+   * Supports formatting and selection as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-number-function | :number function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
   number,
+
+  /**
+   * Supports formatting and selection as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-string-function | :string function}.
+   *
+   * The `operand` must be a stringifiable value.
+   * An `undefined` value is resolved as an empty string.
+   */
   string
 });
 
 /**
- * Functions classified as DRAFT by the MessageFormat 2 specification.
+ * Functions classified as DRAFT by the
+ * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#contents-of-part-9-messageformat | LDML 47 MessageFormat specification}.
  *
- * These are liable to change, and are not covered by any stability guarantee.
+ * These are liable to change, and are **_not_** covered by any stability guarantee.
  *
  * ```js
  * import { MessageFormat } from 'messageformat';
@@ -54,10 +79,61 @@ export const DefaultFunctions = Object.freeze({
  * @beta
  */
 export const DraftFunctions = Object.freeze({
+  /**
+   * Supports formatting as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-currency-function | :currency function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   *
+   * The `currency` option must be provided by either the operand's `options` or the `exprOpt` expression options.
+   */
   currency,
+
+  /**
+   * Supports formatting as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-date-function | :date function}.
+   *
+   * The `operand` must be a Date, number, or string representing a date,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
   date,
+
+  /**
+   * Supports formatting as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-datetime-function | :datetime function}.
+   *
+   * The `operand` must be a Date, number, or string representing a date,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
   datetime,
+
+  /**
+   * Supports formatting and selection as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-math-function | :math function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
   math,
+
+  /**
+   * Supports formatting as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-time-function | :time function}.
+   *
+   * The `operand` must be a Date, number, or string representing a date,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   */
   time,
+
+  /**
+   * Supports formatting as defined in LDML 47 for the
+   * {@link https://www.unicode.org/reports/tr35/tr35-75/tr35-messageFormat.html#the-unit-function | :unit function}.
+   *
+   * The `operand` must be a number, BigInt, or string representing a JSON number,
+   * or an object wrapping such a value, with a `valueOf()` accessor and an optional `options` object.
+   *
+   * The `unit` option must be provided by either the operand's `options` or the `exprOpt` expression options.
+   */
   unit
 });

--- a/mf2/messageformat/src/functions/number.ts
+++ b/mf2/messageformat/src/functions/number.ts
@@ -3,8 +3,15 @@ import { MessageResolutionError } from '../errors.ts';
 import type { MessageExpressionPart } from '../formatted-parts.ts';
 import type { MessageValue } from '../message-value.ts';
 import type { MessageFunctionContext } from '../resolve/function-context.ts';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { DefaultFunctions, DraftFunctions } from './index.ts';
 import { asPositiveInteger, asString } from './utils.ts';
 
+/**
+ * The resolved value of a {@link DraftFunctions.currency | :currency},
+ * {@link DefaultFunctions.integer | :integer}, {@link DraftFunctions.math | :math},
+ * {@link DefaultFunctions.number | :number}, or {@link DraftFunctions.unit | :unit} expression.
+ */
 export interface MessageNumber extends MessageValue {
   readonly type: 'number';
   readonly source: string;
@@ -12,6 +19,7 @@ export interface MessageNumber extends MessageValue {
   readonly options: Readonly<
     Intl.NumberFormatOptions & Intl.PluralRulesOptions
   >;
+
   /**
    * In addition to matching exact values,
    * numerical values may also match keys with the same plural rule category,
@@ -27,7 +35,11 @@ export interface MessageNumber extends MessageValue {
   valueOf(): number | bigint;
 }
 
-/** @category Formatted Parts */
+/**
+ * The formatted part for a {@link MessageNumber} value.
+ *
+ * @category Formatted Parts
+ */
 export interface MessageNumberPart extends MessageExpressionPart {
   type: 'number';
   source: string;
@@ -133,13 +145,6 @@ export function getMessageNumber(
   };
 }
 
-/**
- * `number` accepts a number, BigInt or string representing a JSON number as input
- * and formats it with a subset of the options of
- * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat | Intl.NumberFormat}.
- * It also supports plural category selection via
- * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules | Intl.PluralRules}.
- */
 export function number(
   ctx: MessageFunctionContext,
   exprOpt: Record<string, unknown>,
@@ -183,13 +188,6 @@ export function number(
   return getMessageNumber(ctx, value, options, true);
 }
 
-/**
- * `integer` accepts a number, BigInt or string representing a JSON number as input
- * and formats it with a subset of the options of
- * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat | Intl.NumberFormat}.
- * It also supports plural category selection via
- * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules | Intl.PluralRules}.
- */
 export function integer(
   ctx: MessageFunctionContext,
   exprOpt: Record<string, unknown>,

--- a/mf2/messageformat/src/functions/number.ts
+++ b/mf2/messageformat/src/functions/number.ts
@@ -12,7 +12,7 @@ import { asPositiveInteger, asString } from './utils.ts';
  * {@link DefaultFunctions.integer | :integer}, {@link DraftFunctions.math | :math},
  * {@link DefaultFunctions.number | :number}, or {@link DraftFunctions.unit | :unit} expression.
  */
-export interface MessageNumber extends MessageValue {
+export interface MessageNumber extends MessageValue<'number'> {
   readonly type: 'number';
   readonly source: string;
   readonly dir: 'ltr' | 'rtl' | 'auto';
@@ -40,7 +40,7 @@ export interface MessageNumber extends MessageValue {
  *
  * @category Formatted Parts
  */
-export interface MessageNumberPart extends MessageExpressionPart {
+export interface MessageNumberPart extends MessageExpressionPart<'number'> {
   type: 'number';
   source: string;
   locale: string;

--- a/mf2/messageformat/src/functions/string.ts
+++ b/mf2/messageformat/src/functions/string.ts
@@ -2,6 +2,10 @@ import type { MessageExpressionPart } from '../formatted-parts.ts';
 import type { MessageValue } from '../message-value.ts';
 import type { MessageFunctionContext } from '../resolve/function-context.ts';
 
+/**
+ * The resolved value of a {@link DefaultFunctions.string | :string} expression,
+ * or of an expression with a literal operand and no function.
+ */
 export interface MessageString extends MessageValue {
   readonly type: 'string';
   readonly source: string;
@@ -12,7 +16,11 @@ export interface MessageString extends MessageValue {
   valueOf(): string;
 }
 
-/** @category Formatted Parts */
+/**
+ * The formatted part for a {@link MessageString} value.
+ *
+ * @category Formatted Parts
+ */
 export interface MessageStringPart extends MessageExpressionPart {
   type: 'string';
   source: string;
@@ -20,17 +28,12 @@ export interface MessageStringPart extends MessageExpressionPart {
   value: string;
 }
 
-/**
- * Accepts any input, and parses any non-string value using `String()`.
- * For no input, resolves its value to an empty string.
- * On error, resolves to a fallback value.
- */
 export function string(
   ctx: Pick<MessageFunctionContext, 'dir' | 'locales' | 'source'>,
   _options: Record<string, unknown>,
-  input?: unknown
+  operand?: unknown
 ): MessageString {
-  const str = input === undefined ? '' : String(input);
+  const str = operand === undefined ? '' : String(operand);
   const selStr = str.normalize();
   return {
     type: 'string',

--- a/mf2/messageformat/src/functions/string.ts
+++ b/mf2/messageformat/src/functions/string.ts
@@ -6,7 +6,7 @@ import type { MessageFunctionContext } from '../resolve/function-context.ts';
  * The resolved value of a {@link DefaultFunctions.string | :string} expression,
  * or of an expression with a literal operand and no function.
  */
-export interface MessageString extends MessageValue {
+export interface MessageString extends MessageValue<'string'> {
   readonly type: 'string';
   readonly source: string;
   readonly dir: 'ltr' | 'rtl' | 'auto';
@@ -21,7 +21,7 @@ export interface MessageString extends MessageValue {
  *
  * @category Formatted Parts
  */
-export interface MessageStringPart extends MessageExpressionPart {
+export interface MessageStringPart extends MessageExpressionPart<'string'> {
   type: 'string';
   source: string;
   locale: string;

--- a/mf2/messageformat/src/functions/test-functions.ts
+++ b/mf2/messageformat/src/functions/test-functions.ts
@@ -10,7 +10,7 @@ import type { MessageValue } from '../message-value.ts';
 import type { MessageFunctionContext } from '../resolve/function-context.ts';
 import { asPositiveInteger, asString } from './utils.ts';
 
-interface TestValue extends MessageValue {
+interface TestValue extends MessageValue<'test'> {
   readonly type: 'test';
   readonly options: {
     canFormat: boolean;

--- a/mf2/messageformat/src/functions/unknown.ts
+++ b/mf2/messageformat/src/functions/unknown.ts
@@ -1,7 +1,7 @@
 import type { MessageExpressionPart } from '../formatted-parts.ts';
 import type { MessageValue } from '../message-value.ts';
 
-export interface MessageUnknownValue extends MessageValue {
+export interface MessageUnknownValue extends MessageValue<'unknown'> {
   readonly type: 'unknown';
   readonly source: string;
   readonly dir: 'auto';
@@ -11,7 +11,7 @@ export interface MessageUnknownValue extends MessageValue {
 }
 
 /** @category Formatted Parts */
-export interface MessageUnknownPart extends MessageExpressionPart {
+export interface MessageUnknownPart extends MessageExpressionPart<'unknown'> {
   type: 'unknown';
   source: string;
   value: unknown;

--- a/mf2/messageformat/src/message-value.ts
+++ b/mf2/messageformat/src/message-value.ts
@@ -5,13 +5,13 @@ export const BIDI_ISOLATE = Symbol('bidi-isolate');
 /**
  * The base for all resolved message values.
  */
-export interface MessageValue {
-  readonly type: string;
+export interface MessageValue<T extends string, P extends string = T> {
+  readonly type: T;
   readonly source: string;
   readonly dir?: 'ltr' | 'rtl' | 'auto';
   readonly options?: Readonly<object>;
   selectKey?: (keys: Set<string>) => string | null;
-  toParts?: () => MessageExpressionPart[];
+  toParts?: () => MessageExpressionPart<P>[];
   toString?: () => string;
   valueOf?: () => unknown;
   /** @private */

--- a/mf2/messageformat/src/message-value.ts
+++ b/mf2/messageformat/src/message-value.ts
@@ -2,6 +2,9 @@ import type { MessageExpressionPart } from './formatted-parts.ts';
 
 export const BIDI_ISOLATE = Symbol('bidi-isolate');
 
+/**
+ * The base for all resolved message values.
+ */
 export interface MessageValue {
   readonly type: string;
   readonly source: string;

--- a/mf2/messageformat/src/messageformat.ts
+++ b/mf2/messageformat/src/messageformat.ts
@@ -252,15 +252,6 @@ export class MessageFormat {
     return parts;
   }
 
-  resolvedOptions() {
-    return {
-      bidiIsolation: this.#bidiIsolation,
-      dir: this.#dir,
-      functions: Object.freeze(this.#functions),
-      localeMatcher: this.#localeMatcher
-    };
-  }
-
   private createContext(
     msgParams?: Record<string, unknown>,
     onError: Context['onError'] = (error: Error) => {

--- a/mf2/messageformat/src/messageformat.ts
+++ b/mf2/messageformat/src/messageformat.ts
@@ -185,11 +185,11 @@ export class MessageFormat<T extends string = never, P extends string = T> {
    *
    * ```js
    * [
-   *   { type: 'literal', value: 'Hello ' },
+   *   { type: 'text', value: 'Hello ' },
    *   { type: 'bidiIsolation', value: '\u2068' },
    *   { type: 'string', source: '$user.name', locale: 'en', value: 'Kat' },
    *   { type: 'bidiIsolation', value: '\u2069' },
-   *   { type: 'literal', value: ', today is ' },
+   *   { type: 'text', value: ', today is ' },
    *   {
    *     type: 'datetime',
    *     source: '$date',
@@ -220,7 +220,7 @@ export class MessageFormat<T extends string = never, P extends string = T> {
     const parts: MessagePart<P>[] = [];
     for (const elem of selectPattern(ctx, this.#message)) {
       if (typeof elem === 'string') {
-        parts.push({ type: 'literal', value: elem });
+        parts.push({ type: 'text', value: elem });
       } else if (elem.type === 'markup') {
         parts.push(formatMarkup(ctx, elem));
       } else {

--- a/mf2/messageformat/src/messageformat.ts
+++ b/mf2/messageformat/src/messageformat.ts
@@ -27,10 +27,11 @@ export type MessageFunction = (
 /** @category Formatting */
 export interface MessageFormatOptions {
   /**
-   * The bidi isolation strategy for messages,
-   * i.e. how parts with different or unknown directionalities are isolated from each other.
+   * The bidi isolation strategy for message formatting,
+   * i.e. how expression placeholders with different or unknown directionalities
+   * are isolated from the rest of the formatted message.
    *
-   * The default `'default'` strategy isolates all placeholders,
+   * The default `'default'` strategy isolates all expression placeholders,
    * except when both the message and the placeholder are known to be left-to-right.
    *
    * The `'none'` strategy applies no isolation at all.
@@ -48,13 +49,15 @@ export interface MessageFormatOptions {
    * determines which algorithm to use when selecting between them;
    * the default for `Intl` formatters is `'best fit'`.
    *
+   * The locale is resolved separately by each message function handler call.
+   *
    * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locale_negotiation
    */
   localeMatcher?: 'best fit' | 'lookup';
 
   /**
-   * The set of custom functions available during message resolution.
-   * Extends the default set of functions.
+   * A set of custom functions to make available during message resolution.
+   * Extends the {@link DefaultFunctions} set of functions.
    */
   functions?: Record<string, MessageFunction>;
 }
@@ -103,16 +106,17 @@ export class MessageFormat {
    * import { MessageFormat } from 'messageformat';
    * import { DraftFunctions } from 'messageformat/functions';
    *
-   * const msg = 'Hello {$user.name}, today is {$date :date}';
+   * const msg = 'Hello {$user.name}, today is {$date :date style=long}';
    * const mf = new MessageFormat('en', msg, { functions: DraftFunctions });
    * mf.format({ user: { name: 'Kat' }, date: new Date('2025-03-01') });
    * ```
    *
    * ```js
-   * 'Hello Kat, today is Mar 1, 2025'
+   * 'Hello Kat, today is March 1, 2025'
    * ```
    *
-   * @param msgParams - To refer to an inner property of an object value,
+   * @param msgParams - Values that may be referenced by `$`-prefixed variable references.
+   *   To refer to an inner property of an object value,
    *   use `.` as a separator; in case of conflict, the longest starting substring wins.
    * @param onError - Called in case of error.
    *   If not set, errors are by default logged as warnings.
@@ -164,7 +168,7 @@ export class MessageFormat {
    * import { MessageFormat } from 'messageformat';
    * import { DraftFunctions } from 'messageformat/functions';
    *
-   * const msg = 'Hello {$user.name}, today is {$date :date}';
+   * const msg = 'Hello {$user.name}, today is {$date :date style=long}';
    * const mf = new MessageFormat('en', msg, { functions: DraftFunctions });
    * mf.formatToParts({ user: { name: 'Kat' }, date: new Date('2025-03-01') });
    * ```
@@ -182,7 +186,7 @@ export class MessageFormat {
    *     dir: 'ltr',
    *     locale: 'en',
    *     parts: [
-   *       { type: 'month', value: 'Mar' },
+   *       { type: 'month', value: 'March' },
    *       { type: 'literal', value: ' ' },
    *       { type: 'day', value: '1' },
    *       { type: 'literal', value: ', ' },
@@ -192,7 +196,8 @@ export class MessageFormat {
    * ]
    * ```
    *
-   * @param msgParams - To refer to an inner property of an object value,
+   * @param msgParams - Values that may be referenced by `$`-prefixed variable references.
+   *   To refer to an inner property of an object value,
    *   use `.` as a separator; in case of conflict, the longest starting substring wins.
    * @param onError - Called in case of error.
    *   If not set, errors are by default logged as warnings.

--- a/mf2/messageformat/src/mf2-features.test.ts
+++ b/mf2/messageformat/src/mf2-features.test.ts
@@ -15,7 +15,7 @@ import {
   MessageBiDiIsolationPart,
   MessageExpressionPart,
   MessageFormat,
-  MessageLiteralPart,
+  MessageTextPart,
   type Model
 } from './index.ts';
 
@@ -59,7 +59,7 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
     const parts1 = mf.formatToParts({ range: { start: 0, end: 1 } });
     expect(parts1).toEqual([
       { type: 'range', source: '$range', value: '0 - 1' },
-      { type: 'literal', value: ' dag' }
+      { type: 'text', value: ' dag' }
     ]);
 
     const msg2 = mf.format({ range: { start: 1, end: 2 } });
@@ -67,7 +67,7 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
     const parts2 = mf.formatToParts({ range: { start: 1, end: 2 } });
     expect(parts2).toEqual([
       { type: 'range', source: '$range', value: '1 - 2' },
-      { type: 'literal', value: ' dagen' }
+      { type: 'text', value: ' dagen' }
     ]);
   });
 });
@@ -292,9 +292,7 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
   function hackyFixArticles(
     locales: string[],
     parts: Array<
-      | MessageExpressionPart<string>
-      | MessageLiteralPart
-      | MessageBiDiIsolationPart
+      MessageExpressionPart<string> | MessageBiDiIsolationPart | MessageTextPart
     >
   ) {
     if (locales[0] !== 'en') throw new Error('Only English supported');
@@ -328,11 +326,11 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     const parts = mf.formatToParts({ foo: 'foo', other: 'other' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
-      { type: 'literal', value: 'A ' },
+      { type: 'text', value: 'A ' },
       { type: 'bidiIsolation', value: '\u2068' },
       { type: 'string', locale: 'en', source: '$foo', value: 'foo' },
       { type: 'bidiIsolation', value: '\u2069' },
-      { type: 'literal', value: ' and an ' },
+      { type: 'text', value: ' and an ' },
       { type: 'bidiIsolation', value: '\u2068' },
       { type: 'string', locale: 'en', source: '$other', value: 'other' },
       { type: 'bidiIsolation', value: '\u2069' }
@@ -346,9 +344,9 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     const parts = mf.formatToParts({ foo: 'other', other: 'foo' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
-      { type: 'literal', value: 'An ' },
+      { type: 'text', value: 'An ' },
       { type: 'string', locale: 'en', source: '$foo', value: 'other' },
-      { type: 'literal', value: ' and a ' },
+      { type: 'text', value: ' and a ' },
       { type: 'string', locale: 'en', source: '$other', value: 'foo' }
     ]);
   });
@@ -360,9 +358,9 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     const parts = mf.formatToParts({ foo: 'foo', other: 'other' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
-      { type: 'literal', value: 'The ' },
+      { type: 'text', value: 'The ' },
       { type: 'string', locale: 'en', source: '$foo', value: 'foo' },
-      { type: 'literal', value: ' and lotsa ' },
+      { type: 'text', value: ' and lotsa ' },
       { type: 'string', locale: 'en', source: '$other', value: 'other' }
     ]);
   });
@@ -375,9 +373,9 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
       { type: 'string', locale: 'en', source: '$foo', value: 'A' },
-      { type: 'literal', value: ' foo and an ' },
+      { type: 'text', value: ' foo and an ' },
       { type: 'string', locale: 'en', source: '|...|', value: '...' },
-      { type: 'literal', value: ' ' },
+      { type: 'text', value: ' ' },
       { type: 'string', locale: 'en', source: '$other', value: 'other' }
     ]);
   });

--- a/mf2/messageformat/src/mf2-features.test.ts
+++ b/mf2/messageformat/src/mf2-features.test.ts
@@ -24,7 +24,7 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
     { source, locales: [locale] }: MessageFunctionContext,
     options: Record<string, unknown>,
     input: unknown
-  ): MessageValue {
+  ): MessageValue<'range'> {
     const { start, end } = input as { start: number; end: number };
     const value = `${start} - ${end}`;
     return {
@@ -213,7 +213,7 @@ maybe('List formatting', () => {
       { locales, source }: MessageFunctionContext,
       options: Record<string, unknown>,
       input?: unknown
-    ): MessageValue => {
+    ): MessageValue<'list', 'element' | 'literal'> => {
       let list = Array.isArray(input)
         ? input.map(String)
         : input === undefined
@@ -292,7 +292,9 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
   function hackyFixArticles(
     locales: string[],
     parts: Array<
-      MessageExpressionPart | MessageLiteralPart | MessageBiDiIsolationPart
+      | MessageExpressionPart<string>
+      | MessageLiteralPart
+      | MessageBiDiIsolationPart
     >
   ) {
     if (locales[0] !== 'en') throw new Error('Only English supported');

--- a/mf2/messageformat/src/resolve/function-ref.test.ts
+++ b/mf2/messageformat/src/resolve/function-ref.test.ts
@@ -2,7 +2,7 @@ import { MessageFormat, MessageNumberPart } from 'messageformat';
 import { DraftFunctions, MessageFunction } from 'messageformat/functions';
 
 test('Custom function', () => {
-  const custom: MessageFunction = (
+  const custom: MessageFunction<'custom'> = (
     { dir, source, locales: [locale] },
     _opt,
     input

--- a/mf2/messageformat/src/resolve/markup.test.ts
+++ b/mf2/messageformat/src/resolve/markup.test.ts
@@ -6,7 +6,7 @@ describe('Simple open/close', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{/b}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
-      { type: 'literal', value: 'foo' },
+      { type: 'text', value: 'foo' },
       { type: 'markup', kind: 'close', source: '/b', name: 'b' }
     ]);
     expect(mf.format()).toBe('foo');
@@ -26,7 +26,7 @@ describe('Simple open/close', () => {
         source: '#b',
         name: 'b'
       },
-      { type: 'literal', value: 'foo' },
+      { type: 'text', value: 'foo' },
       { type: 'bidiIsolation', value: '\u2068' },
       { type: 'string', source: '$foo', locale: 'en', value: 'foo bar' },
       { type: 'bidiIsolation', value: '\u2069' },
@@ -65,10 +65,10 @@ describe('Multiple open/close', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{/b}{#a}bar{/a}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
-      { type: 'literal', value: 'foo' },
+      { type: 'text', value: 'foo' },
       { type: 'markup', kind: 'close', source: '/b', name: 'b' },
       { type: 'markup', kind: 'open', source: '#a', name: 'a' },
-      { type: 'literal', value: 'bar' },
+      { type: 'text', value: 'bar' },
       { type: 'markup', kind: 'close', source: '/a', name: 'a' }
     ]);
     expect(mf.format()).toBe('foobar');
@@ -78,9 +78,9 @@ describe('Multiple open/close', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{#a}bar{/a}{/b}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
-      { type: 'literal', value: 'foo' },
+      { type: 'text', value: 'foo' },
       { type: 'markup', kind: 'open', source: '#a', name: 'a' },
-      { type: 'literal', value: 'bar' },
+      { type: 'text', value: 'bar' },
       { type: 'markup', kind: 'close', source: '/a', name: 'a' },
       { type: 'markup', kind: 'close', source: '/b', name: 'b' }
     ]);
@@ -91,11 +91,11 @@ describe('Multiple open/close', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{#a}bar{/b}baz{/a}');
     expect(mf.formatToParts()).toEqual([
       { type: 'markup', kind: 'open', source: '#b', name: 'b' },
-      { type: 'literal', value: 'foo' },
+      { type: 'text', value: 'foo' },
       { type: 'markup', kind: 'open', source: '#a', name: 'a' },
-      { type: 'literal', value: 'bar' },
+      { type: 'text', value: 'bar' },
       { type: 'markup', kind: 'close', source: '/b', name: 'b' },
-      { type: 'literal', value: 'baz' },
+      { type: 'text', value: 'baz' },
       { type: 'markup', kind: 'close', source: '/a', name: 'a' }
     ]);
     expect(mf.format()).toBe('foobarbaz');

--- a/mf2/messageformat/src/resolve/resolve-expression.ts
+++ b/mf2/messageformat/src/resolve/resolve-expression.ts
@@ -1,14 +1,17 @@
 import type { Expression } from '../data-model/types.ts';
 import type { Context } from '../format-context.ts';
+import type { MessageFallback } from '../functions/fallback.ts';
+import type { MessageString } from '../functions/string.ts';
+import type { MessageUnknownValue } from '../functions/unknown.ts';
 import type { MessageValue } from '../message-value.ts';
 import { resolveFunctionRef } from './resolve-function-ref.ts';
 import { resolveLiteral } from './resolve-literal.ts';
 import { resolveVariableRef } from './resolve-variable.ts';
 
-export function resolveExpression(
-  ctx: Context,
+export function resolveExpression<T extends string, P extends string>(
+  ctx: Context<T, P>,
   { arg, functionRef }: Expression
-): MessageValue {
+): MessageFallback | MessageString | MessageUnknownValue | MessageValue<T, P> {
   if (functionRef) {
     return resolveFunctionRef(ctx, arg, functionRef);
   }

--- a/mf2/messageformat/src/resolve/resolve-function-ref.ts
+++ b/mf2/messageformat/src/resolve/resolve-function-ref.ts
@@ -7,15 +7,16 @@ import type {
 import { MessageError } from '../errors.ts';
 import type { Context } from '../format-context.ts';
 import { fallback } from '../functions/fallback.ts';
-import { BIDI_ISOLATE } from '../message-value.ts';
+import type { MessageFallback } from '../functions/index.ts';
+import { BIDI_ISOLATE, type MessageValue } from '../message-value.ts';
 import { MessageFunctionContext } from './function-context.ts';
 import { getValueSource, resolveValue } from './resolve-value.ts';
 
-export function resolveFunctionRef(
-  ctx: Context,
+export function resolveFunctionRef<T extends string, P extends string>(
+  ctx: Context<T, P>,
   operand: Literal | VariableRef | undefined,
   { name, options }: FunctionRef
-) {
+): MessageValue<T, P> | MessageFallback {
   const source = getValueSource(operand) ?? `:${name}`;
   try {
     const fnInput = operand ? [resolveValue(ctx, operand)] : [];

--- a/mf2/messageformat/src/resolve/resolve-literal.ts
+++ b/mf2/messageformat/src/resolve/resolve-literal.ts
@@ -1,8 +1,9 @@
-import type { Context } from '../format-context.ts';
-import { MessageFunctionContext } from './function-context.ts';
 import type { Literal } from '../data-model/types.ts';
+import type { Context } from '../format-context.ts';
+import { string } from '../functions/string.ts';
+import { MessageFunctionContext } from './function-context.ts';
 
 export function resolveLiteral(ctx: Context, lit: Literal) {
   const msgCtx = new MessageFunctionContext(ctx, `|${lit.value}|`);
-  return ctx.functions.string(msgCtx, {}, lit.value);
+  return string(msgCtx, {}, lit.value);
 }

--- a/mf2/messageformat/src/resolve/resolve-variable.ts
+++ b/mf2/messageformat/src/resolve/resolve-variable.ts
@@ -78,13 +78,16 @@ export function lookupVariableRef(ctx: Context, { name }: VariableRef) {
   return value;
 }
 
-export function resolveVariableRef(ctx: Context, ref: VariableRef) {
+export function resolveVariableRef<T extends string, P extends string>(
+  ctx: Context<T, P>,
+  ref: VariableRef
+) {
   const source = '$' + ref.name;
   const value = lookupVariableRef(ctx, ref);
 
   let type = typeof value;
   if (type === 'object') {
-    const mv = value as MessageValue;
+    const mv = value as MessageValue<T, P>;
     if (mv.type === 'fallback') return fallback(source);
     if (ctx.localVars.has(mv)) return mv;
     if (value instanceof Number) type = 'number';

--- a/mf2/messageformat/src/spec.test.ts
+++ b/mf2/messageformat/src/spec.test.ts
@@ -12,7 +12,6 @@ import { TestFunctions } from './functions/test-functions.ts';
 import {
   MessageDataModelError,
   MessageFormat,
-  MessageFormatOptions,
   MessageSyntaxError,
   parseMessage,
   stringifyMessage,
@@ -21,16 +20,14 @@ import {
 } from './index.ts';
 
 const tests = (tc: Test) => () => {
-  const mfOpt: MessageFormatOptions = {
-    functions: { ...DraftFunctions, ...TestFunctions }
-  };
+  const functions = { ...DraftFunctions, ...TestFunctions };
   switch (testType(tc)) {
     case 'syntax-error':
       describe('syntax error', () => {
         test('MessageFormat(string)', () => {
-          expect(() => new MessageFormat(undefined, tc.src, mfOpt)).toThrow(
-            MessageSyntaxError
-          );
+          expect(
+            () => new MessageFormat(undefined, tc.src, { functions })
+          ).toThrow(MessageSyntaxError);
         });
         test('parseCST(string)', () => {
           const cst = parseCST(tc.src);
@@ -44,9 +41,9 @@ const tests = (tc: Test) => () => {
     case 'data-model-error':
       describe('data model error', () => {
         test('MessageFormat(string)', () => {
-          expect(() => new MessageFormat(undefined, tc.src, mfOpt)).toThrow(
-            MessageSyntaxError
-          );
+          expect(
+            () => new MessageFormat(undefined, tc.src, { functions })
+          ).toThrow(MessageSyntaxError);
         });
         test('parseCST(string)', () => {
           const cst = parseCST(tc.src);
@@ -65,7 +62,7 @@ const tests = (tc: Test) => () => {
     default:
       test('format', () => {
         let errors: any[] = [];
-        if (tc.bidiIsolation) mfOpt.bidiIsolation = tc.bidiIsolation;
+        const mfOpt = { bidiIsolation: tc.bidiIsolation, functions };
         const mf = new MessageFormat(tc.locale, tc.src, mfOpt);
         const msg = mf.format(tc.params, err => errors.push(err));
         if (typeof tc.exp === 'string') expect(msg).toBe(tc.exp);


### PR DESCRIPTION
These changes are preparing the project for a final 4.0 release:
- Drop MessageFormat.p.resolvedOptions (tc39/proposal-intl-messageformat#54)
- Parametrize formatter to discriminate formatted parts (Fixes #444)
- Use frozen null-prototype object for `DefaultFunctions` and `DraftFunctions`
- Do not allow for literal resolution to be customized
- Use type `text` rather than `literal` for formatted text parts
- fluent: Replace `getFluentFunctions` with `getMessageFunction`
- API docs updates