### PR TITLE
Refactor @messageformat/icu-messageformat-1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,5 +28,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci
-      - run: npm run build -w mf1/packages/parser
+      - run: npm run build -w mf1/packages/parser -w mf1/packages/date-skeleton -w mf1/packages/number-skeleton
       - run: npm run docs:mf2

--- a/mf2/icu-messageformat-1/README.md
+++ b/mf2/icu-messageformat-1/README.md
@@ -30,7 +30,8 @@ mf.format({ today: new Date('2022-02-02') });
 import {
   MF1Functions,
   mf1ToMessage,
-  mf1ToMessageData
+  mf1ToMessageData,
+  mf1Validate
 } from '@messageformat/icu-messageformat-1';
 ```
 

--- a/mf2/icu-messageformat-1/README.md
+++ b/mf2/icu-messageformat-1/README.md
@@ -28,7 +28,7 @@ mf.format({ today: new Date('2022-02-02') });
 
 ```js
 import {
-  getMF1Functions,
+  MF1Functions,
   mf1ToMessage,
   mf1ToMessageData
 } from '@messageformat/icu-messageformat-1';

--- a/mf2/icu-messageformat-1/package.json
+++ b/mf2/icu-messageformat-1/package.json
@@ -31,6 +31,8 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "@messageformat/date-skeleton": "^1.1.0",
+    "@messageformat/number-skeleton": "^1.2.0",
     "@messageformat/parser": "^5.0.0",
     "messageformat": "4.0.0-9"
   },

--- a/mf2/icu-messageformat-1/src/functions.ts
+++ b/mf2/icu-messageformat-1/src/functions.ts
@@ -20,6 +20,12 @@ const datetime: (
   operand?: unknown
 ) => MessageDateTime = DraftFunctions.datetime;
 
+const unit: (
+  ctx: MessageFunctionContext,
+  options: Record<string, unknown>,
+  operand?: unknown
+) => MessageNumber = DraftFunctions.unit;
+
 function duration(
   ctx: MessageFunctionContext,
   _options: unknown,
@@ -116,9 +122,7 @@ function plural(
 export let MF1Functions = {
   /**
    * A re-export of {@link DraftFunctions.currency},
-   * used for formatting a `number, currency` placeholder.
-   *
-   * Note that the currency code is set to `"XXX"`.
+   * used for formatting a `number, currency` and `number, ::currency` placeholder.
    */
   currency,
 
@@ -127,6 +131,12 @@ export let MF1Functions = {
    * used for formatting `date` and `time` placeholders.
    */
   datetime,
+
+  /**
+   * A re-export of {@link DraftFunctions.unit},
+   * used for formatting `number, ::measure-unit` and `number, ::unit` placeholders.
+   */
+  unit,
 
   /**
    * Formats a duration expressed as seconds.

--- a/mf2/icu-messageformat-1/src/functions.ts
+++ b/mf2/icu-messageformat-1/src/functions.ts
@@ -25,6 +25,8 @@ function currency(
   operand?: unknown
 ): MessageNumber {
   checkArgStyle(ctx, options);
+  const scale = Number(options['mf1:scale']);
+  if (scale && scale !== 1) operand = scale * Number(operand);
   return DraftFunctions.currency(ctx, options, operand);
 }
 
@@ -88,6 +90,8 @@ function number(
   operand?: unknown
 ): MessageNumber {
   checkArgStyle(ctx, options);
+  const scale = Number(options['mf1:scale']);
+  if (scale && scale !== 1) operand = scale * Number(operand);
   return DefaultFunctions.number(ctx, options, operand);
 }
 

--- a/mf2/icu-messageformat-1/src/index.ts
+++ b/mf2/icu-messageformat-1/src/index.ts
@@ -1,3 +1,4 @@
 export { MF1Functions } from './functions.ts';
 export { MF1Options, mf1ToMessage } from './mf1-to-message.ts';
 export { mf1ToMessageData } from './mf1-to-message-data.ts';
+export { mf1Validate } from './validate.ts';

--- a/mf2/icu-messageformat-1/src/index.ts
+++ b/mf2/icu-messageformat-1/src/index.ts
@@ -1,3 +1,3 @@
-export { getMF1Functions } from './functions.ts';
+export { MF1Functions } from './functions.ts';
 export { MF1Options, mf1ToMessage } from './mf1-to-message.ts';
 export { mf1ToMessageData } from './mf1-to-message-data.ts';

--- a/mf2/icu-messageformat-1/src/mf1-to-message.ts
+++ b/mf2/icu-messageformat-1/src/mf1-to-message.ts
@@ -6,6 +6,7 @@ import {
 } from 'messageformat';
 import { MF1Functions } from './functions.ts';
 import { mf1ToMessageData } from './mf1-to-message-data.ts';
+import { mf1Validate } from './validate.ts';
 
 export type MF1Options = {
   /** See {@link https://messageformat.github.io/messageformat/api/parser.parseoptions/ ParseOptions.strict} in @messageformat/parser */
@@ -15,9 +16,20 @@ export type MF1Options = {
 /**
  * Compile an ICU MessageFormat 1 message into a {@link MessageFormat} instance.
  *
+ * ```js
+ * import { mf1ToMessage } from '@messageformat/icu-messageformat-1';
+ *
+ * const msg = mf1ToMessage('The total is {V, number, currency}.', 'en');
+ * msg.format({ V: 4.2 });
+ * ```
+ *
+ * ```js
+ * 'The total is ¤4.20.' // 'XXX' is used as the default currency code.
+ * ```
+ *
  * @param source - An ICU MessageFormat message, either in its syntax representation,
  *   as an array of `@messageformat/parser` {@link https://messageformat.github.io/messageformat/api/parser.parse/ | AST tokens},
- *   or as a {@link MF.Message} data structure.
+ *   or as a {@link MF.Message | Model.Message} data structure.
  * @param locales - The locale to use for the message.
  * @param options - See {@link MF1Options} and {@link MessageFormatOptions}
  */
@@ -35,6 +47,7 @@ export function mf1ToMessage(
   } else {
     msg = source;
   }
+  mf1Validate(msg);
   opt.functions = opt.functions
     ? Object.assign(Object.create(null), MF1Functions, opt.functions)
     : MF1Functions;

--- a/mf2/icu-messageformat-1/src/mf1-to-message.ts
+++ b/mf2/icu-messageformat-1/src/mf1-to-message.ts
@@ -27,15 +27,15 @@ export type MF1Options = {
  * 'The total is ¤4.20.' // 'XXX' is used as the default currency code.
  * ```
  *
+ * @param locales - The locale to use for the message.
  * @param source - An ICU MessageFormat message, either in its syntax representation,
  *   as an array of `@messageformat/parser` {@link https://messageformat.github.io/messageformat/api/parser.parse/ | AST tokens},
  *   or as a {@link MF.Message | Model.Message} data structure.
- * @param locales - The locale to use for the message.
  * @param options - See {@link MF1Options} and {@link MessageFormatOptions}
  */
 export function mf1ToMessage(
+  locales: string | string[] | undefined,
   source: string | Token[] | MF.Message,
-  locales?: string | string[],
   { strict, ...opt }: MF1Options & MessageFormatOptions = {}
 ): MessageFormat {
   let msg: MF.Message;

--- a/mf2/icu-messageformat-1/src/mf1-to-message.ts
+++ b/mf2/icu-messageformat-1/src/mf1-to-message.ts
@@ -6,7 +6,6 @@ import {
 } from 'messageformat';
 import { MF1Functions } from './functions.ts';
 import { mf1ToMessageData } from './mf1-to-message-data.ts';
-import { mf1Validate } from './validate.ts';
 
 export type MF1Options = {
   /** See {@link https://messageformat.github.io/messageformat/api/parser.parseoptions/ ParseOptions.strict} in @messageformat/parser */
@@ -47,7 +46,6 @@ export function mf1ToMessage(
   } else {
     msg = source;
   }
-  mf1Validate(msg);
   opt.functions = opt.functions
     ? Object.assign(Object.create(null), MF1Functions, opt.functions)
     : MF1Functions;

--- a/mf2/icu-messageformat-1/src/mf1-to-message.ts
+++ b/mf2/icu-messageformat-1/src/mf1-to-message.ts
@@ -19,12 +19,12 @@ export type MF1Options = {
  * ```js
  * import { mf1ToMessage } from '@messageformat/icu-messageformat-1';
  *
- * const msg = mf1ToMessage('The total is {V, number, currency}.', 'en');
+ * const msg = mf1ToMessage('en', 'The total is {V, number, ::currency/EUR}.');
  * msg.format({ V: 4.2 });
  * ```
  *
  * ```js
- * 'The total is ¤4.20.' // 'XXX' is used as the default currency code.
+ * 'The total is €4.20.'
  * ```
  *
  * @param locales - The locale to use for the message.

--- a/mf2/icu-messageformat-1/src/mf1-to-message.ts
+++ b/mf2/icu-messageformat-1/src/mf1-to-message.ts
@@ -4,7 +4,7 @@ import {
   MessageFormat,
   MessageFormatOptions
 } from 'messageformat';
-import { getMF1Functions } from './functions.ts';
+import { MF1Functions } from './functions.ts';
 import { mf1ToMessageData } from './mf1-to-message-data.ts';
 
 export type MF1Options = {
@@ -14,8 +14,6 @@ export type MF1Options = {
 
 /**
  * Compile an ICU MessageFormat 1 message into a {@link MessageFormat} instance.
- *
- * A runtime provided by {@link getMF1Functions} is automatically used in these instances.
  *
  * @param source - An ICU MessageFormat message, either in its syntax representation,
  *   as an array of `@messageformat/parser` {@link https://messageformat.github.io/messageformat/api/parser.parse/ | AST tokens},
@@ -37,6 +35,8 @@ export function mf1ToMessage(
   } else {
     msg = source;
   }
-  opt.functions = Object.assign(getMF1Functions(), opt.functions);
+  opt.functions = opt.functions
+    ? Object.assign(Object.create(null), MF1Functions, opt.functions)
+    : MF1Functions;
   return new MessageFormat(locales, msg, opt);
 }

--- a/mf2/icu-messageformat-1/src/mf1.test.ts
+++ b/mf2/icu-messageformat-1/src/mf1.test.ts
@@ -348,10 +348,16 @@ export const testCases: Record<string, TestCase[]> = {
     },
     {
       src: 'The total is {V, number, currency}.',
-      exp: [[{ V: 5.5 }, 'The total is ¤5.50.']]
+      exp: [
+        [{ V: 5.5 }, { res: 'The total is {$V}.', errors: ['bad-operand'] }]
+      ]
     },
     {
       src: '{N, number, ::currency/GBP}',
+      exp: [[{ N: 42 }, '£42.00']]
+    },
+    {
+      src: '{N, number, ::foo}',
       exp: [[{ N: 42 }, { compileError: /argStyle/ }]]
     }
   ],
@@ -365,6 +371,17 @@ export const testCases: Record<string, TestCase[]> = {
       locale: 'fi',
       src: 'Kello on nyt {T, time}',
       exp: [[{ T: 978384385000 }, /^Kello on nyt \d\d?.\d\d.25/]]
+    }
+  ],
+
+  'Datetime skeletons': [
+    {
+      src: 'At {1,time,::jmm} on {1,date,::dMMMM}',
+      exp: [[{ 1: 978484385000 }, /^At \d\d?:\d\d\s(AM|PM) on January \d$/]]
+    },
+    {
+      src: "{1, date, ::EEE, MMM d, ''yy}",
+      exp: [[{ 1: 978484385000 }, { compileError: /argStyle/ }]]
     }
   ],
 

--- a/mf2/icu-messageformat-1/src/mf1.test.ts
+++ b/mf2/icu-messageformat-1/src/mf1.test.ts
@@ -342,6 +342,13 @@ export const testCases: Record<string, TestCase[]> = {
       // IE 11 may insert a space or non-breaking space before the % char
     },
     {
+      src: '{P, number, :: % scale/10}',
+      exp: [
+        [{ P: 1 }, /^10\D?%$/],
+        [{ P: 0.99 }, /^9.9\D?%$/]
+      ]
+    },
+    {
       src: 'The total is {V, number, currency}.',
       exp: [
         [{ V: 5.5 }, { res: 'The total is {$V}.', errors: ['bad-operand'] }]
@@ -350,6 +357,14 @@ export const testCases: Record<string, TestCase[]> = {
     {
       src: '{N, number, ::currency/GBP}',
       exp: [[{ N: 42 }, '£42.00']]
+    },
+    {
+      src: '{N, number, ::currency/GBP scale/0.01}',
+      exp: [[{ N: 4200 }, '£42.00']]
+    },
+    {
+      src: '{N, number, ::unit/meter-per-second scale/1}',
+      exp: [[{ N: 42 }, '42 m/s']]
     },
     {
       src: '{N, number, ::foo}',

--- a/mf2/icu-messageformat-1/src/mf1.test.ts
+++ b/mf2/icu-messageformat-1/src/mf1.test.ts
@@ -411,7 +411,7 @@ for (const [title, cases] of Object.entries(testCases)) {
             if (typeof res === 'string' || res instanceof RegExp) {
               errors = [];
             } else if ('compileError' in res) {
-              expect(() => mf1ToMessage(data, locale)).toThrow(
+              expect(() => mf1ToMessage(locale, data)).toThrow(
                 res.compileError
               );
               return;
@@ -420,7 +420,7 @@ for (const [title, cases] of Object.entries(testCases)) {
               res = res.res;
             }
 
-            const mf = mf1ToMessage(data, locale, { bidiIsolation: 'none' });
+            const mf = mf1ToMessage(locale, data, { bidiIsolation: 'none' });
             const onError = jest.fn();
             const msg = mf.format(
               param as Record<string, string | number | Date>,

--- a/mf2/icu-messageformat-1/src/validate.ts
+++ b/mf2/icu-messageformat-1/src/validate.ts
@@ -1,0 +1,46 @@
+import { type Model as MF, MessageError, visit } from 'messageformat';
+import { DefaultFunctions } from 'messageformat/functions';
+import { MF1Functions } from './functions.ts';
+
+/**
+ * Ensure that the `msg` data model does not contain any unsupported MF1 argType or argStyle references,
+ * calling `onError` on errors.
+ * If `onError` is not defined, a {@link MessageError} will be thrown on error.
+ */
+export function mf1Validate(
+  msg: MF.Message,
+  onError: (
+    type: 'unknown-function' | 'unsupported-operation',
+    expr: MF.Expression
+  ) => void = (type, expr) => {
+    const argTypeAttr = expr.attributes?.get('mf1:argType');
+    const argType =
+      argTypeAttr && argTypeAttr !== true
+        ? argTypeAttr.value
+        : expr.functionRef!.name.replace('mf1:', '');
+    if (type === 'unknown-function') {
+      throw new MessageError(type, `Unsupported MF1 argType: ${argType}`);
+    } else {
+      const opt = expr.functionRef!.options!.get('mf1:argStyle')!;
+      const argStyle = opt?.type === 'literal' ? opt.value : '�';
+      throw new MessageError(
+        type,
+        `Unsupported MF1 ${argType} argStyle: ${argStyle}`
+      );
+    }
+  }
+) {
+  visit(msg, {
+    expression(expr) {
+      if (expr.functionRef) {
+        const name = expr.functionRef.name;
+        if (!(name in DefaultFunctions) && !(name in MF1Functions)) {
+          onError('unknown-function', expr);
+        }
+        if (expr.functionRef.options?.has('mf1:argStyle')) {
+          onError('unsupported-operation', expr);
+        }
+      }
+    }
+  });
+}

--- a/mf2/messageformat/src/data-model/visit.ts
+++ b/mf2/messageformat/src/data-model/visit.ts
@@ -21,7 +21,7 @@ import type {
  * Visitors for nodes that contain other nodes may return a callback function
  * that will be called with no arguments when exiting the node.
  *
- * If set, the `node` visitor is called for all {@link Model.Node} values
+ * If set, the `node` visitor is called for all {@link Node} values
  * for which an explicit visitor is not defined.
  *
  * Many visitors will be called with additional arguments

--- a/mf2/messageformat/src/messageformat.ts
+++ b/mf2/messageformat/src/messageformat.ts
@@ -2,7 +2,7 @@ import { parseMessage } from './data-model/parse.ts';
 import type { Message } from './data-model/types.ts';
 import { validate } from './data-model/validate.ts';
 import { FSI, LRI, PDI, RLI, getLocaleDir } from './dir-utils.ts';
-import { MessageDataModelError, MessageError } from './errors.ts';
+import { MessageError } from './errors.ts';
 import type { Context } from './format-context.ts';
 import type { MessageFallbackPart, MessagePart } from './formatted-parts.ts';
 import { DefaultFunctions } from './functions/index.ts';
@@ -109,9 +109,7 @@ export class MessageFormat<T extends string = never, P extends string = T> {
         : [];
     this.#dir = options?.dir ?? getLocaleDir(this.#locales[0]);
     this.#message = typeof source === 'string' ? parseMessage(source) : source;
-    validate(this.#message, (type, node) => {
-      throw new MessageDataModelError(type, node);
-    });
+    validate(this.#message);
     this.#functions = options?.functions
       ? Object.assign(Object.create(null), DefaultFunctions, options.functions)
       : DefaultFunctions;

--- a/mf2/messageformat/src/mf2-features.test.ts
+++ b/mf2/messageformat/src/mf2-features.test.ts
@@ -1,6 +1,6 @@
 import { fluentToResource } from '@messageformat/fluent';
 import {
-  getMF1Functions,
+  MF1Functions,
   mf1ToMessage,
   mf1ToMessageData
 } from '@messageformat/icu-messageformat-1';
@@ -136,7 +136,7 @@ describe('Multi-selector messages (unicode-org/message-format-wg#119)', () => {
     expect(msg.selectors).toHaveLength(6);
     expect(msg.variants).toHaveLength(64);
 
-    const mf = new MessageFormat('en', msg, { functions: getMF1Functions() });
+    const mf = new MessageFormat('en', msg, { functions: MF1Functions });
 
     const one = mf.format({
       N: 1,

--- a/mf2/messageformat/src/mf2-features.test.ts
+++ b/mf2/messageformat/src/mf2-features.test.ts
@@ -88,7 +88,7 @@ describe('Multi-selector messages (unicode-org/message-format-wg#119)', () => {
     expect(msg.selectors).toHaveLength(4);
     expect(msg.variants).toHaveLength(81);
 
-    const mf = mf1ToMessage(msg, 'en');
+    const mf = mf1ToMessage('en', msg);
 
     const none = mf.format({
       poolCount: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,8 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@messageformat/date-skeleton": "^1.1.0",
+        "@messageformat/number-skeleton": "^1.2.0",
         "@messageformat/parser": "^5.0.0",
         "messageformat": "4.0.0-9"
       }


### PR DESCRIPTION
The accessor `getMF1Functions()` is replaced with a static `MF1Functions`, which contains an expanded set of MF1 compatibility functions; most of these wrap default or draft MF2 spec functions.

A validator `mf1Validate()` is provided. This is not run during `mf1ToMessage()`, though, as the functions now validate their options at runtime (this provides for better fallback).

MF1 syntax support is extended, so datetime & number skeletons + number patterns are now supported. As the MF2 option bags do not provide all of the same features, a best effort is made to match the input. The number format `scale/dddd` token is specifically supported, however, as it's often required for percentage formatting.