### PR TITLE
MF2 updates

### DIFF
--- a/mf2/fluent/README.md
+++ b/mf2/fluent/README.md
@@ -26,8 +26,7 @@ import { fluentToResource } from '@messageformat/fluent';
 const locale = 'en-US';
 const src = 'msg = Today is {DATETIME($today, dateStyle: "medium")}\n';
 
-const resource = fluentToResource(src, locale);
-
+const resource = fluentToResource(locale, src);
 const msg = resource.get('msg').get('');
 
 msg.format({ today: new Date('2022-02-02') });
@@ -35,12 +34,18 @@ msg.format({ today: new Date('2022-02-02') });
 
 msg.formatToParts({ today: new Date('2022-02-02') });
 // [
-//   MessageLiteral { type: 'literal', value: 'Today is ' },
-//   MessageDateTime {
+//   { type: 'text', value: 'Today is ' },
+//   {
 //     type: 'datetime',
-//     value: 2022-02-02T00:00:00.000Z,
-//     options: { localeMatcher: 'best fit', dateStyle: 'medium' },
-//     source: '$today :DATETIME'
+//     dir: 'ltr',
+//     locale: 'en',
+//     parts: [
+//       { type: 'month', value: 'Feb' },
+//       { type: 'literal', value: ' ' },
+//       { type: 'day', value: '2' },
+//       { type: 'literal', value: ', ' },
+//       { type: 'year', value: '2022' }
+//     ]
 //   }
 // ]
 ```

--- a/mf2/fluent/src/fluent-to-resource.ts
+++ b/mf2/fluent/src/fluent-to-resource.ts
@@ -38,6 +38,7 @@ export function fluentToResource(
   opt.functions = Object.assign(
     {
       currency: DraftFunctions.currency,
+      datetime: DraftFunctions.datetime,
       unit: DraftFunctions.unit,
       'fluent:message': getMessageFunction(res)
     },

--- a/mf2/fluent/src/fluent.test.ts
+++ b/mf2/fluent/src/fluent.test.ts
@@ -449,7 +449,6 @@ describe('formatToParts', () => {
         { type: 'text', value: 'Foo ' },
         {
           type: 'number',
-          source: '$num',
           dir: 'ltr',
           locale: 'en',
           parts: [{ type: 'integer', value: '42' }]
@@ -475,7 +474,6 @@ describe('formatToParts', () => {
       expect(bar).toMatchObject([
         {
           type: 'fluent-message',
-          source: '|foo|',
           parts: [
             { type: 'text', value: 'Foo ' },
             { type: 'bidiIsolation', value: '\u2068' },
@@ -582,7 +580,6 @@ describe('formatToParts', () => {
         { type: 'text', value: 'Foo ' },
         {
           type: 'number',
-          source: '$num',
           dir: 'ltr',
           locale: 'en',
           parts: [{ type: 'integer', value: '42' }]

--- a/mf2/fluent/src/functions.ts
+++ b/mf2/fluent/src/functions.ts
@@ -33,7 +33,6 @@ export interface MessageReferenceValue extends MessageValue<'fluent-message'> {
 export interface MessageReferencePart
   extends MessageExpressionPart<'fluent-message'> {
   type: 'fluent-message';
-  source: string;
   dir?: 'ltr' | 'rtl';
   parts: MessagePart<string>[];
 }
@@ -53,7 +52,7 @@ export const getMessageFunction = (res: FluentMessageResource) =>
     options: Record<string, unknown>,
     input?: unknown
   ): MessageReferenceValue {
-    const { onError, source } = ctx;
+    const { onError } = ctx;
     const locale = ctx.locales[0];
     const dir = ctx.dir ?? getLocaleDir(locale);
     const { msgId, msgAttr } = valueToMessageRef(input ? String(input) : '');
@@ -63,7 +62,7 @@ export const getMessageFunction = (res: FluentMessageResource) =>
     let str: string | undefined;
     return {
       type: 'fluent-message',
-      source,
+      source: ctx.source,
       dir,
       selectKey(keys) {
         str ??= mf.format(options, onError);
@@ -73,8 +72,8 @@ export const getMessageFunction = (res: FluentMessageResource) =>
         const parts = mf.formatToParts(options, onError);
         const res =
           dir === 'ltr' || dir === 'rtl'
-            ? { type: 'fluent-message' as const, source, dir, locale, parts }
-            : { type: 'fluent-message' as const, source, locale, parts };
+            ? { type: 'fluent-message' as const, dir, locale, parts }
+            : { type: 'fluent-message' as const, locale, parts };
         return [res];
       },
       toString: () => (str ??= mf.format(options, onError)),

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -38,11 +38,10 @@ export interface MessageBiDiIsolationPart {
  */
 export interface MessageExpressionPart<P extends string> {
   type: P;
-  source: string;
   dir?: 'ltr' | 'rtl';
   locale?: string;
   id?: string;
-  parts?: Array<{ type: string; source?: string; value?: unknown }>;
+  parts?: Array<{ type: string; value?: unknown }>;
   value?: unknown;
 }
 

--- a/mf2/messageformat/src/formatted-parts.ts
+++ b/mf2/messageformat/src/formatted-parts.ts
@@ -60,7 +60,6 @@ export interface MessageTextPart {
 export interface MessageMarkupPart {
   type: 'markup';
   kind: 'open' | 'standalone' | 'close';
-  source: string;
   name: string;
   id?: string;
   options?: { [key: string]: unknown };

--- a/mf2/messageformat/src/functions/datetime.ts
+++ b/mf2/messageformat/src/functions/datetime.ts
@@ -31,7 +31,6 @@ export interface MessageDateTime extends MessageValue<'datetime'> {
  */
 export interface MessageDateTimePart extends MessageExpressionPart<'datetime'> {
   type: 'datetime';
-  source: string;
   locale: string;
   parts: Intl.DateTimeFormatPart[];
 }
@@ -176,7 +175,7 @@ function dateTimeImplementation(
   input: unknown,
   parseOptions: (res: Record<string, unknown>) => void
 ): MessageDateTime {
-  const { localeMatcher, locales, source } = ctx;
+  const { localeMatcher, locales } = ctx;
   const opt: Intl.DateTimeFormatOptions = { localeMatcher };
   if (input && typeof input === 'object') {
     if (input && 'options' in input) Object.assign(opt, input.options);
@@ -197,7 +196,7 @@ function dateTimeImplementation(
   }
   if (!(value instanceof Date) || isNaN(value.getTime())) {
     const msg = 'Input is not a date';
-    throw new MessageResolutionError('bad-operand', msg, source);
+    throw new MessageResolutionError('bad-operand', msg, ctx.source);
   }
 
   parseOptions(opt as Record<string, unknown>);
@@ -209,7 +208,7 @@ function dateTimeImplementation(
   let str: string | undefined;
   return {
     type: 'datetime',
-    source,
+    source: ctx.source,
     get dir() {
       if (dir == null) {
         locale ??= Intl.DateTimeFormat.supportedLocalesOf(locales, opt)[0];
@@ -226,8 +225,8 @@ function dateTimeImplementation(
       locale ??= dtf.resolvedOptions().locale;
       dir ??= getLocaleDir(locale);
       return dir === 'ltr' || dir === 'rtl'
-        ? [{ type: 'datetime', source, dir, locale, parts }]
-        : [{ type: 'datetime', source, locale, parts }];
+        ? [{ type: 'datetime', dir, locale, parts }]
+        : [{ type: 'datetime', locale, parts }];
     },
     toString() {
       dtf ??= new Intl.DateTimeFormat(locales, opt);

--- a/mf2/messageformat/src/functions/number.ts
+++ b/mf2/messageformat/src/functions/number.ts
@@ -42,7 +42,6 @@ export interface MessageNumber extends MessageValue<'number'> {
  */
 export interface MessageNumberPart extends MessageExpressionPart<'number'> {
   type: 'number';
-  source: string;
   locale: string;
   parts: Intl.NumberFormatPart[];
 }
@@ -82,7 +81,7 @@ export function getMessageNumber(
   options: MessageNumberOptions,
   canSelect: boolean
 ): MessageNumber {
-  let { dir, locales, source } = ctx;
+  let { dir, locales } = ctx;
   // @ts-expect-error We may have been a bit naughty earlier.
   if (options.useGrouping === 'never') options.useGrouping = false;
   if (
@@ -91,7 +90,7 @@ export function getMessageNumber(
     !ctx.literalOptionKeys.has('select')
   ) {
     const msg = 'The option select may only be set by a literal value';
-    ctx.onError(new MessageResolutionError('bad-option', msg, source));
+    ctx.onError(new MessageResolutionError('bad-option', msg, ctx.source));
     canSelect = false;
   }
 
@@ -101,7 +100,7 @@ export function getMessageNumber(
   let str: string | undefined;
   return {
     type: 'number',
-    source,
+    source: ctx.source,
     get dir() {
       if (dir == null) {
         locale ??= Intl.NumberFormat.supportedLocalesOf(locales, options)[0];
@@ -133,8 +132,8 @@ export function getMessageNumber(
       locale ??= nf.resolvedOptions().locale;
       dir ??= getLocaleDir(locale);
       return dir === 'ltr' || dir === 'rtl'
-        ? [{ type: 'number', source, dir, locale, parts }]
-        : [{ type: 'number', source, locale, parts }];
+        ? [{ type: 'number', dir, locale, parts }]
+        : [{ type: 'number', locale, parts }];
     },
     toString() {
       nf ??= new Intl.NumberFormat(locales, options);

--- a/mf2/messageformat/src/functions/string.ts
+++ b/mf2/messageformat/src/functions/string.ts
@@ -23,7 +23,6 @@ export interface MessageString extends MessageValue<'string'> {
  */
 export interface MessageStringPart extends MessageExpressionPart<'string'> {
   type: 'string';
-  source: string;
   locale: string;
   value: string;
 }
@@ -41,11 +40,11 @@ export function string(
     dir: ctx.dir ?? 'auto',
     selectKey: keys => (keys.has(selStr) ? selStr : null),
     toParts() {
-      const { dir, source } = ctx;
+      const { dir } = ctx;
       const locale = ctx.locales[0];
       return dir === 'ltr' || dir === 'rtl'
-        ? [{ type: 'string', source, dir, locale, value: str }]
-        : [{ type: 'string', source, locale, value: str }];
+        ? [{ type: 'string', dir, locale, value: str }]
+        : [{ type: 'string', locale, value: str }];
     },
     toString: () => str,
     valueOf: () => str

--- a/mf2/messageformat/src/functions/test-functions.ts
+++ b/mf2/messageformat/src/functions/test-functions.ts
@@ -118,7 +118,7 @@ function testFunction(
       ? () => {
           if (opt.failsFormat) throw new Error('Formatting failed');
           const parts = Array.from(testParts(value, opt.decimalPlaces));
-          return [{ type: 'test', source, locale: 'und', parts }];
+          return [{ type: 'test', locale: 'und', parts }];
         }
       : undefined,
     toString: opt.canFormat

--- a/mf2/messageformat/src/functions/unit.ts
+++ b/mf2/messageformat/src/functions/unit.ts
@@ -15,8 +15,7 @@ export function unit(
   exprOpt: Record<string | symbol, unknown>,
   operand?: unknown
 ): MessageNumber {
-  const { source } = ctx;
-  const input = readNumericOperand(operand, source);
+  const input = readNumericOperand(operand, ctx.source);
   const options: MessageNumberOptions = Object.assign({}, input.options, {
     localeMatcher: ctx.localeMatcher,
     style: 'unit'
@@ -51,14 +50,14 @@ export function unit(
         ctx.onError(error);
       } else {
         const msg = `Value ${optval} is not valid for :currency option ${name}`;
-        ctx.onError(new MessageResolutionError('bad-option', msg, source));
+        ctx.onError(new MessageResolutionError('bad-option', msg, ctx.source));
       }
     }
   }
 
   if (!options.unit) {
     const msg = 'A unit identifier is required for :unit';
-    throw new MessageResolutionError('bad-operand', msg, source);
+    throw new MessageResolutionError('bad-operand', msg, ctx.source);
   }
 
   return getMessageNumber(ctx, input.value, options, false);

--- a/mf2/messageformat/src/functions/unknown.ts
+++ b/mf2/messageformat/src/functions/unknown.ts
@@ -13,7 +13,6 @@ export interface MessageUnknownValue extends MessageValue<'unknown'> {
 /** @category Formatted Parts */
 export interface MessageUnknownPart extends MessageExpressionPart<'unknown'> {
   type: 'unknown';
-  source: string;
   value: unknown;
 }
 
@@ -24,7 +23,7 @@ export const unknown = (
   type: 'unknown',
   source,
   dir: 'auto',
-  toParts: () => [{ type: 'unknown', source, value: input }],
+  toParts: () => [{ type: 'unknown', value: input }],
   toString: () => String(input),
   valueOf: () => input
 });

--- a/mf2/messageformat/src/messageformat.ts
+++ b/mf2/messageformat/src/messageformat.ts
@@ -193,12 +193,11 @@ export class MessageFormat<T extends string = never, P extends string = T> {
    * [
    *   { type: 'text', value: 'Hello ' },
    *   { type: 'bidiIsolation', value: '\u2068' },
-   *   { type: 'string', source: '$user.name', locale: 'en', value: 'Kat' },
+   *   { type: 'string', locale: 'en', value: 'Kat' },
    *   { type: 'bidiIsolation', value: '\u2069' },
    *   { type: 'text', value: ', today is ' },
    *   {
    *     type: 'datetime',
-   *     source: '$date',
    *     dir: 'ltr',
    *     locale: 'en',
    *     parts: [

--- a/mf2/messageformat/src/mf2-features.test.ts
+++ b/mf2/messageformat/src/mf2-features.test.ts
@@ -37,7 +37,7 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
         const rc = pr.select(end);
         return keys.has(rc) ? rc : null;
       },
-      toParts: () => [{ type: 'range', source, value }],
+      toParts: () => [{ type: 'range', value }],
       toString: () => value
     };
   }
@@ -58,7 +58,7 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
     expect(msg1).toBe('0 - 1 dag');
     const parts1 = mf.formatToParts({ range: { start: 0, end: 1 } });
     expect(parts1).toEqual([
-      { type: 'range', source: '$range', value: '0 - 1' },
+      { type: 'range', value: '0 - 1' },
       { type: 'text', value: ' dag' }
     ]);
 
@@ -66,7 +66,7 @@ describe('Plural Range Selectors & Range Formatters (unicode-org/message-format-
     expect(msg2).toBe('1 - 2 dagen');
     const parts2 = mf.formatToParts({ range: { start: 1, end: 2 } });
     expect(parts2).toEqual([
-      { type: 'range', source: '$range', value: '1 - 2' },
+      { type: 'range', value: '1 - 2' },
       { type: 'text', value: ' dagen' }
     ]);
   });
@@ -230,8 +230,7 @@ maybe('List formatting', () => {
         type: 'list',
         source,
         dir: 'ltr',
-        toParts: () =>
-          lf.formatToParts(list).map(part => Object.assign(part, { source })),
+        toParts: () => lf.formatToParts(list),
         toString: () => lf.format(list)
       };
     };
@@ -328,11 +327,11 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     expect(parts).toEqual([
       { type: 'text', value: 'A ' },
       { type: 'bidiIsolation', value: '\u2068' },
-      { type: 'string', locale: 'en', source: '$foo', value: 'foo' },
+      { type: 'string', locale: 'en', value: 'foo' },
       { type: 'bidiIsolation', value: '\u2069' },
       { type: 'text', value: ' and an ' },
       { type: 'bidiIsolation', value: '\u2068' },
-      { type: 'string', locale: 'en', source: '$other', value: 'other' },
+      { type: 'string', locale: 'en', value: 'other' },
       { type: 'bidiIsolation', value: '\u2069' }
     ]);
   });
@@ -345,9 +344,9 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
       { type: 'text', value: 'An ' },
-      { type: 'string', locale: 'en', source: '$foo', value: 'other' },
+      { type: 'string', locale: 'en', value: 'other' },
       { type: 'text', value: ' and a ' },
-      { type: 'string', locale: 'en', source: '$other', value: 'foo' }
+      { type: 'string', locale: 'en', value: 'foo' }
     ]);
   });
 
@@ -359,9 +358,9 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
       { type: 'text', value: 'The ' },
-      { type: 'string', locale: 'en', source: '$foo', value: 'foo' },
+      { type: 'string', locale: 'en', value: 'foo' },
       { type: 'text', value: ' and lotsa ' },
-      { type: 'string', locale: 'en', source: '$other', value: 'other' }
+      { type: 'string', locale: 'en', value: 'other' }
     ]);
   });
 
@@ -372,11 +371,11 @@ describe('Neighbouring text transformations (unicode-org/message-format-wg#160)'
     const parts = mf.formatToParts({ foo: 'An', other: 'other' });
     hackyFixArticles(['en'], parts);
     expect(parts).toEqual([
-      { type: 'string', locale: 'en', source: '$foo', value: 'A' },
+      { type: 'string', locale: 'en', value: 'A' },
       { type: 'text', value: ' foo and an ' },
-      { type: 'string', locale: 'en', source: '|...|', value: '...' },
+      { type: 'string', locale: 'en', value: '...' },
       { type: 'text', value: ' ' },
-      { type: 'string', locale: 'en', source: '$other', value: 'other' }
+      { type: 'string', locale: 'en', value: 'other' }
     ]);
   });
 });

--- a/mf2/messageformat/src/resolve/format-markup.ts
+++ b/mf2/messageformat/src/resolve/format-markup.ts
@@ -8,9 +8,7 @@ export function formatMarkup(
   ctx: Context,
   { kind, name, options }: Markup
 ): MessageMarkupPart {
-  const source =
-    kind === 'close' ? `/${name}` : kind === 'open' ? `#${name}` : `#${name}/`;
-  const part: MessageMarkupPart = { type: 'markup', kind, source, name };
+  const part: MessageMarkupPart = { type: 'markup', kind, name };
   if (options?.size) {
     part.options = {};
     for (const [name, value] of options) {

--- a/mf2/messageformat/src/resolve/function-ref.test.ts
+++ b/mf2/messageformat/src/resolve/function-ref.test.ts
@@ -11,7 +11,7 @@ test('Custom function', () => {
     source,
     dir: dir ?? 'auto',
     locale,
-    toParts: () => [{ type: 'custom', source, locale, value: `part:${input}` }],
+    toParts: () => [{ type: 'custom', locale, value: `part:${input}` }],
     toString: () => `str:${input}`
   });
   const mf = new MessageFormat('en', '{$var :custom}', {
@@ -20,7 +20,7 @@ test('Custom function', () => {
   expect(mf.format({ var: 42 })).toEqual('\u2068str:42\u2069');
   expect(mf.formatToParts({ var: 42 })).toEqual([
     { type: 'bidiIsolation', value: '\u2068' },
-    { type: 'custom', source: '$var', locale: 'en', value: 'part:42' },
+    { type: 'custom', locale: 'en', value: 'part:42' },
     { type: 'bidiIsolation', value: '\u2069' }
   ]);
 });

--- a/mf2/messageformat/src/resolve/markup.test.ts
+++ b/mf2/messageformat/src/resolve/markup.test.ts
@@ -27,7 +27,7 @@ describe('Simple open/close', () => {
       },
       { type: 'text', value: 'foo' },
       { type: 'bidiIsolation', value: '\u2068' },
-      { type: 'string', source: '$foo', locale: 'en', value: 'foo bar' },
+      { type: 'string', locale: 'en', value: 'foo bar' },
       { type: 'bidiIsolation', value: '\u2069' },
       { type: 'markup', kind: 'close', name: 'b', options: { foo: ' bar 13 ' } }
     ]);

--- a/mf2/messageformat/src/resolve/markup.test.ts
+++ b/mf2/messageformat/src/resolve/markup.test.ts
@@ -5,9 +5,9 @@ describe('Simple open/close', () => {
   test('no options, literal body', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{/b}');
     expect(mf.formatToParts()).toEqual([
-      { type: 'markup', kind: 'open', source: '#b', name: 'b' },
+      { type: 'markup', kind: 'open', name: 'b' },
       { type: 'text', value: 'foo' },
-      { type: 'markup', kind: 'close', source: '/b', name: 'b' }
+      { type: 'markup', kind: 'close', name: 'b' }
     ]);
     expect(mf.format()).toBe('foo');
   });
@@ -23,20 +23,13 @@ describe('Simple open/close', () => {
         type: 'markup',
         kind: 'open',
         options: { foo: '42', bar: 'foo bar' },
-        source: '#b',
         name: 'b'
       },
       { type: 'text', value: 'foo' },
       { type: 'bidiIsolation', value: '\u2068' },
       { type: 'string', source: '$foo', locale: 'en', value: 'foo bar' },
       { type: 'bidiIsolation', value: '\u2069' },
-      {
-        type: 'markup',
-        kind: 'close',
-        source: '/b',
-        name: 'b',
-        options: { foo: ' bar 13 ' }
-      }
+      { type: 'markup', kind: 'close', name: 'b', options: { foo: ' bar 13 ' } }
     ]);
     expect(mf.format({ foo: 'foo bar' })).toBe('foo\u2068foo bar\u2069');
   });
@@ -64,12 +57,12 @@ describe('Multiple open/close', () => {
   test('adjacent', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{/b}{#a}bar{/a}');
     expect(mf.formatToParts()).toEqual([
-      { type: 'markup', kind: 'open', source: '#b', name: 'b' },
+      { type: 'markup', kind: 'open', name: 'b' },
       { type: 'text', value: 'foo' },
-      { type: 'markup', kind: 'close', source: '/b', name: 'b' },
-      { type: 'markup', kind: 'open', source: '#a', name: 'a' },
+      { type: 'markup', kind: 'close', name: 'b' },
+      { type: 'markup', kind: 'open', name: 'a' },
       { type: 'text', value: 'bar' },
-      { type: 'markup', kind: 'close', source: '/a', name: 'a' }
+      { type: 'markup', kind: 'close', name: 'a' }
     ]);
     expect(mf.format()).toBe('foobar');
   });
@@ -77,12 +70,12 @@ describe('Multiple open/close', () => {
   test('nested', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{#a}bar{/a}{/b}');
     expect(mf.formatToParts()).toEqual([
-      { type: 'markup', kind: 'open', source: '#b', name: 'b' },
+      { type: 'markup', kind: 'open', name: 'b' },
       { type: 'text', value: 'foo' },
-      { type: 'markup', kind: 'open', source: '#a', name: 'a' },
+      { type: 'markup', kind: 'open', name: 'a' },
       { type: 'text', value: 'bar' },
-      { type: 'markup', kind: 'close', source: '/a', name: 'a' },
-      { type: 'markup', kind: 'close', source: '/b', name: 'b' }
+      { type: 'markup', kind: 'close', name: 'a' },
+      { type: 'markup', kind: 'close', name: 'b' }
     ]);
     expect(mf.format()).toBe('foobar');
   });
@@ -90,13 +83,13 @@ describe('Multiple open/close', () => {
   test('overlapping', () => {
     const mf = new MessageFormat(undefined, '{#b}foo{#a}bar{/b}baz{/a}');
     expect(mf.formatToParts()).toEqual([
-      { type: 'markup', kind: 'open', source: '#b', name: 'b' },
+      { type: 'markup', kind: 'open', name: 'b' },
       { type: 'text', value: 'foo' },
-      { type: 'markup', kind: 'open', source: '#a', name: 'a' },
+      { type: 'markup', kind: 'open', name: 'a' },
       { type: 'text', value: 'bar' },
-      { type: 'markup', kind: 'close', source: '/b', name: 'b' },
+      { type: 'markup', kind: 'close', name: 'b' },
       { type: 'text', value: 'baz' },
-      { type: 'markup', kind: 'close', source: '/a', name: 'a' }
+      { type: 'markup', kind: 'close', name: 'a' }
     ]);
     expect(mf.format()).toBe('foobarbaz');
   });

--- a/mf2/messageformat/src/resolve/variable.test.ts
+++ b/mf2/messageformat/src/resolve/variable.test.ts
@@ -11,7 +11,6 @@ describe('variables', () => {
     expect(mf.formatToParts({ val: 42 })).toEqual([
       {
         type: 'number',
-        source: '$val',
         dir: 'ltr',
         locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
@@ -25,7 +24,6 @@ describe('variables', () => {
     expect(mf.formatToParts({ val })).toEqual([
       {
         type: 'number',
-        source: '$val',
         dir: 'ltr',
         locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
@@ -39,7 +37,6 @@ describe('variables', () => {
     expect(mf.formatToParts({ val })).toEqual([
       {
         type: 'number',
-        source: '$val',
         dir: 'ltr',
         locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
@@ -51,7 +48,7 @@ describe('variables', () => {
     const val = { valueOf: () => BigInt(42) };
     expect(mf.formatToParts({ val })).toEqual([
       { type: 'bidiIsolation', value: '\u2068' },
-      { type: 'unknown', source: '$val', value: val },
+      { type: 'unknown', value: val },
       { type: 'bidiIsolation', value: '\u2069' }
     ]);
   });
@@ -64,7 +61,6 @@ describe('variables', () => {
     expect(mf.formatToParts({ val })).toEqual([
       {
         type: 'number',
-        source: '$val',
         dir: 'ltr',
         locale: 'en',
         parts: [
@@ -87,7 +83,6 @@ describe('Variable paths', () => {
     expect(mf.formatToParts({ 'user.name': 42 })).toEqual([
       {
         type: 'number',
-        source: '$user.name',
         dir: 'ltr',
         locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
@@ -99,7 +94,6 @@ describe('Variable paths', () => {
     expect(mf.formatToParts({ user: { name: 42 } })).toEqual([
       {
         type: 'number',
-        source: '$user.name',
         dir: 'ltr',
         locale: 'en',
         parts: [{ type: 'integer', value: '42' }]
@@ -111,7 +105,6 @@ describe('Variable paths', () => {
     expect(mf.formatToParts({ user: { name: 13 }, 'user.name': 42 })).toEqual([
       {
         type: 'number',
-        source: '$user.name',
         dir: 'ltr',
         locale: 'en',
         parts: [{ type: 'integer', value: '42' }]

--- a/mf2/messageformat/src/spec.test.ts
+++ b/mf2/messageformat/src/spec.test.ts
@@ -19,6 +19,8 @@ import {
   visit
 } from './index.ts';
 
+const skipTags = new Set(['u:locale']);
+
 const tests = (tc: Test) => () => {
   const functions = { ...DraftFunctions, ...TestFunctions };
   switch (testType(tc)) {
@@ -121,7 +123,12 @@ const tests = (tc: Test) => () => {
 for (const scenario of testScenarios('test/messageformat-wg/test/tests')) {
   describe(scenario.scenario, () => {
     for (const tc of testCases(scenario)) {
-      (tc.only ? describe.only : describe)(testName(tc), tests(tc));
+      const describe_ = tc.only
+        ? describe.only
+        : tc.tags?.some(tag => skipTags.has(tag))
+          ? describe.skip
+          : describe;
+      describe_(testName(tc), tests(tc));
     }
   });
 }

--- a/test/utils/mfwg-test-utils.ts
+++ b/test/utils/mfwg-test-utils.ts
@@ -135,17 +135,14 @@ type ExpPart =
   | {
       type: 'markup';
       kind: 'open' | 'standalone' | 'close';
-      source?: string;
       name: string;
       options?: Record<string, unknown>;
     }
   | {
       type: string;
-      source: string;
       locale?: string;
       parts?: {
         type: string;
-        source?: string;
         value?: unknown;
         [k: string]: unknown;
       }[];

--- a/test/utils/mfwg-test-utils.ts
+++ b/test/utils/mfwg-test-utils.ts
@@ -93,6 +93,9 @@ type DefaultTestProperties = {
     | { name: string; type: 'datetime'; value: string }
   >;
 
+  /** List of features that the test relies on. */
+  tags?: string[];
+
   /** The expected result of formatting the message to a string. */
   exp?: string;
 


### PR DESCRIPTION
These changes are preparing the project for a final 4.0 release:
- unicode-org/message-format-wg#1050
- unicode-org/message-format-wg#1061
- `@messageformat/fluent`: Add datetime to functions, fix docs example