### PR TITLE
fix: make the data-model data

### DIFF
--- a/mf2/fluent/src/fluent-to-message.ts
+++ b/mf2/fluent/src/fluent-to-message.ts
@@ -129,18 +129,18 @@ function asExpression(exp: Fluent.Expression): MF.Expression {
         throw new Error(`More than one positional argument is not supported.`);
       }
       if (named.length > 0) {
-        annotation.options = new Map();
+        annotation.options = {}
         for (const { name, value } of named) {
           const quoted = value.type !== 'NumberLiteral';
           const litValue = quoted ? value.parse().value : value.value;
-          annotation.options.set(name.name, {
+          annotation.options[name.name] = {
             type: 'literal',
             value: litValue
-          });
+          };
         }
       }
       if (annotation.name === 'number') {
-        const style = annotation.options?.get('style');
+        const style = annotation.options?.style;
         if (style?.type === 'literal') {
           switch (style.value) {
             case 'decimal':
@@ -154,7 +154,7 @@ function asExpression(exp: Fluent.Expression): MF.Expression {
                 `Unsupported NUMBER(..., style=${JSON.stringify(style.value)})`
               );
           }
-          annotation.options!.delete('style');
+          delete annotation.options!.style;
         }
       }
       return args.length > 0
@@ -180,14 +180,14 @@ function asExpression(exp: Fluent.Expression): MF.Expression {
         ? `-${exp.id.name}.${exp.attribute.name}`
         : `-${exp.id.name}`;
       if (exp.arguments?.named.length) {
-        annotation.options = new Map();
+        annotation.options = {};
         for (const { name, value } of exp.arguments.named) {
           const quoted = value.type !== 'NumberLiteral';
           const litValue = quoted ? value.parse().value : value.value;
-          annotation.options.set(name.name, {
+          annotation.options[name.name] = {
             type: 'literal',
             value: litValue
-          });
+          };
         }
       }
       return {

--- a/mf2/fluent/src/fluent-to-message.ts
+++ b/mf2/fluent/src/fluent-to-message.ts
@@ -129,7 +129,7 @@ function asExpression(exp: Fluent.Expression): MF.Expression {
         throw new Error(`More than one positional argument is not supported.`);
       }
       if (named.length > 0) {
-        annotation.options = {}
+        annotation.options = {};
         for (const { name, value } of named) {
           const quoted = value.type !== 'NumberLiteral';
           const litValue = quoted ? value.parse().value : value.value;

--- a/mf2/fluent/src/message-to-fluent.ts
+++ b/mf2/fluent/src/message-to-fluent.ts
@@ -151,9 +151,10 @@ function functionRefToFluent(
 ): Fluent.InlineExpression {
   const args = new Fluent.CallArguments();
   if (arg) args.positional[0] = arg;
-  if (Object.keys(options || {}).length) {
+  const entries = options ? Object.entries(options) : null;
+  if (entries?.length) {
     args.named = [];
-    for (const [name, value] of Object.entries(options || {})) {
+    for (const [name, value] of entries) {
       if (name === 'u:dir' || name === 'u:locale') {
         throw new Error(`The option "${name}" is not supported in Fluent`);
       }

--- a/mf2/fluent/src/message-to-fluent.ts
+++ b/mf2/fluent/src/message-to-fluent.ts
@@ -151,9 +151,9 @@ function functionRefToFluent(
 ): Fluent.InlineExpression {
   const args = new Fluent.CallArguments();
   if (arg) args.positional[0] = arg;
-  if (options?.size) {
+  if (Object.keys(options || {}).length) {
     args.named = [];
-    for (const [name, value] of options) {
+    for (const [name, value] of Object.entries(options || {})) {
       if (name === 'u:dir' || name === 'u:locale') {
         throw new Error(`The option "${name}" is not supported in Fluent`);
       }

--- a/mf2/icu-messageformat-1/src/mf1-to-message-data.ts
+++ b/mf2/icu-messageformat-1/src/mf1-to-message-data.ts
@@ -52,20 +52,20 @@ function findSelectArgs(tokens: AST.Token[]): SelectArg[] {
 
 function parseNumberArgStyle(argStyle: string): MF.FunctionRef {
   let name = 'number';
-  const options: MF.Options = new Map();
+  const options: MF.Options = {};
   const onError = () => {
     if (name === 'number') name = 'mf1:number';
-    options.set('mf1:argStyle', { type: 'literal', value: argStyle });
+    options['mf1:argStyle'] = { type: 'literal', value: argStyle };
   };
   const skeleton = argStyle.startsWith('::')
     ? parseNumberSkeleton(argStyle.substring(2), onError)
     : parseNumberPattern(argStyle, 'XXX', onError);
   const nfOpt = getNumberFormatOptions(skeleton, (stem, option) => {
     if (stem === 'scale') {
-      options.set('mf1:scale', { type: 'literal', value: String(option) });
+      options['mf1:scale'] = { type: 'literal', value: String(option) };
       if (skeleton.unit?.style === 'percent') {
         name = 'mf1:unit';
-        options.set('unit', { type: 'literal', value: 'percent' });
+        options['unit'] = { type: 'literal', value: 'percent' };
       } else if (name === 'number') {
         name = 'mf1:number';
       }
@@ -93,7 +93,7 @@ function parseNumberArgStyle(argStyle: string): MF.FunctionRef {
             name = 'mf1:unit';
             key = 'mf1:scale';
             value = '100';
-            if (options.has(key)) continue loop;
+            if (Object.hasOwn(options, key)) continue loop;
             break;
           case 'unit':
             name = 'mf1:unit';
@@ -106,7 +106,7 @@ function parseNumberArgStyle(argStyle: string): MF.FunctionRef {
         if (value === false) value = 'never';
         break;
     }
-    options.set(key, { type: 'literal', value });
+    options[key] = { type: 'literal', value };
   }
   return { type: 'function', name, options };
 }
@@ -115,9 +115,9 @@ function tokenToFunctionRef(token: AST.FunctionArg): {
   functionRef: MF.FunctionRef;
   attributes: MF.Attributes;
 } {
-  const attributes: MF.Attributes = new Map([
-    ['mf1:argType', { type: 'literal', value: token.key }]
-  ]);
+  const attributes: MF.Attributes = {
+    'mf1:argType': { type: 'literal', value: token.key }
+  };
   let argStyle = '';
   if (token.param) {
     for (const pt of token.param) {
@@ -125,29 +125,29 @@ function tokenToFunctionRef(token: AST.FunctionArg): {
       else throw new Error(`Unsupported param type: ${pt.type}`);
     }
     argStyle = argStyle.trim();
-    attributes.set('mf1:argStyle', { type: 'literal', value: argStyle });
+    attributes['mf1:argStyle'] = { type: 'literal', value: argStyle };
   }
 
   switch (token.key) {
     case 'date': {
-      const options: MF.Options = new Map();
+      const options: MF.Options = {};
       switch (argStyle) {
         case '':
           break;
         case 'full':
-          options.set('fields', {
+          options['fields'] = {
             type: 'literal',
             value: 'year-month-day-weekday'
-          });
-          options.set('length', { type: 'literal', value: 'long' });
+          };
+          options['length'] = { type: 'literal', value: 'long' };
           break;
         case 'long':
         case 'medium':
         case 'short':
-          options.set('length', { type: 'literal', value: argStyle });
+          options['length'] = { type: 'literal', value: argStyle };
           break;
         default:
-          options.set('mf1:argStyle', { type: 'literal', value: argStyle });
+          options['mf1:argStyle'] = { type: 'literal', value: argStyle };
       }
       return {
         functionRef: { type: 'function', name: 'mf1:date', options },
@@ -172,10 +172,10 @@ function tokenToFunctionRef(token: AST.FunctionArg): {
             functionRef: {
               type: 'function',
               name: 'mf1:unit',
-              options: new Map([
-                ['unit', { type: 'literal', value: 'percent' }],
-                ['mf1:scale', { type: 'literal', value: '100' }]
-              ])
+              options: {
+                unit: { type: 'literal', value: 'percent' },
+                'mf1:scale': { type: 'literal', value: '100' }
+              }
             },
             attributes
           };
@@ -189,25 +189,25 @@ function tokenToFunctionRef(token: AST.FunctionArg): {
       }
 
     case 'time': {
-      const options: MF.Options = new Map();
+      const options: MF.Options = {};
       switch (argStyle) {
         case 'full':
-          options.set('precision', { type: 'literal', value: 'second' });
-          options.set('timeZoneName', { type: 'literal', value: 'long' });
+          options['precision'] = { type: 'literal', value: 'second' };
+          options['timeZoneName'] = { type: 'literal', value: 'long' };
           break;
         case 'long':
-          options.set('precision', { type: 'literal', value: 'second' });
-          options.set('timeZoneName', { type: 'literal', value: 'short' });
+          options['precision'] = { type: 'literal', value: 'second' };
+          options['timeZoneName'] = { type: 'literal', value: 'short' };
           break;
         case '':
         case 'medium':
-          options.set('precision', { type: 'literal', value: 'second' });
+          options['precision'] = { type: 'literal', value: 'second' };
           break;
         case 'short':
-          options.set('precision', { type: 'literal', value: 'minute' });
+          options['precision'] = { type: 'literal', value: 'minute' };
           break;
         default:
-          options.set('mf1:argStyle', { type: 'literal', value: argStyle });
+          options['mf1:argStyle'] = { type: 'literal', value: argStyle };
       }
       return {
         functionRef: { type: 'function', name: 'mf1:time', options },
@@ -221,9 +221,9 @@ function tokenToFunctionRef(token: AST.FunctionArg): {
         name: `mf1:${token.key}`
       };
       if (argStyle) {
-        functionRef.options = new Map([
-          ['mf1:argStyle', { type: 'literal', value: argStyle }]
-        ]);
+        functionRef.options = {
+          'mf1:argStyle': { type: 'literal', value: argStyle }
+        };
       }
       return { functionRef, attributes };
     }
@@ -267,16 +267,16 @@ function argToInputDeclaration({
   if (type === 'select') {
     functionRef = { type: 'function', name: 'string' };
   } else {
-    const options: MF.Options = new Map();
+    const options: MF.Options = {};
     if (type === 'selectordinal') {
-      options.set('select', { type: 'literal', value: 'ordinal' });
+      options['select'] = { type: 'literal', value: 'ordinal' };
     }
     if (pluralOffset) {
-      options.set('offset', { type: 'literal', value: String(pluralOffset) });
+      options['offset'] = { type: 'literal', value: String(pluralOffset) };
       functionRef = { type: 'function', name: 'mf1:plural', options };
     } else {
       functionRef = { type: 'function', name: 'number' };
-      if (options.size) functionRef.options = options;
+      if (Object.keys(options).length) functionRef.options = options;
     }
   }
   return {

--- a/mf2/icu-messageformat-1/src/validate.ts
+++ b/mf2/icu-messageformat-1/src/validate.ts
@@ -18,7 +18,7 @@ export function mf1Validate(
     type: 'unknown-function' | 'unsupported-operation',
     expr: MF.Expression
   ) => void = (type, expr) => {
-    const argTypeAttr = expr.attributes?.['mf1:argType'];
+    const argTypeAttr = expr.attributes && Object.hasOwn(expr.attributes, 'mf1:argType') ? expr.attributes['mf1:argType'] : undefined;
     const argType =
       argTypeAttr && argTypeAttr !== true
         ? argTypeAttr.value
@@ -31,7 +31,7 @@ export function mf1Validate(
       );
     } else {
       const msg = `Unsupported MF1 ${argType} argStyle`;
-      const opt = expr.functionRef!.options!['mf1:argStyle']!;
+      const opt = expr.functionRef!.options!['mf1:argStyle'];
       if (opt?.type === 'literal') {
         const error = new MessageFunctionError(type, `${msg}: ${opt.value}`);
         error.source = opt.value;
@@ -49,7 +49,7 @@ export function mf1Validate(
         if (!(name in DefaultFunctions) && !(name in MF1Functions)) {
           onError('unknown-function', expr);
         }
-        if (Object.hasOwn(expr.functionRef.options, 'mf1:argStyle')) {
+        if (expr.functionRef.options?.['mf1:argStyle'] !== undefined) {
           onError('unsupported-operation', expr);
         }
       }

--- a/mf2/icu-messageformat-1/src/validate.ts
+++ b/mf2/icu-messageformat-1/src/validate.ts
@@ -18,7 +18,10 @@ export function mf1Validate(
     type: 'unknown-function' | 'unsupported-operation',
     expr: MF.Expression
   ) => void = (type, expr) => {
-    const argTypeAttr = expr.attributes && Object.hasOwn(expr.attributes, 'mf1:argType') ? expr.attributes['mf1:argType'] : undefined;
+    const argTypeAttr =
+      expr.attributes && Object.hasOwn(expr.attributes, 'mf1:argType')
+        ? expr.attributes['mf1:argType']
+        : undefined;
     const argType =
       argTypeAttr && argTypeAttr !== true
         ? argTypeAttr.value

--- a/mf2/icu-messageformat-1/src/validate.ts
+++ b/mf2/icu-messageformat-1/src/validate.ts
@@ -18,7 +18,7 @@ export function mf1Validate(
     type: 'unknown-function' | 'unsupported-operation',
     expr: MF.Expression
   ) => void = (type, expr) => {
-    const argTypeAttr = expr.attributes?.get('mf1:argType');
+    const argTypeAttr = expr.attributes?.['mf1:argType'];
     const argType =
       argTypeAttr && argTypeAttr !== true
         ? argTypeAttr.value
@@ -31,7 +31,7 @@ export function mf1Validate(
       );
     } else {
       const msg = `Unsupported MF1 ${argType} argStyle`;
-      const opt = expr.functionRef!.options!.get('mf1:argStyle')!;
+      const opt = expr.functionRef!.options!['mf1:argStyle']!;
       if (opt?.type === 'literal') {
         const error = new MessageFunctionError(type, `${msg}: ${opt.value}`);
         error.source = opt.value;
@@ -49,7 +49,7 @@ export function mf1Validate(
         if (!(name in DefaultFunctions) && !(name in MF1Functions)) {
           onError('unknown-function', expr);
         }
-        if (expr.functionRef.options?.has('mf1:argStyle')) {
+        if (Object.hasOwn(expr.functionRef.options, 'mf1:argStyle')) {
           onError('unsupported-operation', expr);
         }
       }

--- a/mf2/messageformat/src/data-model/from-cst.ts
+++ b/mf2/messageformat/src/data-model/from-cst.ts
@@ -137,25 +137,25 @@ function asExpression(
 }
 
 function asOptions(options: CST.Option[]): Model.Options {
-  const map: Model.Options = new Map();
+  const map: Model.Options = {};
   for (const opt of options) {
     const name = asName(opt.name);
-    if (map.has(name)) {
+    if (Object.hasOwn(map, name)) {
       throw new MessageSyntaxError('duplicate-option-name', opt.start, opt.end);
     }
-    map.set(name, asValue(opt.value));
+    map[name] = asValue(opt.value);
   }
   return map;
 }
 
 function asAttributes(attributes: CST.Attribute[]): Model.Attributes {
-  const map: Model.Attributes = new Map();
+  const map: Model.Attributes = {};
   for (const attr of attributes) {
     const name = asName(attr.name);
-    if (map.has(name)) {
+    if (Object.hasOwn(map, name)) {
       throw new MessageSyntaxError('duplicate-attribute', attr.start, attr.end);
     }
-    map.set(name, attr.value ? asValue(attr.value) : true);
+    map[name] = attr.value ? asValue(attr.value) : true;
   }
   return map;
 }

--- a/mf2/messageformat/src/data-model/parse.ts
+++ b/mf2/messageformat/src/data-model/parse.ts
@@ -256,20 +256,20 @@ function expression(allowMarkup: boolean): Model.Expression | Model.Markup {
 /** Requires and consumes leading and trailing whitespace. */
 function options() {
   ws('/}');
-  const options: Model.Options = new Map();
+  const options: Model.Options = {};
   let isEmpty = true;
   while (pos < source.length) {
     const next = source[pos];
     if (next === '@' || next === '/' || next === '}') break;
     const start = pos;
     const name_ = identifier();
-    if (options.has(name_)) {
+    if (Object.hasOwn(options, name_)) {
       throw SyntaxError('duplicate-option-name', start, pos);
     }
     ws();
     expect('=', true);
     ws();
-    options.set(name_, value(true));
+    options[name_] = value(true);
     isEmpty = false;
     ws('/}');
   }
@@ -277,23 +277,23 @@ function options() {
 }
 
 function attributes() {
-  const attributes: Model.Attributes = new Map();
+  const attributes: Model.Attributes = {};
   let isEmpty = true;
   while (source[pos] === '@') {
     const start = pos;
     pos += 1; // '@'
     const name_ = identifier();
-    if (attributes.has(name_)) {
+    if (Object.hasOwn(attributes, name_)) {
       throw SyntaxError('duplicate-attribute', start, pos);
     }
     ws('=/}');
     if (source[pos] === '=') {
       pos += 1; // '='
       ws();
-      attributes.set(name_, literal(true));
+      attributes[name_] = literal(true);
       ws('/}');
     } else {
-      attributes.set(name_, true);
+      attributes[name_] = true;
     }
     isEmpty = false;
   }

--- a/mf2/messageformat/src/data-model/stringify.ts
+++ b/mf2/messageformat/src/data-model/stringify.ts
@@ -56,7 +56,7 @@ function stringifyDeclaration(decl: Declaration) {
 function stringifyFunctionRef({ name, options }: FunctionRef) {
   let res = `:${name}`;
   if (options) {
-    for (const [key, value] of options) {
+    for (const [key, value] of Object.entries(options)) {
       res += ' ' + stringifyOption(key, value);
     }
   }
@@ -67,12 +67,12 @@ function stringifyMarkup({ kind, name, options, attributes }: Markup) {
   let res = kind === 'close' ? '{/' : '{#';
   res += name;
   if (options) {
-    for (const [name, value] of options) {
+    for (const [name, value] of Object.entries(options)) {
       res += ' ' + stringifyOption(name, value);
     }
   }
   if (attributes) {
-    for (const [name, value] of attributes) {
+    for (const [name, value] of Object.entries(attributes)) {
       res += ' ' + stringifyAttribute(name, value);
     }
   }
@@ -127,7 +127,7 @@ function stringifyExpression({ arg, attributes, functionRef }: Expression) {
     res += stringifyFunctionRef(functionRef);
   }
   if (attributes) {
-    for (const [name, value] of attributes) {
+    for (const [name, value] of Object.entries(attributes)) {
       res += ' ' + stringifyAttribute(name, value);
     }
   }

--- a/mf2/messageformat/src/data-model/types.ts
+++ b/mf2/messageformat/src/data-model/types.ts
@@ -196,9 +196,9 @@ export interface Markup {
 /**
  * The options of {@link FunctionRef} and {@link Markup}.
  */
-export type Options = Map<string, Literal | VariableRef>;
+export type Options = Record<string, Literal | VariableRef>;
 
 /**
  * The attributes of {@link Expression} and {@link Markup}.
  */
-export type Attributes = Map<string, true | Literal>;
+export type Attributes = Record<string, true | Literal>;

--- a/mf2/messageformat/src/data-model/visit.ts
+++ b/mf2/messageformat/src/data-model/visit.ts
@@ -89,7 +89,7 @@ export function visit(
     if (options_) {
       const end = options?.(options_, context);
       if (value) {
-        for (const value_ of options_.values()) {
+        for (const value_ of Object.values(options_)) {
           value(value_, context, 'option');
         }
       }
@@ -104,7 +104,7 @@ export function visit(
     if (attributes_) {
       const end = attributes?.(attributes_, context);
       if (value) {
-        for (const value_ of attributes_.values()) {
+        for (const value_ of Object.values(attributes_)) {
           if (value_ !== true) value(value_, context, 'attribute');
         }
       }

--- a/mf2/messageformat/src/resolve/format-markup.ts
+++ b/mf2/messageformat/src/resolve/format-markup.ts
@@ -9,9 +9,10 @@ export function formatMarkup(
   { kind, name, options }: Markup
 ): MessageMarkupPart {
   const part: MessageMarkupPart = { type: 'markup', kind, name };
-  if (Object.keys(options || {}).length) {
+  const entries = options ? Object.entries(options) : null;
+  if (entries?.length) {
     part.options = {};
-    for (const [name, value] of Object.entries(options || {})) {
+    for (const [name, value] of entries) {
       if (name === 'u:dir') {
         const error = new MessageFunctionError(
           'bad-option',

--- a/mf2/messageformat/src/resolve/format-markup.ts
+++ b/mf2/messageformat/src/resolve/format-markup.ts
@@ -9,9 +9,9 @@ export function formatMarkup(
   { kind, name, options }: Markup
 ): MessageMarkupPart {
   const part: MessageMarkupPart = { type: 'markup', kind, name };
-  if (options?.size) {
+  if (Object.keys(options || {}).length) {
     part.options = {};
-    for (const [name, value] of options) {
+    for (const [name, value] of Object.entries(options || {})) {
       if (name === 'u:dir') {
         const error = new MessageFunctionError(
           'bad-option',

--- a/mf2/messageformat/src/resolve/function-context.ts
+++ b/mf2/messageformat/src/resolve/function-context.ts
@@ -14,7 +14,7 @@ export class MessageFunctionContext {
     this.#source = source;
 
     this.dir = undefined;
-    const dirOpt = options?.get('u:dir');
+    const dirOpt = options?.['u:dir'];
     if (dirOpt) {
       const dir = String(resolveValue(ctx, dirOpt));
       if (dir === 'ltr' || dir === 'rtl' || dir === 'auto') {
@@ -29,12 +29,12 @@ export class MessageFunctionContext {
       }
     }
 
-    const idOpt = options?.get('u:id');
+    const idOpt = options?.['u:id'];
     this.id = idOpt ? String(resolveValue(ctx, idOpt)) : undefined;
 
     if (options) {
       this.#litKeys = new Set();
-      for (const [key, value] of options) {
+      for (const [key, value] of Object.entries(options)) {
         if (value.type === 'literal') this.#litKeys.add(key);
       }
     }

--- a/mf2/messageformat/src/resolve/function-context.ts
+++ b/mf2/messageformat/src/resolve/function-context.ts
@@ -14,7 +14,8 @@ export class MessageFunctionContext {
     this.#source = source;
 
     this.dir = undefined;
-    const dirOpt = options && Object.hasOwn(options, 'u:dir') ? options['u:dir'] : undefined;
+    const dirOpt =
+      options && Object.hasOwn(options, 'u:dir') ? options['u:dir'] : undefined;
     if (dirOpt) {
       const dir = String(resolveValue(ctx, dirOpt));
       if (dir === 'ltr' || dir === 'rtl' || dir === 'auto') {
@@ -29,7 +30,8 @@ export class MessageFunctionContext {
       }
     }
 
-    const idOpt = options && Object.hasOwn(options, 'u:id') ? options['u:id'] : undefined;
+    const idOpt =
+      options && Object.hasOwn(options, 'u:id') ? options['u:id'] : undefined;
     this.id = idOpt ? String(resolveValue(ctx, idOpt)) : undefined;
 
     if (options) {

--- a/mf2/messageformat/src/resolve/function-context.ts
+++ b/mf2/messageformat/src/resolve/function-context.ts
@@ -14,7 +14,7 @@ export class MessageFunctionContext {
     this.#source = source;
 
     this.dir = undefined;
-    const dirOpt = options?.['u:dir'];
+    const dirOpt = options && Object.hasOwn(options, 'u:dir') ? options['u:dir'] : undefined;
     if (dirOpt) {
       const dir = String(resolveValue(ctx, dirOpt));
       if (dir === 'ltr' || dir === 'rtl' || dir === 'auto') {
@@ -29,7 +29,7 @@ export class MessageFunctionContext {
       }
     }
 
-    const idOpt = options?.['u:id'];
+    const idOpt = options && Object.hasOwn(options, 'u:id') ? options['u:id'] : undefined;
     this.id = idOpt ? String(resolveValue(ctx, idOpt)) : undefined;
 
     if (options) {

--- a/mf2/messageformat/src/resolve/resolve-function-ref.ts
+++ b/mf2/messageformat/src/resolve/resolve-function-ref.ts
@@ -79,7 +79,7 @@ export function resolveFunctionRef<T extends string, P extends string>(
 function resolveOptions(ctx: Context, options: Options | undefined) {
   const opt: Record<string, unknown> = Object.create(null);
   if (options) {
-    for (const [name, value] of options) {
+    for (const [name, value] of Object.entries(options)) {
       if (!name.startsWith('u:')) opt[name] = resolveValue(ctx, value);
     }
   }

--- a/mf2/xliff/src/mf2xliff.ts
+++ b/mf2/xliff/src/mf2xliff.ts
@@ -472,7 +472,7 @@ function resolveExpression({
   if (functionRef) {
     const elements: X.MessageFunction['elements'] = [];
     if (functionRef.options) {
-      for (const [name, value] of functionRef.options) {
+      for (const [name, value] of Object.entries(functionRef.options)) {
         elements.push({
           type: 'element',
           name: 'mf:option',
@@ -494,7 +494,7 @@ function resolveExpression({
     else throw new Error('Invalid empty expression');
   }
   if (attributes) {
-    for (const [name, value] of attributes) {
+    for (const [name, value] of Object.entries(attributes)) {
       elements.push({
         type: 'element',
         name: 'mf:attribute',
@@ -509,7 +509,7 @@ function resolveExpression({
 function resolveMarkup({ name, options, attributes }: MF.Markup) {
   const elements: X.MessageOption[] = [];
   if (options) {
-    for (const [name, value] of options) {
+    for (const [name, value] of Object.entries(options)) {
       elements.push({
         type: 'element',
         name: 'mf:option',
@@ -522,7 +522,7 @@ function resolveMarkup({ name, options, attributes }: MF.Markup) {
     { type: 'element', name: 'mf:markup', attributes: { name }, elements }
   ];
   if (attributes) {
-    for (const [name, value] of attributes) {
+    for (const [name, value] of Object.entries(attributes)) {
       mfElements.push({
         type: 'element',
         name: 'mf:attribute',

--- a/mf2/xliff/src/xliff2mf.ts
+++ b/mf2/xliff/src/xliff2mf.ts
@@ -381,7 +381,7 @@ function getMessageElements(
 function resolveExpression(elements: X.MessageElements): MF.Expression {
   let xArg: X.MessageLiteral | X.MessageVariable | undefined;
   let xFunc: X.MessageFunction | undefined;
-  const attributes: MF.Attributes = new Map();
+  const attributes: MF.Attributes = {};
   for (const el of elements) {
     switch (el.name) {
       case 'mf:literal':
@@ -397,7 +397,7 @@ function resolveExpression(elements: X.MessageElements): MF.Expression {
         throw new Error('Cannot reference markup as expression');
       case 'mf:attribute': {
         const aName = el.attributes.name;
-        if (attributes.has(aName)) {
+        if (Object.hasOwn(attributes, aName)) {
           throw new Error(`Duplicate attribute name: ${aName}`);
         }
         const value = el.elements?.find(el => el.type === 'element');
@@ -406,9 +406,9 @@ function resolveExpression(elements: X.MessageElements): MF.Expression {
           if (rv.type !== 'literal') {
             throw new Error(`Unsupported attribute value: ${value}`);
           }
-          attributes.set(aName, rv);
+          attributes[aName] = rv;
         } else {
-          attributes.set(aName, true);
+          attributes[aName] = true;
         }
         break;
       }
@@ -449,14 +449,11 @@ function resolveOptions(
 ): MF.Options | undefined {
   const optEls = parent.elements?.filter(el => el.type === 'element');
   if (!optEls?.length) return undefined;
-  const options: MF.Options = new Map();
+  const options: MF.Options = {};
   for (const el of optEls) {
     const name = el.attributes.name;
-    if (options.has(name)) throw new Error(`Duplicate option name: ${name}`);
-    options.set(
-      name,
-      resolveValue(el.elements.find(el => el.type === 'element'))
-    );
+    if (Object.hasOwn(options, name)) throw new Error(`Duplicate option name: ${name}`);
+    options[name] = resolveValue(el.elements.find(el => el.type === 'element'));
   }
   return options;
 }

--- a/mf2/xliff/src/xliff2mf.ts
+++ b/mf2/xliff/src/xliff2mf.ts
@@ -452,7 +452,8 @@ function resolveOptions(
   const options: MF.Options = {};
   for (const el of optEls) {
     const name = el.attributes.name;
-    if (Object.hasOwn(options, name)) throw new Error(`Duplicate option name: ${name}`);
+    if (Object.hasOwn(options, name))
+      throw new Error(`Duplicate option name: ${name}`);
     options[name] = resolveValue(el.elements.find(el => el.type === 'element'));
   }
   return options;


### PR DESCRIPTION
Remove the use of `Map` from data-model, to enable using pre-parsed messages. Removing the need for parsing while running my application.